### PR TITLE
added utf-8 paths support

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -289,7 +289,7 @@ Router.prototype._dispatch = function(req, res, next){
  */
 
 Router.prototype._options = function(req, res){
-  var path = parse(req.url).pathname
+  var path = decodeURIComponent(parse(req.url).pathname)
     , body = this._optionsFor(path).join(',');
   res.header('Allow', body).send(body);
 };
@@ -328,7 +328,7 @@ Router.prototype._optionsFor = function(path){
 Router.prototype._match = function(req, i){
   var method = req.method.toLowerCase()
     , url = parse(req.url)
-    , path = url.pathname
+    , path = decodeURIComponent(url.pathname)
     , routes = this.routes
     , captures
     , route


### PR DESCRIPTION
Hello again.
I've looked through 'connect' sources, and found out that it correctly decodes the path for static resources.
I think the node.exe is the culprit now - it gets the correct path when calling "fs.stat" method, but fails to locate this path. Maybe because I'm on windows.

Another bug I've found in Express is that utf-8 routes don't work.
I've corrected it, by modifying the Router class.
