### PR TITLE
Express / jqtpl partial rendering issue

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -167,6 +167,7 @@ function renderPartial(res, view, options, parentLocals, parent){
 
   // Deduce name from view path
   var name = options.as || partial.resolveObjectName(view);
+  options.filename = options.filename + "{" + name + "}";
 
   // Render partial
   function render(){


### PR DESCRIPTION
Hi,

Node sure if this is the right place to discuss this, and pretty sure this isn't the right patch, but there's an issue with Express and jqtpl (possibly also other rendering engines).

When rendering partials, options.filename (which is passed to the rendering engine) is set to the filename for the containing template rather than that of the partial. I don't know enough about the API to know if this is the desired behaviour, but it's confusing jqtpl's filename-based caching.

This is the patch I'm using in my project - solves the problem for me. I'd be open to better / cleaner answers, including bouncing the issue to jqtpl.

Thanks,

Arthur
