### PR TITLE
EOL style per platform

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -8,6 +8,7 @@ var express = require('../')
   , exec = require('child_process').exec
   , program = require('commander')
   , mkdirp = require('mkdirp')
+  , os = require('os')
   , fs = require('fs');
 
 // CLI
@@ -23,6 +24,10 @@ program
 // Path
 
 var path = program.args.shift() || '.';
+
+// end-of-line code
+
+var eol = os.platform()=='win32'? '\r\n' : '\n'
 
 // Template engine
 
@@ -49,7 +54,7 @@ var index = [
   , 'exports.index = function(req, res){'
   , '  res.render(\'index\', { title: \'Express\' });'
   , '};'
-].join('\r\n');
+].join(eol);
 
 /**
  * Jade layout template.
@@ -63,7 +68,7 @@ var jadeLayout = [
   , '    link(rel=\'stylesheet\', href=\'/stylesheets/style.css\')'
   , '  body'
   , '    block content'
-].join('\r\n');
+].join(eol);
 
 /**
  * Jade index template.
@@ -75,7 +80,7 @@ var jadeIndex = [
   , 'block content'
   , '  h1= title'
   , '  p Welcome to #{title}'
-].join('\r\n');
+].join(eol);
 
 /**
  * EJS index template.
@@ -93,7 +98,7 @@ var ejsIndex = [
   , '    <p>Welcome to <%= title %></p>'
   , '  </body>'
   , '</html>'
-].join('\r\n');
+].join(eol);
 
 /**
  * JSHTML layout template.
@@ -110,7 +115,7 @@ var jshtmlLayout = [
   , '    @write(body)'
   , '  </body>'
   , '</html>'
-].join('\r\n');
+].join(eol);
 
 /**
  * JSHTML index template.
@@ -119,7 +124,7 @@ var jshtmlLayout = [
 var jshtmlIndex = [
     '<h1>@write(title)</h1>'
   , '<p>Welcome to @write(title)</p>'
-  ].join('\r\n');
+  ].join(eol);
 
 /**
  * Default css template.
@@ -134,7 +139,7 @@ var css = [
   , 'a {'
   , '  color: #00B7FF;'
   , '}'
-].join('\r\n');
+].join(eol);
 
 /**
  * Default less template.
@@ -149,7 +154,7 @@ var less = [
   , 'a {'
   , '  color: #00B7FF;'
   , '}'
-].join('\r\n');
+].join(eol);
 
 /**
  * Default stylus template.
@@ -161,7 +166,7 @@ var stylus = [
   , '  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif'
   , 'a'
   , '  color: #00B7FF'
-].join('\r\n');
+].join(eol);
 
 /**
  * App template.
@@ -200,7 +205,7 @@ var app = [
   , ''
   , 'console.log("Express server listening on port 3000");'
   , ''
-].join('\r\n');
+].join(eol);
 
 // Generate application
 
@@ -274,7 +279,7 @@ function createApplicationAt(path) {
     // CSS Engine support
     switch (program.css) {
       case 'stylus':
-        app = app.replace('{css}', '\r\n  app.use(require(\'stylus\').middleware({ src: __dirname + \'/public\' }));');
+        app = app.replace('{css}', eol + '  app.use(require(\'stylus\').middleware({ src: __dirname + \'/public\' }));');
         break;
       default:
         app = app.replace('{css}', '');
@@ -282,22 +287,22 @@ function createApplicationAt(path) {
 
     // Session support
     app = app.replace('{sess}', program.sessions
-      ? '\n  app.use(express.cookieParser(\'your secret here\'));\n  app.use(express.session());'
+      ? eol + '  app.use(express.cookieParser(\'your secret here\'));' + eol + '  app.use(express.session());'
       : '');
 
     // Template support
     app = app.replace(':TEMPLATE', program.template);
 
     // package.json
-    var json = '{\n';
-    json += '    "name": "application-name"\n';
-    json += '  , "version": "0.0.1"\n';
-    json += '  , "private": true\n';
-    json += '  , "dependencies": {\n';
-    json += '      "express": "' + express.version + '"\n';
-    if (program.css) json += '    , "' + program.css + '": ">= 0.0.1"\n';
-    if (program.template) json += '    , "' + program.template + '": ">= 0.0.1"\n';
-    json += '  }\n';
+    var json = '{' + eol;
+    json += '    "name": "application-name"' + eol;
+    json += '  , "version": "0.0.1"' + eol;
+    json += '  , "private": true' + eol;
+    json += '  , "dependencies": {' + eol;
+    json += '      "express": "' + express.version + '"' + eol;
+    if (program.css) json += '    , "' + program.css + '": ">= 0.0.1"' + eol;
+    if (program.template) json += '    , "' + program.template + '": ">= 0.0.1"' + eol;
+    json += '  }' + eol;
     json += '}';
 
 


### PR DESCRIPTION
I made a change to select the end-of-line code depending on the platform type.
The patch also fixed the typo of '\n' in the session support string and package.json, which was apparently fixed in the 2.x branch.
Thank you. 
