### PR TITLE
Update Connect Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     { "name": "Guillermo Rauch", "email": "rauchg@gmail.com" }
   ],
   "dependencies": {
-    "connect": "2.0.0",
+    "connect": "2.0.3",
     "commander": "0.5.2",
     "mime": "1.2.5",
     "mkdirp": "0.3.0",


### PR DESCRIPTION
Can't install express with Connect 2.0.0 version specified.
