### PR TITLE
The guide says that `res.contentType` can accept literal types. This makes that true.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -285,7 +285,13 @@ res.download = function(path, filename, fn){
 
 res.contentType =
 res.type = function(type){
-  return this.set('Content-Type', mime.lookup(type));
+  var fallback = 'application/octet-stream'
+    , mimetype = mime.lookup(type)
+    , matchtype = /^[a-z].+\/[a-z].+$/i;
+  if (type !== fallback && mimetype === fallback && type.match(matchtype)) {
+    mimetype = type;
+  }
+  return this.set('Content-Type', mimetype);
 };
 
 /**

--- a/test/res.type.js
+++ b/test/res.type.js
@@ -18,5 +18,33 @@ describe('res', function(){
         done();
       })
     })
+    it('should fallback to application/octet-stream', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.type('./path/foo.blargh').end('var name = "tj";');
+      });
+
+      request(app)
+      .get('/')
+      .end(function(res){
+        res.headers.should.have.property('content-type', 'application/octet-stream');
+        done();
+      })
+    })
+    it('should handle literal mime types', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.type('multipart/encrypted').end('var name = "tj";');
+      });
+
+      request(app)
+      .get('/')
+      .end(function(res){
+        res.headers.should.have.property('content-type', 'multipart/encrypted');
+        done();
+      })
+    })
   })
 })


### PR DESCRIPTION
I mentioned in the comments for #1047 that this will break code that does `res.contentType('path/foo.blagh')` with the expectation that they will get the fallback type `application/octet-stream` but I think that's an acceptable tradeoff.
