### PR TITLE
Easier and coherent IP handling for proxy and non-proxy requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -339,7 +339,7 @@ req.__defineGetter__('secure', function(){
 req.__defineGetter__('ips', function(){
   var trustProxy = this.app.get('trust proxy');
   var val = this.get('X-Forwarded-For');
-  return trusProxy && val
+  return trustProxy && val
     ? val.split(/ *, */).reverse()
     : [];
 });

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -338,10 +337,29 @@ req.__defineGetter__('secure', function(){
  */
 
 req.__defineGetter__('ips', function(){
+  var trustProxy = this.app.get('trust proxy');
   var val = this.get('X-Forwarded-For');
-  return val
+  return trusProxy && val
     ? val.split(/ *, */).reverse()
     : [];
+});
+
+/**
+ * If "trust proxy" is `true`, parse
+ * the "X-Forwarded-For" ip address list
+ * and return the last ip address (the client's ip).
+ * 
+ * If not, return req.connection.remoteAddress.
+ * 
+ * @return {String}
+ * @api public
+ */
+
+req.__defineGetter__('ip', function(){
+  var trustProxy = this.app.get('trust proxy');
+  return trustProxy ?
+    (this.ips.reverse()[0] || this.connection.remoteAddress) : 
+    this.connection.remoteAddress;
 });
 
 /**


### PR DESCRIPTION
`req.ip` will now return a string containing the client's IP. Regardless if the client uses a proxy, multiple proxies or none.

I fixed a minor security issue in `req.ips` too.
