### PR TITLE
bugfix for no named parameters in url

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -140,7 +140,7 @@ req.accepts = function(type){
 
 req.param = function(name, defaultValue){
   // route params like /user/:id
-  if (this.params.hasOwnProperty(name) && undefined !== this.params[name]) {
+  if (this.params && this.params.hasOwnProperty(name) && undefined !== this.params[name]) {
     return this.params[name]; 
   }
   // query string params


### PR DESCRIPTION
If the user does not have any named parameters in their url, calling req.param(..) results in:
Cannot call method 'hasOwnProperty' of undefined
