### PR TITLE
special handling of app.set() config objects

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -74,6 +74,13 @@
   
   Mounted servers inherit their parent server's settings.
 
+  Objects are merged rather than overwritten.
+
+     app.set('tv settings', { channel: 42 });
+     app.set('tv settings', { volume: 100 });
+     app.get('tv settings');
+     // => { channel: 42, volume: 100 }
+
 # app.enabled()
 
   Check if `setting` is enabled (truthy).

--- a/lib/application.js
+++ b/lib/application.js
@@ -270,10 +270,23 @@ app.set = function(setting, val){
     } else if (this.parent) {
       return this.parent.set(setting);
     }
-  } else {
-    this.settings[setting] = val;
-    return this;
+    return undefined;
   }
+
+  // Merge objects instead of overwriting them.
+  isObject = function(obj){
+    return obj && (typeof obj === "object") && (obj.constructor == Object);
+  }
+  if (isObject(this.settings[setting]) && isObject(val)) {
+    for (var key in this.settings[setting]) {
+      if (this.settings[setting].hasOwnProperty(key)) {
+        val[key] = this.settings[setting][key];
+      }
+    }
+  }
+
+  this.settings[setting] = val;
+  return this;
 };
 
 /**


### PR DESCRIPTION
Previous behavior was to overwrite objects, but it makes much more sense
for a configuration file to merge the new object with the existing one.

This allows for things like:

```
 app.set('tv settings', { channel: 42 });
 app.set('tv settings', { volume: 100 });
 app.get('tv settings');
 // => { channel: 42, volume: 100 }
```

This seems much more intuitive, and avoids confusing bugs like:

```
app.configure(function(){
    app.set('view options', { layout: false });
});
app.configure('development', function(){
    app.set('view options', { pretty: true });
});
// => In development config, layout: true !?!?
```

But it's a public API change. Conceivably some websites may rely on the above behavior. But it seems really insidious and misleading, and probably the following is more common:

```
app.configure(function(){
    app.set('view options', { layout: false });
});
app.configure('development', function(){
    app.set('view options', { layout: false, pretty: true });
});
```

which won't break from these changes  -- it will just be redundant.
