### PR TITLE
Reminder for users using the examples

### DIFF
--- a/examples/multipart/app.js
+++ b/examples/multipart/app.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -6,6 +5,8 @@
 var express = require('../../lib/express')
   , form = require('connect-form');
 
+//NOTE!!: if express.bodyParser is already being used, it will parse the body before connect-form has a chance
+//and req.form will not fire any events because it has nothing else to read from the socket.
 var app = express.createServer(
   // connect-form (http://github.com/visionmedia/connect-form)
   // middleware uses the formidable middleware to parse urlencoded


### PR DESCRIPTION
Just a comment reminder. Already had to answer two stack overflow questions with users of the same problem.

Since version 2.0 of connect now includes formidable and parses all requests, users have been having issues with formidable on their own.
