### PR TITLE
old version number for generated package.json

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -10,10 +10,16 @@ var fs = require('fs')
   , mkdirp = require('mkdirp');
 
 /**
+ * Package information.
+ */
+
+var pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json'));
+
+/**
  * Framework version.
  */
 
-var version = '2.5.8';
+var version = pkg.version;
 
 /**
  * Add session support.


### PR DESCRIPTION
Used `package.json` version number for `express` command :) I don't use `require` for old version node (0.4.x)
