### PR TITLE
Add protocol to fix link being interpreted as relative in README.md.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,8 +56,8 @@ app.listen(3000);
   Built on Connect you can use _only_ what you need, and nothing more, applications
   can be as big or as small as you like, even a single file. Express does
   not force you to use any specific ORM or template engine. With support for over
-  14 template engines via [Consolidate.js](github.com/visionmedia/consolidate.js) you
-  can quickly craft your perfect framework.
+  14 template engines via [Consolidate.js](http://github.com/visionmedia/consolidate.js)
+  you can quickly craft your perfect framework.
 
 ## More Information
 


### PR DESCRIPTION
Minor fix for an minor problem: the link to Consolidate.js was busted because it was being treated as relative.
