### PR TITLE
Strip unsafe characters out of JSONP callbacks to prevent XSS

### DIFF
--- a/lib/express/response.js
+++ b/lib/express/response.js
@@ -85,7 +85,7 @@ http.ServerResponse.prototype.send = function(body, headers, status){
         body = JSON.stringify(body);
         if (this.req.query.callback && this.app.settings['jsonp callback']) {
           this.header('Content-Type', 'text/javascript');
-          body = this.req.query.callback + '(' + body + ');';
+          body = this.req.query.callback.replace(/[^\w$.]/g, '') + '(' + body + ');';
         }
       }
       break;

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -66,6 +66,10 @@ module.exports = {
       { body: 'baz({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'text/javascript', 'X-Foo': 'baz' }});
 
     assert.response(app,
+      { url: '/jsonp?callback=illegal()[]=;' },
+      { body: 'illegal({"foo":"bar"});', status: 201, headers: { 'Content-Type': 'text/javascript', 'X-Foo': 'baz' }});
+
+    assert.response(app,
       { url: '/json?callback=test' },
       { body: '{"foo":"bar"}', status: 201, headers: { 'Content-Type': 'application/json', 'X-Foo': 'baz' }});
 


### PR DESCRIPTION
Will send another pull request with a backported fix for the 1.x branch.
