### PR TITLE
Tiny docs change

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1,4 +1,3 @@
-
 ### Installation
 
     $ npm install express
@@ -47,7 +46,7 @@ otherwise the first call to _app.get()_, _app.post()_, etc will mount the routes
 	
     app.configure('production', function(){
       var oneYear = 31557600000;
-      app.use(express.static({ root: __dirname + '/public', maxAge: oneYear }));
+      app.use(express.static(__dirname + '/public', {maxAge: oneYear }));
       app.use(express.errorHandler());
     });
 


### PR DESCRIPTION
Connect 1.0's static middleware doesn't support anymore setting the root inside the options hash.

Wasted some time on this one while migrating since it wasn't mentioned in the migration guide. Since I found this line in the guide I didn't suspect a thing. I suggest also doing one of the following:
1. Mentioning it in the migration guide
2. Add support for the old syntax in static() for backwards compliance
3. Add a check in static() that fails when someone tries to pass an options hash as the "root" parameter.

If you want, you can reply with your preference and I can create a new pull request with it.
