### PR TITLE
Added the ability to force the install of express scaffolding to a non-empty directory.

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -19,6 +19,7 @@ program
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('-J, --jshtml', 'add jshtml engine support (defaults to jade)')
   .option('-S, --stylus', 'add stylus support')
+  .option('-f, --force', 'force express scaffolding to deploy to non-empty directory')
   .parse(process.argv);
 
 // Path
@@ -211,7 +212,7 @@ var app = [
 
 (function createApplication(path) {
   emptyDirectory(path, function(empty){
-    if (empty) {
+    if (empty || program.force) {
       createApplicationAt(path);
     } else {
       program.confirm('destination is not empty, continue? ', function(ok){


### PR DESCRIPTION
I have used this to successfully install scaffolding using a local copy (non-global) of express into the same directory that express was installed from. Cloud9 does not give you the opportunity to say yes to the empty directory warning, so this was used as a workaround.

```
npm install express
node node_modules/express/bin/express -f
```
