### PR TITLE
Updated express command

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -167,7 +167,7 @@ var appTest = [
   , "  'GET /': function(){"
   , "    assert.response(app,"
   , "      { url: '/' },"
-  , "      { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' }},"
+  , "      { status: 200, headers: { 'Content-Type': 'text/html' }},"
   , "      function(res){"
   , "        assert.includes(res.body, '<title>Express</title>');"
   , "      });"
@@ -220,7 +220,7 @@ var app = [
   , ''
   , 'if (!module.parent) {'
   , '  app.listen(3000);'
-  , '  console.log("Express server listening on port %d", app.address().port)'
+  , '  console.log("Express server listening on port %d", app.address().port);'
   , '}'
   , ''
 ].join('\n');


### PR DESCRIPTION
Hi

These are minor fixes for `express` command.
- Fixed a genereated test's bug: Express 2.0 seems not to send `charset=utf-8`.
- Added a forgotten semicolon.
