### PR TITLE
Do not lie about what res.contentType() accepts

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -785,13 +785,15 @@ Sets the _Content-Type_ response header to the given _type_.
       res.contentType(filename);
       // Content-Type is now "image/png"
 
-A literal _Content-Type_ works as well:
-
-      res.contentType('application/json');
-
 Or simply the extension without leading `.`:
 
       res.contentType('json');
+
+Note that a literal _Content-Type_ will not always work and should be avoided.
+If you want to set the header to some exotic value, use this:
+
+    res.header('Content-Type', 'teh/lolz')
+
 
 ### res.attachment([filename])
 


### PR DESCRIPTION
Passing it a literal content type string will not always work. For
`application/json` it works only by pure chance. It is because `json` is also
coincidentally the file extension. But if you tried `application/javascript`
it would set the content type header to `application/octet-stream`, because
`javascript` is not a known file extension.

FIXME: do I have to regenerate the html docs or can you do that for me?
