### PR TITLE
Ability to nest routes

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -180,7 +180,7 @@
      http.createServer({ ... }, app).listen(443);
 
 # app.with()
-  Appends a prefix to the urls defined inside of it's callback.
+  Preppends a prefix to the urls defined inside of it's callback.
 
   Example
 

--- a/docs/application.md
+++ b/docs/application.md
@@ -179,3 +179,15 @@
      http.createServer(app).listen(80);
      http.createServer({ ... }, app).listen(443);
 
+# app.with()
+  Appends a prefix to the urls defined inside of it's callback.
+
+  Example
+
+     app.get('/', home);
+     
+     app.with('/admin', function () {
+
+       app.get('/', adminHome); //(ie: localhost:3000/admin)
+
+     });

--- a/lib/application.js
+++ b/lib/application.js
@@ -426,9 +426,15 @@ methods.forEach(function(method){
  */
 app.prefix = null;
 app.with = function (prefix, cb) {
-  app.prefix = prefix;
+  app.prefix = (app.prefix) 
+    ? app.prefix + prefix 
+    : prefix;
+
   cb();
-  app.prefix = null;
+  //re-establish the prefix to the previous one.
+  app.prefix = (app.prefix) 
+    ? app.prefix.replace(prefix, '')
+    : null;
 }
 
 /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -404,15 +404,32 @@ app.configure = function(env, fn){
 /**
  * Delegate `.VERB(...)` calls to `.route(VERB, ...)`.
  */
-
 methods.forEach(function(method){
   app[method] = function(path){
+    path =  ( app.prefix ) 
+            ? app.prefix + ((path === '/') ? '' : path)
+            : path;
     if ('get' == method && 1 == arguments.length) return this.set(path); 
     var args = [method].concat([].slice.call(arguments));
     if (!this._usedRouter) this.use(this.router);
     return this._router.route.apply(this._router, args);
   }
 });
+
+/**
+ * Method for adding a prefix to the urls int the routes defined 
+ * throught the call of the cb.
+ *
+ * @param {String} prefix
+ * @param {Function} cb
+ * @api public
+ */
+app.prefix = null;
+app.with = function (prefix, cb) {
+  app.prefix = prefix;
+  cb();
+  app.prefix = null;
+}
 
 /**
  * Special-cased "all" method, applying the given route `path`,

--- a/lib/application.js
+++ b/lib/application.js
@@ -433,7 +433,7 @@ app.with = function (prefix, cb) {
   cb();
   //re-establish the prefix to the previous one.
   app.prefix = (app.prefix) 
-    ? app.prefix.replace(prefix, '')
+    ? app.prefix.substr(0, app.prefix.lastIndexOf(prefix))
     : null;
 }
 

--- a/test/app.with.js
+++ b/test/app.with.js
@@ -6,7 +6,7 @@ describe('app.with()', function(){
   it('should append a prefix to the url', function(done){
     var app = express();
 
-    app.with('myPrefix', function () {
+    app.with('/myPrefix', function () {
       app.del('/tobi', function(req, res){
         res.end('deleted tobi!');
       });
@@ -15,5 +15,72 @@ describe('app.with()', function(){
     request(app)
     .delete('/myPrefix/tobi')
     .expect('deleted tobi!', done);
-  })
-})
+  });
+
+  it('should work with / in the inner route', function(done){
+    var app = express();
+
+    app.with('/myPrefix', function () {
+      app.del('/', function(req, res){
+        res.end('deleted tobi!');
+      });
+    });
+
+    request(app)
+    .delete('/myPrefix')
+    .expect('deleted tobi!', done);
+  });
+
+  it('should re-establish the prefix after the with is called', function(done){
+    var app = express();
+
+    app.with('/myPrefix', function () {
+      app.del('/', function(req, res){
+        res.end('deleted tobi!');
+      });
+    });
+
+    app.get('/newone', function (req, res) {
+      res.send('yay!')
+    });
+
+    request(app)
+    .get('/newone')
+    .expect('yay!', done);
+  });
+
+  it('should be able to nest prefixes', function(done){
+    var app = express();
+
+    app.with('/myPrefix', function () {
+      app.with('/nested', function () {
+        app.del('/tobi', function(req, res){
+          res.end('deleted tobi!');
+        });  
+      });
+    });
+
+    request(app)
+    .delete('/myPrefix/nested/tobi')
+    .expect('deleted tobi!', done);
+  });
+
+  it('should re-establish nested prefixes', function (done){
+    var app = express();
+
+    app.with('/myPrefix', function () {
+      app.with('/nested', function () {
+        app.del('/tobi', function(req, res){
+          res.end('deleted tobi!');
+        });
+      });
+      app.get('/newone', function (req, res){
+          res.end('yay!');
+      });
+    });
+
+    request(app)
+    .get('/myPrefix/newone')
+    .expect('yay!', done);
+  });
+});

--- a/test/app.with.js
+++ b/test/app.with.js
@@ -83,4 +83,24 @@ describe('app.with()', function(){
     .get('/myPrefix/newone')
     .expect('yay!', done);
   });
+
+  it('should re-establish to the right prefix', function (done){
+    var app = express();
+
+    app.with('/myPrefix', function () {
+      app.with('/my', function () {
+        app.del('/tobi', function(req, res){
+          res.end('deleted tobi!');
+        });
+      });
+      app.get('/newone', function (req, res){
+          res.end('yay!');
+      });
+    });
+
+    request(app)
+    .get('/myPrefix/newone')
+    .expect('yay!', done);
+  });
+
 });

--- a/test/app.with.js
+++ b/test/app.with.js
@@ -1,0 +1,19 @@
+
+var express = require('../')
+  , request = require('./support/http');
+
+describe('app.with()', function(){
+  it('should append a prefix to the url', function(done){
+    var app = express();
+
+    app.with('myPrefix', function () {
+      app.del('/tobi', function(req, res){
+        res.end('deleted tobi!');
+      });
+    });
+
+    request(app)
+    .delete('/myPrefix/tobi')
+    .expect('deleted tobi!', done);
+  })
+})


### PR DESCRIPTION
I think it would be useful in some cases to be able to define routes with a given prefix, so for example I would like to be able to do something like this:

```
 app.get('/', home);

 app.with('/admin', function () {

   app.get('/', adminHome); //(ie: localhost:3000/admin)

 });
```
