### PR TITLE
Fixed app.locals for options used by _render

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -352,6 +352,9 @@ res._render = function(view, opts, fn, parent, sub){
   // merge render() .locals
   if (opts && opts.locals) merge(options, opts.locals);
 
+  // Merge view locals
+  union(options, locals);
+
   // status support
   if (options.status) this.statusCode = options.status;
 
@@ -397,9 +400,6 @@ res._render = function(view, opts, fn, parent, sub){
     // apply
     merge(options, this.__dynamic);
   }
-
-  // Merge view locals
-  union(options, locals);
 
   // Always expose partial() as a local
   options.partial = function(path, opts){


### PR DESCRIPTION
I moved the code that merges app._locals to into options so that it could actually be used by options used by _render() like options.layout.  Without this change, setting the layout in app.local() doesn't work.
