### PR TITLE
Fixed a typo: "A route is simple a string" => "A route is simply a string

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -355,7 +355,7 @@ are available as <code>req.params</code>.</p>
 });
 </code></pre>
 
-<p>A route is simple a string which is compiled to a <em>RegExp</em> internally. For example
+<p>A route is simply a string which is compiled to a <em>RegExp</em> internally. For example
 when <em>/user/:id</em> is compiled, a simplified version of the regexp may look similar to:</p>
 
 <pre><code>\/user\/([^\/]+)\/?


### PR DESCRIPTION
Fixed a typo: "A route is simple a string" => "A route is simply a string"
