### PR TITLE
Add support for multiple view roots

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - view
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -93,6 +92,20 @@ exports.compile = function(view, cache, cid, options){
  */
 
 exports.lookup = function(view, options){
+  // If root is an array of paths, let's try each path until we find the view
+  if (options.root instanceof Array) {
+    var opts = utils.merge({}, options)
+      , root = opts.root
+      , foundView = null
+    for (var i=0; i<root.length; i++) {
+      opts.root = root[i]
+      foundView = exports.lookup(view, opts)
+      if (foundView.exists) break            
+    }
+    return foundView
+  }
+
+  // Fallback to standard behavior, when root is a single directory
   var orig = view = new View(view, options);
 
   // Try _ prefix ex: ./views/_<name>.jade


### PR DESCRIPTION
Added support for multiple view roots: define "views" options as an array, and all paths will be checked until the first one found.

This would allow to "package" modules embedding their own views, override views, etc...
