### PR TITLE
Support PURGE request method.

### DIFF
--- a/lib/router/methods.js
+++ b/lib/router/methods.js
@@ -55,6 +55,14 @@ var RFC5323 = ['SEARCH'];
 var RFC5789 = ['PATCH'];
 
 /**
+ * PURGE Method for caching reverse-proxy
+ * http://wiki.squid-cache.org/SquidFaq/OperatingSquid#How_can_I_purge_an_object_from_my_cache.3F
+ * https://www.varnish-cache.org/docs/trunk/tutorial/purging.html
+ */
+
+var CACHE_PURGE = ['PURGE'];
+
+/**
  * Expose the methods.
  */
 
@@ -65,6 +73,7 @@ module.exports = [].concat(
   , RFC3648
   , RFC3744
   , RFC5323
-  , RFC5789).map(function(method){
+  , RFC5789
+  , CACHE_PURGE).map(function(method){
     return method.toLowerCase();
   });


### PR DESCRIPTION
Following my report of https://github.com/joyent/node/issues/2775, PURGE request supported has been added to node.js. In order to be usable with Express, the method needs to be added to lib/router/methods.js.
