### PR TITLE
installing with curl fails because github forces https

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,8 @@
-
 install() {
     mkdir -p /tmp/$2 \
         && cd /tmp/$2 \
         && echo "... installing $2" \
-        && curl -# -L "http://github.com/$1/$2/tarball/master" \
+        && curl -k -# -L "http://github.com/$1/$2/tarball/master" \
             | tar xz --strip 1 \
         && mkdir -p ~/.node_libraries \
         && cp -fr lib/$2 ~/.node_libraries/$2


### PR DESCRIPTION
$ curl -# http://expressjs.com/install.sh | sh
###### ################################################################## 100.0%

... installing express
###### ################################################################## 100.0%

curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify faile
d
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
