### PR TITLE
add res.locals.use

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -15,6 +15,7 @@ var connect = require('connect')
   , middleware = require('./middleware')
   , debug = require('debug')('express:application')
   , View = require('./view')
+  , local = require('./local')
   , url = require('url')
   , utils = connect.utils
   , path = require('path')
@@ -43,7 +44,6 @@ app.init = function(){
   this.cache = {};
   this.settings = {};
   this.engines = {};
-  this.viewCallbacks = [];
   this.defaultConfiguration();
 };
 
@@ -65,30 +65,14 @@ app.defaultConfiguration = function(){
   this.use(middleware.init(this));
 
   // app locals
-  this.locals = function(obj){
-    for (var key in obj) self.locals[key] = obj[key];
-    return self;
-  };
-
-  // response locals
-  this.locals.use = function(fn){
-    if (3 == fn.length) {
-      self.viewCallbacks.push(fn);
-    } else {
-      self.viewCallbacks.push(function(req, res, done){
-        fn(req, res);
-        done();
-      });
-    }
-    return this;
-  };
+  local.init.call(this);
 
   // inherit view callbacks
   this.on('mount', function(parent){
     this.request.__proto__ = parent.request;
     this.response.__proto__ = parent.response;
     this.engines.__proto__ = parent.engines;
-    this.viewCallbacks = parent.viewCallbacks.slice(0);
+    this.locals.callbacks = parent.locals.callbacks;
   });
 
   // router

--- a/lib/local.js
+++ b/lib/local.js
@@ -1,0 +1,30 @@
+var local = function(obj){
+  for (var key in obj) this.locals[key] = obj[key]
+  return this;
+};
+
+var use = function(fn){
+  if (3 == fn.length) {
+    this.__callbacks.push(fn);
+  } else {
+    this.__callbacks.push(function(req, res, done){
+      fn(req, res);
+      done();
+    });
+  }
+  return this;
+};
+
+exports.init = function(){
+  var self = this;
+  this.__callbacks = [];
+  this.locals = local.bind(this);
+  this.locals.use = use.bind(this);
+  this.locals.__defineSetter__('callbacks', function(callbacks){
+    self.__callbacks = callbacks;
+    return self;
+  });
+  this.locals.__defineGetter__('callbacks', function(){
+    return self.__callbacks;
+  });
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,3 +1,4 @@
+var local = require('./local');
 
 /*!
  * Express - middleware
@@ -26,10 +27,7 @@ exports.init = function(app){
     req.__proto__ = app.request;
     res.__proto__ = app.response;
 
-    res.locals = function(obj){
-      for (var key in obj) res.locals[key] = obj[key];
-      return res;
-    };
+    local.init.call(res);
 
     next();
   }

--- a/lib/response.js
+++ b/lib/response.js
@@ -627,7 +627,7 @@ res.render = function(view, options, fn){
   }
 
   // invoke view callbacks
-  var callbacks = app.viewCallbacks
+  var callbacks = app.locals.callbacks.concat(this.locals.callbacks)
     , pending = callbacks.length
     , len = pending
     , done;

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -6,10 +6,10 @@ describe('app', function(){
   describe('.locals(obj)', function(){
     it('should merge locals', function(){
       var app = express();
-      Object.keys(app.locals).should.eql(['use', 'settings']);
+      Object.keys(app.locals).should.eql(['use', 'callbacks', 'settings']);
       app.locals({ user: 'tobi', age: 1 });
       app.locals({ age: 2 });
-      Object.keys(app.locals).should.eql(['use', 'settings', 'user', 'age']);
+      Object.keys(app.locals).should.eql(['use', 'callbacks', 'settings', 'user', 'age']);
       app.locals.user.should.equal('tobi');
       app.locals.age.should.equal(2);
     })

--- a/test/res.locals.use.js
+++ b/test/res.locals.use.js
@@ -1,0 +1,44 @@
+var express = require('../')
+  , request = require('./support/http');
+
+describe('res', function () {
+  describe('.locals.use(fn)', function () {
+    it('should render', function(done) {
+      var app = express();
+
+      app.set('views', __dirname + '/fixtures');
+
+      app.use(function(req, res) {
+        res.locals.use(function(req, res, done) {
+          process.nextTick(function(){
+            res.locals.first = 'tobi';
+            done();
+          });
+        });
+
+        res.locals.use(function(req, res, done) {
+          process.nextTick(function(){
+            res.locals.last = 'holowaychuk';
+            done();
+          });
+        });
+
+        res.locals.use(function(req, res, done) {
+          process.nextTick(function(){
+            res.locals.species = 'ferret';
+            done();
+          });
+        });
+
+        res.render('pet.jade');
+      })
+
+      request(app)
+      .get('/')
+      .end(function(res){
+        res.body.should.equal('<p>tobi holowaychuk is a ferret</p>');
+        done();
+      })
+    })
+  })
+})


### PR DESCRIPTION
This is a experimental implementation of feature request [issue 1120](https://github.com/visionmedia/express/issues/1120) which I opened.

I still don't quite understand connect/express ecosystem. As I see in [issure 1000](https://github.com/visionmedia/express/issues/1000) `app.local` is implemented by expando rather than prototype inheritance.

I don't know about javascript performance, but it seems to me that mixining to every response as I implemented is quite inefficient.
