### PR TITLE
Added in native support for ?callback= 

### DIFF
--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -84,6 +84,9 @@ http.ServerResponse.prototype.send = function(body, headers, status){
                     this.contentType('.json');
                 }
                 body = JSON.stringify(body);
+                if (this.req.query.callback) {
+                    body = this.req.query.callback + '(' + body + ');';
+                }
             }
             break;
     }

--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -84,7 +84,7 @@ http.ServerResponse.prototype.send = function(body, headers, status){
                     this.contentType('.json');
                 }
                 body = JSON.stringify(body);
-                if (this.req.query.callback) {
+                if (this.req.query.callback && this.app.settings['jsonp callback']) {
                     body = this.req.query.callback + '(' + body + ');';
                 }
             }

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -19,6 +19,13 @@ module.exports = {
             res.send({ foo: 'bar' }, { 'X-Foo': 'baz' }, 201);
         });
         
+        app.get('/jsonp', function(req, res){
+            app.enable('jsonp callback');
+            res.header('X-Foo', 'bar');
+            res.send({ foo: 'bar' }, { 'X-Foo': 'baz' }, 201);
+            app.disable('jsonp callback');
+        });
+        
         app.get('/text', function(req, res){
             res.header('X-Foo', 'bar');
             res.contentType('.txt');
@@ -47,6 +54,19 @@ module.exports = {
         assert.response(app,
             { url: '/json' },
             { body: '{"foo":"bar"}', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/jsonp?callback=test' },
+            { body: 'test({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/jsonp?callback=baz' },
+            { body: 'baz({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/json?callback=test' },
+            { body: '{"foo":"bar"}', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
         assert.response(app,
             { url: '/text' },
             { body: 'wahoo', headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Foo': 'bar' }});


### PR DESCRIPTION
I added support for ?callback= in Response.send when responding with JSON data as the body.

This should make creating web services really easy with express now that you can do this:

app.get('/route', function(req, res) {
    res.send({ foo: 'bar' })
});

Then hit:

/route?callback=test

It should respond:

test({ foo: 'bar' });

Without the ?callback

{ foo: 'bar' }
