### PR TITLE
(trivial) Give express init middleware function an explicit name

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -16,7 +16,7 @@
  */
 
 exports.init = function(app){
-  return function(req, res, next){
+  return function expressInit(req, res, next){
     var charset;
     res.setHeader('X-Powered-By', 'Express');
     req.app = res.app = app;


### PR DESCRIPTION
Middleware stack printout before:
    NODE> app.stack
    [ { route: '', handle: [Function: query] },
      { route: '', handle: [Function] },
      { route: '', handle: [Function: favicon] },
      { route: '', handle: [Function: logger] },

```
Middleware stack printout after:
NODE> app.stack
[ { route: '', handle: [Function: query] },
  { route: '', handle: [Function: expressInit] },
  { route: '', handle: [Function: favicon] },
  { route: '', handle: [Function: logger] },
```
