### PR TITLE
Small patch to install.sh to make it work under FreeBSD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ install() {
         && cd /tmp/$2 \
         && echo "... installing $2" \
         && curl -# -L "http://github.com/$1/$2/tarball/master" \
-            | tar xz --strip 1 \
+            | tar xzf - --strip 1 \
         && mkdir -p ~/.node_libraries \
         && cp -fr lib/$2 ~/.node_libraries/$2
 }


### PR DESCRIPTION
FreeBSD's tar (and possibly other BSDs) need an explicit "-f -" to read from STDIN. Without it, tar tries reading from a tape drive.
