### PR TITLE
[2.x] Do not to call `app.address()` before `listening` event

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -185,8 +185,9 @@ var app = [
   , ''
   , 'app.get(\'/\', routes.index);'
   , ''
-  , 'app.listen(3000);'
-  , 'console.log("Express server listening on port %d in %s mode", app.address().port, app.settings.env);'
+  , 'app.listen(3000, function(){'
+  , '  console.log("Express server listening on port %d in %s mode", app.address().port, app.settings.env);'
+  , '});'
   , ''
 ].join(eol);
 


### PR DESCRIPTION
Not sure if you still take pull requests for `2.x`, but:

According to joyent/node@d3f6b094c71a8d2c78dc6cd8bb50b01db6d38e27,
call to `net.Server.address()` should happen only after `net.Server`
emits `listening` event.
