### PR TITLE
Unused require of fs module

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - View
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -11,7 +10,6 @@
 
 var path = require('path')
   , utils = require('./utils')
-  , fs = require('fs')
   , dirname = path.dirname
   , basename = path.basename
   , extname = path.extname


### PR DESCRIPTION
Looks like File System module usage had been refactored out of view.js some time ago, but the require remained.
