### PR TITLE
Add express-negotiate to 3rd party module list

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -242,6 +242,7 @@ app.listen(3000);
 <li><a href="http://github.com/visionmedia/express-namespace">express-namespace</a> namespaced routing support</li>
 <li><a href="http://github.com/visionmedia/express-expose">express-expose</a> expose objects, functions, modules and more to client-side js</li>
 <li><a href="https://github.com/visionmedia/express-params">express-params</a> app.param() extensions</li>
+<li><a href="http://github.com/chrisleishman/express-negotiate">express-negotiate</a> negotiate the best content type for the client</li>
 <li><a href="https://github.com/LearnBoost/express-mongoose">express-mongoose</a> plugin for easy rendering of Mongoose async Query results</li>
 </ul>
 


### PR DESCRIPTION
I just released a expressjs extension to allow cleaner content negotiation (based on the accept header or on a file extension).  If you'd like to add it to the 3rd party module list, here's a patch.
