### PR TITLE
Tentative support for node 0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express",
   "description": "Sinatra inspired web development framework",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [ 
     { "name": "TJ Holowaychuk", "email": "tj@vision-media.ca" }, 
@@ -34,5 +34,5 @@
     "test": "make test",
     "prepublish" : "npm prune"
   },
-  "engines": { "node": ">= 0.4.1 < 0.5.0" }
+  "engines": { "node": ">= 0.4.1 < 0.6.0" }
 }


### PR DESCRIPTION
Any chance for supporting node 0.5 in the npm package?

I have been using express with 0.5.0-pre for a while now as I experiment with SPDY support.  Admittedly, I have not explored the full breadth of express, but all of my sample apps have worked fine.
