### PR TITLE
added newline character check in url in response.redirect function

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -469,6 +469,12 @@ res.redirect = function(url){
   // perform redirect
   url = map[url] || url;
 
+  // Throw exception if url contains newline characters to avoid HTTP Response Splitting attack
+  // https://www.owasp.org/index.php/HTTP_Response_Splitting
+  if(url.indexOf('\n') !== -1) {
+    throw 'redirect uri contains newline characters';
+  }
+
   // relative
   if (!~url.indexOf('://')) {
     var path = app.path();

--- a/lib/response.js
+++ b/lib/response.js
@@ -472,7 +472,7 @@ res.redirect = function(url){
   // Throw exception if url contains newline characters to avoid HTTP Response Splitting attack
   // https://www.owasp.org/index.php/HTTP_Response_Splitting
   if(url.indexOf('\n') !== -1) {
-    throw 'redirect uri contains newline characters';
+    throw Error('redirect uri contains newline characters');
   }
 
   // relative


### PR DESCRIPTION
currently express framework do not check for newline characters
it is vulnerable to http splitting attack

example:
start the test server https://gist.github.com/1654555

browse http://localhost:3000/?foo=bar%0D%0ASet-Cookie%3Aname%3Dvalue
you will be re redirected to another page and cookie will be set
