### PR TITLE
Fix for query parameters being lost if routed in a certain way

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ var Server = exports = module.exports = function Server(middleware){
 
   // Expose objects to each other
   this.use(function(req, res, next){
-    req.query = {};
+    req.query = req.query || {};
     res.headers = { 'X-Powered-By': 'Express' };
     req.app = res.app = self;
     req.res = res;


### PR DESCRIPTION
Hi TJ,

I've put in a quick, possibly horrible fix for a bug I noticed when using modules. The query parameters were being lost because of the way the server was handling requests.
Basically further up somewhere the req.url was losing the query string, and this.use in Server was always clearing the query of the request then rebuilding if the url had a query string.

Setup to see this bug was:
- Basic server with it's own set of routes.
- app.use('./apath', require('anotherServer'));
- A route in anotherServer spitting out query string
- Request the route in anotherServer and watch query string dissapear.

Let me know if you need more information / you have any suggestions, it's blocking my project from working as expected.

Thanks,
Danny.
