### PR TITLE
res.render(), manually set HTTP status using the 'HTTPStatus' option instead of the 'status' option.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -357,7 +357,7 @@ res._render = function(view, opts, fn, parent, sub){
   if (opts && opts.locals) merge(options, opts.locals);
 
   // status support
-  if (options.status) this.statusCode = options.status;
+  if (options.HTTPStatus) this.statusCode = options.HTTPStatus;
 
   // capture attempts
   options.attempts = [];

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -165,7 +165,7 @@ module.exports = {
     });
   
     app.get('/status', function(req, res){
-      res.render('hello.jade', { status: 500 });
+      res.render('hello.jade', { HTTPStatus: 500 });
     });
   
     assert.response(app,


### PR DESCRIPTION
Per issue #739.
