### PR TITLE
update keywords for search.npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "should": "*",
     "connect-redis": "*"
   },
-  "keywords": ["framework", "sinatra", "web", "rest", "restful"],
+  "keywords": ["express", "framework", "sinatra", "web", "rest", "restful"],
   "repository": "git://github.com/visionmedia/express",
   "main": "index",
   "bin": { "express": "./bin/express" },


### PR DESCRIPTION
Apparently, search.npmjs.org uses keywords to index their modules.

Now, searching for `express`, express didn't show up. We can fix this temporary by adding the `express` keyword. Or, we can hope that search.npmjs.org gets a better search backend.
