### PR TITLE
Redirect Safe to protect from unsafe url

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -574,6 +573,16 @@ res.redirect = function(url){
   this.set('Content-Length', Buffer.byteLength(body));
   this.end(head ? null : body);
 };
+
+res.redirectSafe = function(url) {
+    var _url = (arguments.length == 2)?arguments[1]:url;
+
+    if(~_url.indexOf('://')) {
+        this.redirect('/');
+    } else {
+        this.redirect.apply(this, arguments);
+    }
+}
 
 /**
  * Render `view` with the given `options` and optional callback `fn`.


### PR DESCRIPTION
`res.redirectSafe(url)` ensures that the redirection is for `/` paths only. If it is not, then a redirect to `/` is made. 
- Implemented as a **very basic** convenience method to handle open redirection attacks. 
