### PR TITLE
Added support for arrays of paths

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - router - Route
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -59,7 +58,7 @@ Route.prototype.match = function(path){
  * key names. For example "/user/:id" will
  * then contain ["id"].
  *
- * @param  {String|RegExp} path
+ * @param  {String|RegExp|Array} path
  * @param  {Array} keys
  * @param  {Boolean} sensitive
  * @param  {Boolean} strict
@@ -69,6 +68,8 @@ Route.prototype.match = function(path){
 
 function normalize(path, keys, sensitive, strict) {
   if (path instanceof RegExp) return path;
+  if (path instanceof Array) 
+  	path = '(' + path.join('|') + ')';
   path = path
     .concat(strict ? '' : '/?')
     .replace(/\/\(/g, '(?:/')

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -1,4 +1,3 @@
-
 var express = require('../')
   , request = require('./support/http')
   , assert = require('assert');
@@ -110,6 +109,24 @@ describe('app.router', function(){
       .expect('editing user 10', done);
     })
   })
+  
+  describe('when given an array', function(){
+  	it('should match all paths in the array', function(done){
+			var app = express();
+			
+			app.get(['/one', '/two'], function(req, res){
+				res.end('works');
+			});
+			
+			request(app)
+			.get('/one')
+			.expect('works', function() {
+				request(app)
+				.get('/two')
+				.expect('works', done);
+			});
+		})
+	})
 
   describe('case sensitivity', function(){
     it('should be disabled by default', function(done){


### PR DESCRIPTION
Makes it possible to do:

``` javascript
app.get(['/one', '/two'], function (req, res) {
  // something
});
```

Don't know if you want it, but i find it to be a nice alternative to writing a RegExp.
