### PR TITLE
Fix * routing

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -85,6 +85,6 @@ function normalize(path, keys, sensitive, strict) {
         + (optional || '');
     })
     .replace(/([\/.])/g, '\\$1')
-    .replace(/\*/g, '(.+)');
+    .replace(/\*/g, '(.*)');
   return new RegExp('^' + path + '$', sensitive ? '' : 'i');
 }

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -138,6 +138,18 @@ module.exports = {
       { body: 'Cannot GET /user/ab' });
   },
   
+  'test that * operates correctly': function(){
+    var app = express.createServer();
+  
+    app.get('/admin*', function(req, res){
+      res.send(200);
+    });
+  
+    assert.response(app,
+      { url: '/admin', },
+      { status: 200 });
+  },
+  
   'test app.param()': function(){
     var app = express.createServer();
   
@@ -214,7 +226,7 @@ module.exports = {
       { url: '/user/12', method: 'OPTIONS' },
       { headers: { Allow: 'GET,PUT' }});
   },
-  
+
   'test app.lookup': function(){
     var app = express.createServer();
     app.get('/user', function(){});


### PR DESCRIPTION
Currently, when using a wildcard route, you're required to have something in the URL for the wildcard to match against.  Setting up a route as /admin\* should match /admin just as well as /admin/XXXX.  This pull request fixes that, and includes a test.
