### PR TITLE
default title for default jade layout

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -59,7 +59,7 @@ var jadeLayout = [
     '!!!'
   , 'html'
   , '  head'
-  , '    title= title'
+  , '    title= typeof(title) != "undefined" ? title : "Express"'
   , '    link(rel=\'stylesheet\', href=\'/stylesheets/style.css\')'
   , '  body!= body'
 ].join('\r\n');


### PR DESCRIPTION
default jade layout now provides a default title when res.render doesn't pass a custom title (instead of barfing a 500)
