### PR TITLE
View lookup should return something at least

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -66,8 +66,7 @@ View.prototype.lookup = function(path){
   if (exists(path)) return path;
 
   // <path>/index.<engine>
-  path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
+  return join(dirname(path), basename(path, ext), 'index' + ext);
 };
 
 /**


### PR DESCRIPTION
Even if the path doesn't exist it's better for the lookup
method to return the last path checked. Without a return
value, if one attempts to render a path that doesn't
exist one gets "TypeError: Bad argument" because the
first param for fs.readFile is undefined. If the path is
returned one gets the more helpful "Error: ENOENT, no
such file or directory" along with the string for the
path.
