### PR TITLE
Made the signature of View.lookup async, and added option to make the lookup function being overridable

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -20,7 +20,8 @@ var connect = require('connect')
   , path = require('path')
   , http = require('http')
   , join = path.join
-  , fs = require('fs');
+  , fs = require('fs')
+  , lookupView = require('./utils').lookupView;
 
 /**
  * Application prototype.
@@ -498,13 +499,10 @@ app.render = function(name, options, fn){
   if (!view) {
     view = new View(name, {
         defaultEngine: this.get('view engine')
+      , lookupView: this.get('view lookup') || lookupView
       , root: this.get('views') || process.cwd() + '/views'
       , engines: engines
     });
-
-    if (!view.path) {
-      return fn(new Error('Failed to lookup view "' + name + '"'));
-    }
 
     // prime the cache
     if (opts.cache) cache[name] = view;

--- a/lib/response.js
+++ b/lib/response.js
@@ -73,7 +73,7 @@ res.send = function(body){
   
   // Convert string objects to string literals
   if(body instanceof String)
-  	body = body.toString();
+    body = body.toString();
 
   switch (typeof body) {
     // response status

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -260,7 +260,8 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
 }
 
 /**
- * Default view lookup function
+ * Look for view by the given `path`,
+ * returning an absolute path or null if not found.
  *
  * @param  {String} path
  * @param  {Object} options
@@ -271,12 +272,12 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
 exports.lookupView = function(path, options, fn) {
   // <path>.<engine>
   if (!isAbsolute(path)) path = join(options.root, path);
-  exists(path, function(res){
+  exists(path, function(res) {
     if(res) return fn(path);
     
     // <path>/index.<engine>
     path = join(dirname(path), basename(path, options.ext), 'index' + options.ext);
-    exists(path, function(res){
+    exists(path, function(res) {
       fn(res ? path : null);
     });
   })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -261,7 +261,7 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
 
 /**
  * Look for view by the given `path`,
- * returning an absolute path or null if not found.
+ * returning an absolute path.
  *
  * @param  {String} path
  * @param  {Object} options

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,13 @@
  * Module dependencies.
  */
 
-var mime = require('mime');
+var mime = require('mime')
+  , path = require('path')
+  , exists = path.exists
+  , dirname = path.dirname
+  , basename = path.basename
+  , join = path.join;
+
 
 /**
  * Check if `path` looks absolute.
@@ -19,7 +25,7 @@ var mime = require('mime');
  * @api private
  */
 
