### PR TITLE
get port from env in template (fix for #1118)

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -181,6 +181,7 @@ var app = [
   , 'var app = express();'
   , ''
   , 'app.configure(function(){'
+  , '  app.set(\'port\', process.env.PORT || 3000);'
   , '  app.set(\'views\', __dirname + \'/views\');'
   , '  app.set(\'view engine\', \':TEMPLATE\');'
   , '  app.use(express.favicon());'
@@ -197,9 +198,9 @@ var app = [
   , ''
   , 'app.get(\'/\', routes.index);'
   , ''
-  , 'http.createServer(app).listen(3000);'
-  , ''
-  , 'console.log("Express server listening on port 3000");'
+  , 'http.createServer(app).listen(app.set(\'port\'), function() {'
+  , '  console.log("Express server listening on port " + app.set(\'port\'));'
+  , '});'
   , ''
 ].join(eol);
 

--- a/bin/express
+++ b/bin/express
@@ -198,8 +198,8 @@ var app = [
   , ''
   , 'app.get(\'/\', routes.index);'
   , ''
-  , 'http.createServer(app).listen(app.set(\'port\'), function() {'
-  , '  console.log("Express server listening on port " + app.set(\'port\'));'
+  , 'http.createServer(app).listen(app.get(\'port\'), function() {'
+  , '  console.log("Express server listening on port " + app.get(\'port\'));'
   , '});'
   , ''
 ].join(eol);


### PR DESCRIPTION
I made a change to the app template as suggested in #1118, that gets the port from an environment variable, if it's present. This is used by multiple deployment environments, including Heroku. The updated app template uses an application setting, `port`, so it can be used elsewhere as well.
