### PR TITLE
Add app, req & res to options for views

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -267,6 +267,11 @@ res._render = function(view, opts, fn, parent, sub){
     layout = 'layout';
   }
 
+  //Give the view access to the app, res and req objects (Express 1.x options.scope)
+  options.app = app;
+  options.res = self;
+  options.req = self.req;
+
   // Default execution scope to a plain object
   options.scope = options.scope || {};
 
@@ -375,3 +380,4 @@ function hintAtViewPaths(view, options) {
   if (options.isLayout) console.error('  - ' + new View(view.rootPath, options).path);
   console.error();
 }
+


### PR DESCRIPTION
View template engines should have access to app, req & res inside their locals. This patch just adds .app, .res and .req to the locals passed to the view. Similar to the 1.x options.scope.
