### PR TITLE
When mounted, settings should inherit from parent apps

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -131,6 +131,7 @@ Server.prototype.use = function(route, middleware){
             home = app.set('home');
         if (home === '/') home = '';
         app.set('home', (app.route || '') + home);
+        app.parent = this;
         // Mounted hook
         if (app.__mounted) app.__mounted.call(app, this);
     }
@@ -220,6 +221,7 @@ Server.prototype.error = function(fn){
 
 /**
  * Assign `setting` to `val`, or return `setting`'s value.
+ * Mounted servers inherit their parent server's settings.
  *
  * @param {String} setting
  * @param {String} val
@@ -229,7 +231,11 @@ Server.prototype.error = function(fn){
 
 Server.prototype.set = function(setting, val){
     if (val === undefined) {
-        return this.settings[setting];
+        var app = this;
+        do {
+          if (app.settings.hasOwnProperty(setting))
+            return app.settings[setting];
+        } while (app = app.parent);
     } else {
         this.settings[setting] = val;
         return this;

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -288,6 +288,11 @@ module.exports = {
         assert.equal('/blog', blog.route);
         assert.equal('/contact', map.route);
         assert.ok(called, 'mounted() hook failed');
+
+        app.set("test", "parent setting");
+        assert.equal(blog.set("test"), "parent setting", "settings did not inherit from parent app")
+        blog.set("test", "overridden");
+        assert.equal(blog.set("test"), "overridden", "mounted app setting did not override parent app")
         
         app.get('/', function(req, res){
             assert.equal('/', app.set('home'), "home did not default to /");


### PR DESCRIPTION
When mounting apps, parent application settings should be accessible from the child app. For example:

```
var parent = express.createServer();
parent.set("api key", "abc123");
var blog = express.createServer();
parent.use("/blog", blog);
blog.set("api key") => undefined!
```

I don't want to use the `mounted` callback to copy over settings from the parent b/c that's hacky. Instead, this pull request provides child apps access to parent apps settings if not already overridden in the mounted app. To continue the example:

```
blog.set("api key") => "abc123";
blog.set("api key", "something else");
blog.set("api key") => "something else");
```
