### PR TITLE
In 2.x, empty `request.send` triggers node http warning

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - response
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -52,7 +51,7 @@ res.send = function(body, headers, status){
   status = status || this.statusCode;
 
   // allow 0 args as 204
-  if (!arguments.length || undefined === body) body = status = 204;
+  if (!arguments.length || undefined === body) status = 204;
 
   // determine content type
   switch (typeof body) {
@@ -81,7 +80,7 @@ res.send = function(body, headers, status){
   }
 
   // populate Content-Length
-  if (!this.header('Content-Length')) {
+  if (body && !this.header('Content-Length')) {
     this.header('Content-Length', Buffer.isBuffer(body)
       ? body.length
       : Buffer.byteLength(body));


### PR DESCRIPTION
As of Node 0.4.10, an error is printed when `response.write()` or `response.end()` is called with a body for responses where HTTP forbids it.

However, in express (2.4.3), `response.send()` with no parameters fills the body with `204`, triggering that error.
