### PR TITLE
req.accepts: */* wildcard fix

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -135,8 +135,8 @@ req.accepts = function(type){
   // normalize extensions ".json" -> "json"
   if (type && '.' == type[0]) type = type.substr(1);
 
-  // when Accept does not exist, or is '*/*' return true 
-  if (!accept || '*/*' == accept) {
+  // when Accept does not exist, or contains '*/*' return true
+  if (!accept || ~accept.indexOf('*/*')) {
     return true;
   } else if (type) {
     // allow "html" vs "text/html" etc


### PR DESCRIPTION
Look for `*/*` anywhere in the Accept header instead of only supporting it when it's the exact value of the header.

IE8 sends:

```
Accept: image/gif, image/jpeg, image/pjpeg, image/pjpeg, application/x-shockwave-flash, application/x-ms-application, application/x-ms-xbap, application/vnd.ms-xpsdocument, application/xaml+xml, */*
```

for which `req.accepts('html')` returned `false`.

This bug doesn't exist on the master branch.
