### PR TITLE
Remove trailing slashes from install path

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -23,7 +23,7 @@ program
 
 // Path
 
-var path = program.args.shift() || '.';
+var path = program.args.shift().replace(/\/*$/, '') || '.';
 
 // end-of-line code
 


### PR DESCRIPTION
Hi,

This is a small cosmetic change to the `express` script.

When you insert a trailing slash in the path to be used as install path, the trailing slash stays in the variable, resulting in double slashes when the subdirectories are being created. This is ugly and confusing in my opinion.

before:
![before](http://f.cl.ly/items/2x0u0L132716172Z1S08/Screen%20Shot%202012-01-15%20at%2019.25.04.png)

after:
![after](http://f.cl.ly/items/320x1i150s1m470I2O1z/Screen%20Shot%202012-01-15%20at%2019.24.30.png)
