### PR TITLE
path.existsSync is deprecated. It is now called `fs.existsSync`.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,14 +1,14 @@
-
 /**
  * Module dependencies.
  */
 
 var path = require('path')
+  , fs = require('fs')
   , utils = require('./utils')
   , dirname = path.dirname
   , basename = path.basename
   , extname = path.extname
-  , exists = path.existsSync
+  , exists = fs.existsSync || path.existsSync 
   , join = path.join;
 
 /**


### PR DESCRIPTION
BC fix for node 0.7.x in preparation for node 0.8.x

relevant commit: https://github.com/joyent/node/commit/e10ed097cb3b506009ab28af4dec93402aa48693
