### PR TITLE
Adjust dependency version to allow for newer versions of connect, which install with node 0.7.X.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     { "name": "Guillermo Rauch", "email": "rauchg@gmail.com" }
   ],
   "dependencies": {
-    "connect": "2.2.1",
+    "connect": ">=2.2.1",
     "commander": "0.5.2",
     "mime": "1.2.5",
     "mkdirp": "0.3.1",


### PR DESCRIPTION
More of this. So, I can install `connect` now, using `npm install connect`, but `express` still looks for `connect` version `2.2.1`. This change should be the last required thing to get a simple `npm install express` working with node versions 0.7.X. Dependencies. Sorry, TJ. :(
