### PR TITLE
Backported connect version requirement fixes from 1.0.8 to 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "express",
+  "name": "tfe-express",
   "description": "Sinatra inspired web development framework",
-  "version": "1.0.7",
+  "version": "1.0.7-1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [ 
     { "name": "TJ Holowaychuk", "email": "tj@vision-media.ca" }, 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     { "name": "Guillermo Rauch", "email": "rauchg@gmail.com" }
   ],
   "dependencies": {
-    "connect": ">= 0.5.0",
-    "qs": ">= 0.0.2"
+    "connect": ">= 0.5.0 < 1.0.0",
+    "qs": ">= 0.0.5"
   },
   "keywords": ["framework", "sinatra", "web", "rest", "restful"],
   "directories": { "lib": "./lib/express" },


### PR DESCRIPTION
This should allow people to use npm to install Express 1.0.7 for node 0.4.x apps. The connect requirement got fixed in 1.0.8, but that also added a restriction to node versions less than 0.4.0.

I know Express 1.x is only listed as compatible with node 0.2.x, but up until recently people have been able to use Express in their 0.4.x apps. This patch just restores that ability for 1.0.7. I don't know if this is not in keeping with your plans for people to migrate to 2.x, but it seems to be causing problems for people... not being able to use 1.x in their 0.4.x where they were able to before.

I also don't know what you'd release this as... I pushed it to the npm registry as tfe-express@1.0.7-1. Maybe express@1.0.7-1?
