### PR TITLE
Update to commander 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "connect": "2.1.2",
-    "commander": "0.5.2",
+    "commander": "0.6.0",
     "mime": "1.2.5",
     "mkdirp": "0.3.1",
     "debug": "*"


### PR DESCRIPTION
npm install commander@0.5.2 fails with

```
npm ERR! Error: ENOENT, open '/Users/shinuza/tmp/node_modules/commander/package.json'
```

npm install commander@0.6.0 works, depending if 0.6.0 is backwards compatible this pull request might be required to install commander (at least the git up version)
