### PR TITLE
UTF-8 defaults for JSON and JSONP

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -63,7 +63,7 @@ res.send = function(body, headers, status){
       break;
     case 'string':
       if (!this.header('Content-Type')) {
-        this.charset = this.charset || 'utf-8';
+        this.charset = this.charset || this.app.set('charset') || 'utf-8';
         this.contentType('.html');
       }
       break;
@@ -75,10 +75,12 @@ res.send = function(body, headers, status){
         }
       } else {
         if (!this.header('Content-Type')) {
+          this.charset = this.charset || this.app.set('charset') || 'utf-8';
           this.contentType('.json');
         }
         body = JSON.stringify(body);
         if (this.req.query.callback && this.app.set('jsonp callback')) {
+          this.charset = this.charset || this.app.set('charset') || 'utf-8';
           this.header('Content-Type', 'text/javascript');
           body = this.req.query.callback.replace(/[^\w$.]/g, '') + '(' + body + ');';
         }

--- a/lib/response.js
+++ b/lib/response.js
@@ -63,7 +63,7 @@ res.send = function(body, headers, status){
       break;
     case 'string':
       if (!this.header('Content-Type')) {
-        this.charset = this.charset || this.app.set('charset') || 'utf-8';
+        this.charset = this.charset || 'utf-8';
         this.contentType('.html');
       }
       break;
@@ -75,12 +75,12 @@ res.send = function(body, headers, status){
         }
       } else {
         if (!this.header('Content-Type')) {
-          this.charset = this.charset || this.app.set('charset') || 'utf-8';
+          this.charset = this.charset || 'utf-8';
           this.contentType('.json');
         }
         body = JSON.stringify(body);
         if (this.req.query.callback && this.app.set('jsonp callback')) {
-          this.charset = this.charset || this.app.set('charset') || 'utf-8';
+          this.charset = this.charset || 'utf-8';
           this.header('Content-Type', 'text/javascript');
           body = this.req.query.callback.replace(/[^\w$.]/g, '') + '(' + body + ');';
         }

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -61,7 +61,7 @@ module.exports = {
     assert.response(app,
       { url: '/bool' },
       { body: 'true'
-      , headers: { 'Content-Type': 'application/json' }});
+      , headers: { 'Content-Type': 'application/json; charset=utf-8' }});
 
     assert.response(app,
       { url: '/html' },
@@ -76,7 +76,7 @@ module.exports = {
       { body: '{"foo":"bar"}'
       , status: 201
       , headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json; charset=utf-8'
         , 'X-Foo': 'baz'
       }});
   
@@ -85,7 +85,7 @@ module.exports = {
       { body: 'test({"foo":"bar"});'
       , status: 201
       , headers: {
-          'Content-Type': 'text/javascript'
+          'Content-Type': 'text/javascript; charset=utf-8'
         , 'X-Foo': 'baz'
       }});
   
@@ -93,7 +93,7 @@ module.exports = {
       { url: '/jsonp?callback=baz' },
       { body: 'baz({"foo":"bar"});'
       , status: 201, headers: {
-          'Content-Type': 'text/javascript'
+          'Content-Type': 'text/javascript; charset=utf-8'
         , 'X-Foo': 'baz'
       }});
   
@@ -102,7 +102,7 @@ module.exports = {
       { body: 'invalid({"foo":"bar"});'
       , status: 201
       , headers: {
-          'Content-Type': 'text/javascript'
+          'Content-Type': 'text/javascript; charset=utf-8'
         , 'X-Foo': 'baz'
       }});
   
@@ -111,7 +111,7 @@ module.exports = {
       { body: '{"foo":"bar"}'
       , status: 201
       , headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json; charset=utf-8'
         , 'X-Foo': 'baz'
       }});
   


### PR DESCRIPTION
JSON and JSONP default to UTF-8 in the same way as HTML. Introduces app.set('charset') to set charset default at the application level. Closes #632.
