### PR TITLE
docs to show require('connect-redis')(express) re npm 1.x changes

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -931,14 +931,14 @@ app.use(express.session({ secret: "keyboard cat" }));
 
 <p>By default the <em>session</em> middleware uses the memory store bundled with Connect, however many implementations exist. For example <a href="http://github.com/visionmedia/connect-redis">connect-redis</a> supplies a <a href="http://code.google.com/p/redis/">Redis</a> session store and can be used as shown below:</p>
 
-<pre><code>var RedisStore = require('connect-redis');
+<pre><code>var RedisStore = require('connect-redis')(express);
 app.use(express.cookieParser());
 app.use(express.session({ secret: "keyboard cat", store: new RedisStore }));
 </code></pre>
 
 <p>Now the <em>req.session</em> and <em>req.sessionStore</em> properties will be accessible to all routes and subsequent middleware. Properties on <em>req.session</em> are automatically saved on a response, so for example if we wish to shopping cart data:</p>
 
-<pre><code>var RedisStore = require('connect-redis');
+<pre><code>var RedisStore = require('connect-redis')(express);
 app.use(express.bodyParser());
 app.use(express.cookieParser());
 app.use(express.session({ secret: "keyboard cat", store: new RedisStore }));


### PR DESCRIPTION
Due to npm 1.x changes need to pass connect/express to the function connect-redis exports (see https://github.com/visionmedia/connect-redis)
