### PR TITLE
Typos in CSS

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -51,7 +51,7 @@ var jadeLayout = [
 var less = [
     'body {',
     '  padding: 50px;',
-    '  font: 14px "Lucida Grande", "Helvetica Nueue", Arial, sans-serif;',
+    '  font: 14px "Lucida Grande", "Helvetica Neue", Arial, sans-serif;',
     '}'
 ].join('\n');
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -61,7 +61,7 @@ table#source tr.code h1,
 table#source tr.code h2,
 table#source tr.code h3 {
     margin-top: 30px;
-    font-family: "Lucida Grande", "Helvetica Nueue", Arial, sans-serif;
+    font-family: "Lucida Grande", "Helvetica Neue", Arial, sans-serif;
     font-size: 18px;
 }
 table#source tr.code h2 {

--- a/examples/github/public/style.css
+++ b/examples/github/public/style.css
@@ -1,6 +1,6 @@
 body {
     padding: 30px 50px;
-    font: 12px/1.4 "Lucida Grande", "Helvetica Nueue", Arial, sans-serif;
+    font: 12px/1.4 "Lucida Grande", "Helvetica Neue", Arial, sans-serif;
 }
 a {
     color: #00AAFF;

--- a/examples/jade/public/stylesheets/style.css
+++ b/examples/jade/public/stylesheets/style.css
@@ -1,3 +1,3 @@
 body {
   padding: 50px 80px;
-  font: 14px "Helvetica Nueue", "Lucida Grande", Arial, sans-serif;}
+  font: 14px "Helvetica Neue", "Lucida Grande", Arial, sans-serif;}

--- a/examples/jade/public/stylesheets/style.sass
+++ b/examples/jade/public/stylesheets/style.sass
@@ -1,3 +1,3 @@
 body
   :padding 50px 80px
-  :font 14px "Helvetica Nueue", "Lucida Grande", Arial, sans-serif
+  :font 14px "Helvetica Neue", "Lucida Grande", Arial, sans-serif

--- a/examples/mvc/public/style.css
+++ b/examples/mvc/public/style.css
@@ -1,6 +1,6 @@
 body {
   padding: 30px;
-  font: 12px/1.4 "Helvetica Nueue", "Lucida Grande", Arial, sans-serif;
+  font: 12px/1.4 "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
 }
 a {
   color: #00aaff;


### PR DESCRIPTION
Hi,

just fixed a few typos regarding "Helvetica Neue" misspelled as "Helvetica Nueue" in the CSS.

Best,
Philipp
