### PR TITLE
partial(thisVarMyBeUndefined, { ignoreNoPath: true })

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - view
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -383,6 +382,7 @@ res._render = function(view, opts, fn, parent, sub){
 
   // Always expose partial() as a local
   options.partial = function(path, opts){
+    if(opts.ignoreNoPath && !path) return;
     return renderPartial(self, path, opts, options, view);
   };
 


### PR DESCRIPTION
now when you do partial(thisVarMyBeUndefined, { ignoreNoPath: true }) express will not throw an exception
usefull it the partial part is not 
