### PR TITLE
Refactoring: no need for add 'del' and 'all' to methods

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1,11 +1,10 @@
-
 /**
  * Module dependencies.
  */
 
 var connect = require('connect')
   , Router = require('./router')
-  , methods = Router.methods.concat('del', 'all')
+  , methods = Router.methods
   , middleware = require('./middleware')
   , debug = require('debug')('express:application')
   , locals = require('./utils').locals
@@ -427,7 +426,6 @@ methods.forEach(function(method){
 app.all = function(path){
   var args = arguments;
   methods.forEach(function(method){
-    if ('all' == method || 'del' == method) return;
     app[method].apply(this, args);
   }, this);
   return this;


### PR DESCRIPTION
There is no reason to add `del` and `all` into local variable `methods`.
