### PR TITLE
specialcase .:format routing to not include a dot in the capture group

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -81,7 +81,7 @@ function normalize(path, keys, sensitive, strict) {
         + (optional ? '' : slash)
         + '(?:'
         + (optional ? slash : '')
-        + (format || '') + (capture || '([^/]+?)') + ')'
+        + (format || '') + (capture || (format && '([^/.]+?)' || '([^/]+?)')) + ')'
         + (optional || '');
     })
     .replace(/([\/.])/g, '\\$1')

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -138,6 +138,26 @@ module.exports = {
       { body: 'Cannot GET /user/ab' });
   },
   
+  'test named capture group after dot': function(){
+    var app = express.createServer();
+  
+    app.get('/user/:name.:format?', function(req, res){
+      res.send(req.params.name + ' - ' + (req.params.format || ''));
+    });
+    
+    assert.response(app,
+      { url: '/user/foo' },
+      { body: 'foo - ' });
+    
+    assert.response(app,
+      { url: '/user/foo.json' },
+      { body: 'foo - json' });
+    
+    assert.response(app,
+      { url: '/user/foo.bar.json' },
+      { body: 'foo.bar - json' });
+  },
+  
   'test optional * value': function(){
     var app = express.createServer();
   


### PR DESCRIPTION
Per https://github.com/visionmedia/express-resource/pull/27#issuecomment-1664827 I pushed that special case into express.