-exports.isAbsolute = function(path){
+var isAbsolute = exports.isAbsolute = function(path){
   if ('/' == path[0]) return true;
   if (':' == path[1] && '\\' == path[2]) return true;
 };
@@ -251,4 +257,27 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
     .replace(/([\/.])/g, '\\$1')
     .replace(/\*/g, '(.*)');
   return new RegExp('^' + path + '$', sensitive ? '' : 'i');
+}
+
+/**
+ * Default view lookup function
+ *
+ * @param  {String} path
+ * @param  {Object} options
+ * @param  {Function} fn
+ * @api private
+ */
+
+exports.lookupView = function(path, options, fn) {
+  // <path>.<engine>
+  if (!isAbsolute(path)) path = join(options.root, path);
+  exists(path, function(res){
+    if(res) return fn(path);
+    
+    // <path>/index.<engine>
+    path = join(dirname(path), basename(path, options.ext), 'index' + options.ext);
+    exists(path, function(res){
+      fn(res ? path : null);
+    });
+  })
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -272,13 +272,14 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
 exports.lookupView = function(path, options, fn) {
   // <path>.<engine>
   if (!isAbsolute(path)) path = join(options.root, path);
-  exists(path, function(res) {
-    if(res) return fn(path);
+  exists(path, function(res){
+    if(res) return fn(null, path);
     
     // <path>/index.<engine>
     path = join(dirname(path), basename(path, options.ext), 'index' + options.ext);
-    exists(path, function(res) {
-      fn(res ? path : null);
+    exists(path, function(res){
+      if(!res) return fn(new Error('Failed to lookup view "' + options.name + '"'));
+      fn(null, path);
     });
   })
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -8,19 +8,15 @@
  * Module dependencies.
  */
 
-var path = require('path')
-  , utils = require('./utils')
-  , dirname = path.dirname
-  , basename = path.basename
-  , extname = path.extname
-  , exists = path.existsSync
-  , join = path.join;
+var utils = require('./utils')
+  , extname = require('path').extname;
 
 /**
  * Expose `View`.
  */
 
 module.exports = View;
+
 
 /**
  * Initialize a new `View` with the given `name`.
@@ -42,31 +38,31 @@ function View(name, options) {
   this.root = options.root;
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
+  this.lookupView = options.lookupView;
   var ext = this.ext = extname(name);
   if (!ext) name += (ext = this.ext = '.' + this.defaultEngine);
   this.engine = engines[ext] || (engines[ext] = require(ext.slice(1)).__express);
-  this.path = this.lookup(name);
+  this.fullname = name;
 }
 
 /**
  * Lookup view by the given `path`
  *
  * @param {String} path
- * @return {String}
+ * @param {Function} fn
  * @api private
  */
 
-View.prototype.lookup = function(path){
-  var ext = this.ext;
-
-  // <path>.<engine>
-  if (!utils.isAbsolute(path)) path = join(this.root, path);
-  if (exists(path)) return path;
-
-  // <path>/index.<engine>
-  path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
-};
+View.prototype.lookup = function(path, fn) {
+  var _this = this;
+  this.lookupView(path
+    , {ext: this.ext, root: this.root}
+    , function(res) {
+        if(!res) return fn(new Error('Failed to lookup view "' + _this.name + '"'));
+        fn(null, res);
+      }
+  );
+}
 
 /**
  * Render with the given `options` and callback `fn(err, str)`.
@@ -77,5 +73,13 @@ View.prototype.lookup = function(path){
  */
 
 View.prototype.render = function(options, fn){
-  this.engine(this.path, options, fn);
+  var _this = this;
+  
+  if(this.path) return this.engine(res, options, fn);
+  
+  this.lookup(this.fullname, function(err, res){
+    if(err) return fn(err);
+    _this.path = res;
+    _this.engine(res, options, fn);
+  });
 };

--- a/lib/view.js
+++ b/lib/view.js
@@ -56,10 +56,10 @@ function View(name, options) {
 View.prototype.lookup = function(path, fn) {
   var _this = this;
   this.lookupView(path
-    , {ext: this.ext, root: this.root}
-    , function(res) {
-        if(!res) return fn(new Error('Failed to lookup view "' + _this.name + '"'));
-        fn(null, res);
+    , {ext: this.ext, root: this.root, name: this.name}
+    , function(err, path) {
+        if(err) return fn(err);
+        fn(null, path);
       }
   );
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -57,10 +57,7 @@ View.prototype.lookup = function(path, fn) {
   var _this = this;
   this.lookupView(path
     , {ext: this.ext, root: this.root, name: this.name}
-    , function(err, path) {
-        if(err) return fn(err);
-        fn(null, path);
-      }
+    , fn
   );
 }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -72,12 +72,12 @@ View.prototype.lookup = function(path, fn) {
  * @api private
  */
 
-View.prototype.render = function(options, fn){
+View.prototype.render = function(options, fn) {
   var _this = this;
   
   if(this.path) return this.engine(res, options, fn);
   
-  this.lookup(this.fullname, function(err, res){
+  this.lookup(this.fullname, function(err, res) {
     if(err) return fn(err);
     _this.path = res;
     _this.engine(res, options, fn);


### PR DESCRIPTION
This fixes issue [#1089](https://github.com/visionmedia/express/issues/1089).

**Summary of changes:**
- Created a new `lookupView` function in `utils`, which behaves pretty much like the current `View.lookup` method, except it is asynchronous.
- Added a new option `view lookup`, which can be used to replace `utils.lookupView` with a custom function. It expects to be passed a function with the same exact signature as `utils.lookupView`.
- Updated `App.render`, which now passes the lookup function to use to the `View`, in the already-existing options object. Additionally, responsibility to send error message when a view does not exist has been moved to the `View.lookup` method.
- Updated `View.lookup`, whose only responsibility is to call the actual view lookup function passed by `App.render`, and throw an error if not found.
- Updated `View.render`, which now is responsible to call `View.lookup`.
- Also fixes a small indentation problem from my pull request [#1100](https://github.com/visionmedia/express/pull/1100). Sorry about that.
