### PR TITLE
Add `test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "repository": "git://github.com/visionmedia/express",
   "main": "index",
   "bin": { "express": "./bin/express" },
-  "scripts": { "prepublish" : "npm prune" },
+  "scripts": {
+    "prepublish" : "npm prune",
+    "test": "make test"
+  },
   "engines": { "node":">= 0.5.0 < 0.7.0" }
 }
+


### PR DESCRIPTION
Right now your builds on Travis look like [this](http://travis-ci.org/#!/visionmedia/express/builds/485955). This makes Travis able to actually run tests.

Also, many people are really used to `npm test`.
