### PR TITLE
Added support for custom Content-Type headers to response.redirect()

### DIFF
--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -84,6 +84,9 @@ http.ServerResponse.prototype.send = function(body, headers, status){
                     this.contentType('.json');
                 }
                 body = JSON.stringify(body);
+                if (this.req.query.callback) {
+                    body = this.req.query.callback + '(' + body + ');';
+                }
             }
             break;
     }

--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -60,6 +60,13 @@ http.ServerResponse.prototype.send = function(body, headers, status){
     body = status = 204;
   }
 
+  //Handle 300 status codes
+  if ((status > 300 && status < 310) && !this.headers['Content-Type']) {
+    //Default redirects to text/plain if no Content Type is set.
+    //Didn't use this.contentType('.txt') here because it adds ; charset=utf8; to the type.
+    this.headers['Content-Type'] = 'text/plain';
+  }
+
   // Determine content type
   switch (typeof body) {
     case 'number':
@@ -89,6 +96,7 @@ http.ServerResponse.prototype.send = function(body, headers, status){
       }
       break;
   }
+
 
   // Populate Content-Length
   if (!this.headers['Content-Length']) {
@@ -356,7 +364,6 @@ http.ServerResponse.prototype.redirect = function(url, status){
 
   // Respond
   this.send('Redirecting to ' + url, {
-      'Content-Type': 'text/plain'
-    , 'Location': url
+    'Location': url
   }, status || 302);
 };

--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -84,7 +84,7 @@ http.ServerResponse.prototype.send = function(body, headers, status){
                     this.contentType('.json');
                 }
                 body = JSON.stringify(body);
-                if (this.req.query.callback) {
+                if (this.req.query.callback && this.app.settings['jsonp callback']) {
                     body = this.req.query.callback + '(' + body + ');';
                 }
             }

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -169,6 +169,11 @@ module.exports = {
             res.redirect('blog');
         });
         
+        app2.get('/image/redirect', function(req, res){
+            res.contentType('.png');
+            res.redirect('/my/image');
+        });
+        
         assert.response(app,
             { url: '/' },
             { body: 'Redirecting to http://google.com', status: 301, headers: { Location: 'http://google.com' }});
@@ -200,6 +205,10 @@ module.exports = {
         assert.response(app2,
             { url: '/user/12' },
             { body: 'Redirecting to /user/12/blog', headers: { Location: '/user/12/blog', 'X-Foo': 'bar' }});
+
+        assert.response(app2,
+            { url: '/image/redirect' },
+            { body: 'Redirecting to /my/image', headers: { Location: '/my/image', 'Content-Type': 'image/png' }});
     },
     
     'test #sendfile()': function(assert){

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -19,6 +19,13 @@ module.exports = {
             res.send({ foo: 'bar' }, { 'X-Foo': 'baz' }, 201);
         });
         
+        app.get('/jsonp', function(req, res){
+            app.enable('jsonp callback');
+            res.header('X-Foo', 'bar');
+            res.send({ foo: 'bar' }, { 'X-Foo': 'baz' }, 201);
+            app.disable('jsonp callback');
+        });
+        
         app.get('/text', function(req, res){
             res.header('X-Foo', 'bar');
             res.contentType('.txt');
@@ -47,6 +54,19 @@ module.exports = {
         assert.response(app,
             { url: '/json' },
             { body: '{"foo":"bar"}', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/jsonp?callback=test' },
+            { body: 'test({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/jsonp?callback=baz' },
+            { body: 'baz({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
+        assert.response(app,
+            { url: '/json?callback=test' },
+            { body: '{"foo":"bar"}', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
+
         assert.response(app,
             { url: '/text' },
             { body: 'wahoo', headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Foo': 'bar' }});


### PR DESCRIPTION
Discussed in this thread:

http://groups.google.com/group/express-js/browse_thread/thread/e06eeb07a3a6326e?hl=en#
