### PR TITLE
View: set options.filename for correct EJS error reporting

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -365,6 +365,7 @@ res._render = function(view, opts, fn, parent, sub){
 
     options.filename = view.path;
     var engine = view.templateEngine;
+    options.filename = view.path;
     view.fn = engine.compile(view.contents, options)
     if (cacheViews) app.cache[cid] = view;
   }


### PR DESCRIPTION
Please, verify that it not breaks other template engines.
For EJS it helps to print file name in error stack trace correctly, very convenient for development. Otherwise, it doesn't know in which file the error was occurred, only line number.

Thanks!
