### PR TITLE
Validate options.status before pass it to res.statusCode.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - view
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -306,7 +305,7 @@ res.partial = function(view, options, fn){
  */
 
 res.render = function(view, opts, fn, parent, sub){
-  // support callback function as second arg
+  // support callback function as second annrg
   if ('function' == typeof opts) {
     fn = opts, opts = null;
   }
@@ -353,7 +352,7 @@ res._render = function(view, opts, fn, parent, sub){
   if (opts && opts.locals) merge(options, opts.locals);
 
   // status support
-  if (options.status) this.statusCode = options.status;
+  if (options.status && http.STATUS_CODES[options.status]) this.statusCode = options.status;
 
   // capture attempts
   options.attempts = [];


### PR DESCRIPTION
Developers may pass an status variable which is not valid HTTP Status code, but an object contains some other variables). We should not pass status like this to res.statusCode.
