### PR TITLE
In express 2.x, filename should be set on cached templates

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -47,7 +47,10 @@ exports.register = View.register;
  */
 
 exports.compile = function(view, cache, cid, options){
-  if (cache && cid && cache[cid]) return cache[cid];
+  if (cache && cid && cache[cid]){
+    options.filename = cache[cid].path;
+    return cache[cid];
+  }
 
   // lookup
   view = exports.lookup(view, options);
@@ -58,13 +61,13 @@ exports.compile = function(view, cache, cid, options){
     var err = new Error('failed to locate view "' + view.original.view + '"');
     err.view = view.original;
     throw err;
-  }    
+  }
 
   // compile
   options.filename = view.path;
   view.fn = view.templateEngine.compile(view.contents, options);
   cache[cid] = view;
-  
+
   return view;
 };
 
@@ -81,11 +84,11 @@ exports.compile = function(view, cache, cid, options){
  *
  * Lookup:
  *
- *   - partial `_<name>` 
- *   - any `<name>/index` 
- *   - non-layout `../<name>/index` 
- *   - any `<root>/<name>` 
- *   - partial `<root>/_<name>` 
+ *   - partial `_<name>`
+ *   - any `<name>/index`
+ *   - non-layout `../<name>/index`
+ *   - any `<root>/<name>`
+ *   - partial `<root>/_<name>`
  *
  * @param {String} view
  * @param {Object} options
@@ -161,7 +164,7 @@ function renderPartial(res, view, options, parentLocals, parent){
 
   // Inherit locals from parent
   union(options, parentLocals);
-  
+
   // Merge locals
   if (locals) merge(options, locals);
 
@@ -202,7 +205,7 @@ function renderPartial(res, view, options, parentLocals, parent){
         options.lastInCollection = i == len - 1;
         object = val;
         buf += render();
-      }      
+      }
     } else {
       keys = Object.keys(collection);
       len = keys.length;
@@ -227,20 +230,20 @@ function renderPartial(res, view, options, parentLocals, parent){
 };
 
 /**
- * Render `view` partial with the given `options`. Optionally a 
+ * Render `view` partial with the given `options`. Optionally a
  * callback `fn(err, str)` may be passed instead of writing to
  * the socket.
  *
  * Options:
  *
- *   - `object` Single object with name derived from the view (unless `as` is present) 
+ *   - `object` Single object with name derived from the view (unless `as` is present)
  *
  *   - `as` Variable name for each `collection` value, defaults to the view name.
  *     * as: 'something' will add the `something` local variable
  *     * as: this will use the collection value as the template context
  *     * as: global will merge the collection value's properties with `locals`
  *
- *   - `collection` Array of objects, the name is derived from the view name itself. 
+ *   - `collection` Array of objects, the name is derived from the view name itself.
  *     For example _video.html_ will have a object _video_ available to it.
  *
  * @param  {String} view
@@ -294,7 +297,7 @@ res.partial = function(view, options, fn){
  * automatically, however otherwise a response of _200_ and _text/html_ is given.
  *
  * Options:
- *  
+ *
  *  - `scope`     Template evaluation context (the value of `this`)
  *  - `debug`     Output debugging information
  *  - `status`    Response status code
@@ -430,7 +433,7 @@ res._render = function(view, opts, fn, parent, sub){
   // partial return
   } else if (partial) {
     return str;
-  // render complete, and 
+  // render complete, and
   // callback given
   } else if (fn) {
     fn(null, str);


### PR DESCRIPTION
A cached template that relies on the filename local parameter will currently generate an error. This one-line patch fixes the issue.

This commit also eliminates whitespace at the end of lines in views.js. I have vim set up to do this upon save.
