### PR TITLE
use any Commander version above 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "connect": "git://github.com/senchalabs/connect.git",
-    "commander": "0.0.4",
+    "commander": ">= 0.0.4",
     "mime": ">= 1.2.2",
     "qs": ">= 0.3.1",
     "mkdirp": "0.0.7"


### PR DESCRIPTION
The commander version is hardcoded to 0.0.4, and so even Express master supports Node 0.5.x or above the dependencies resolution fails.

I don't actually know if that was deliberate and this is the first patch that came to my mind, quick edited and not tested though.
