### PR TITLE
Only send implied OPTIONS response when allowed methods are found.

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - Router
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -29,7 +28,7 @@ var methods = exports.methods = require('./methods');
 
 /**
  * Initialize a new `Router` with the given `app`.
- * 
+ *
  * @param {express.HTTPServer} app
  * @api private
  */
@@ -196,7 +195,14 @@ Router.prototype._dispatch = function(req, res, next){
     req.route = route = self._match(req, i);
 
     // implied OPTIONS
-    if (!route && 'OPTIONS' == req.method) return self._options(req, res);
+    if (!route && 'OPTIONS' == req.method) {
+      var path = parse(req.url).pathname
+        , allowedMethods = self._optionsFor(path);
+      if (allowedMethods.length > 0) {
+        var body = allowedMethods.join(',');
+        return res.send(body, { Allow: body });
+      }
+    }
 
     // no route
     if (!route) return next();
@@ -253,20 +259,6 @@ Router.prototype._dispatch = function(req, res, next){
       });
     }
   })(0);
-};
-
-/**
- * Respond to __OPTIONS__ method.
- *
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- * @api private
- */
-
-Router.prototype._options = function(req, res){
-  var path = parse(req.url).pathname
-    , body = this._optionsFor(path).join(',');
-  res.header('Allow', body).send(body);
 };
 
 /**


### PR DESCRIPTION
I suggest changing in express/lib/router/index.js, so that when no methods are found, then router should just pass on, so myApi could answer with the myApi.options() which it has defined. Currently app.router replies with an empty 'Allow' request header, even if some methods are accepted for the route.

See reference discussion here: https://groups.google.com/forum/#!msg/express-js/0oNFpyH51_k/VUTLGnA2UYQJ
