### PR TITLE
fix version in the pkg

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -304,7 +304,7 @@ function createApplicationAt(path) {
       , private: true
       , scripts: { start: 'node app' }
       , dependencies: {
-        express: express.version
+        express: program._version
       }
     }
 


### PR DESCRIPTION
When trying to use the express command in the CLI I get the following error message:

``` /usr/local/lib/node_modules/express/bin/express:307
        express: express.version
                 ^
ReferenceError: express is not defined
    at /usr/local/lib/node_modules/express/bin/express:307:18
    at /usr/local/lib/node_modules/express/bin/express:366:11
    at Object.oncomplete (/usr/local/lib/node_modules/express/node_modules/mkdirp/index.js:35:26)
```

And the script dies.
