### PR TITLE
Added local() to request

### DIFF
--- a/lib/express/request.js
+++ b/lib/express/request.js
@@ -136,6 +136,37 @@ http.IncomingMessage.prototype.param = function(name){
 };
 
 /**
+ * Gets/Sets a request local variable
+ *
+ *    To set a value:
+ *       req.local('userId', 'abc123');
+ *
+ *    To get a value:
+ *       var userId = req.local('userId');
+ *
+ * Useful when chaining routes with next()
+ * The first route handler can set a variable on
+ * the request, which can be accessed by the next
+ * route handler.  Common use case is authentication
+ * filters, which can set a 'user' object that can
+ * be accessed downstream on the request.
+ */
+
+http.IncomingMessage.prototype.local = function(name, value) {
+    if (!this.locals) {
+        this.locals = {};
+    }
+
+    if (value) {
+        // set case
+        this.locals[name] = value;
+    }
+    else {
+        return this.locals[name];
+    }
+};
+
+/**
  * Queue flash `msg` of the given `type`.
  *
  * Examples:

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -153,5 +153,26 @@ module.exports = {
         assert.response(app,
             { url: '/' },
             { body: 'ok' });
+    },
+
+    'test #local()': function(assert) {
+        var app = express.createServer();
+
+	app.get('/', function(req, res) {
+	    assert.eql(undefined, req.local('userId'));
+
+            req.local('userId', 'abc');
+            assert.eql('abc', req.local('userId'));
+
+            req.local('userId', ['a','b']);
+            assert.eql(['a','b'], req.local('userId'));
+
+            res.send('ok');
+	});
+
+        assert.response(app,
+            { url: '/' },
+            { body: 'ok' });
     }
+
 };

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -158,8 +158,8 @@ module.exports = {
     'test #local()': function(assert) {
         var app = express.createServer();
 
-	app.get('/', function(req, res) {
-	    assert.eql(undefined, req.local('userId'));
+        app.get('/', function(req, res) {
+            assert.eql(undefined, req.local('userId'));
 
             req.local('userId', 'abc');
             assert.eql('abc', req.local('userId'));
@@ -168,7 +168,7 @@ module.exports = {
             assert.eql(['a','b'], req.local('userId'));
 
             res.send('ok');
-	});
+        });
 
         assert.response(app,
             { url: '/' },


### PR DESCRIPTION
Hi there,

express is cool.  I'm writing an app that uses route chaining via next().  I didn't see an obvious way to set state on the request so that my first route handler could set a variable that I could reference in subsequent handlers.

I added a local() function on request for this.  It's similar to param() but only gets/sets variables that you define.

Not sure if this is a patch more appropriate to add to Connect, but let me know what you think.  

Tests included.

thank you!

-- James
