### PR TITLE
* after :param is no more greedy

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -264,7 +264,7 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
   path = path
     .concat(strict ? '' : '/?')
     .replace(/\/\(/g, '(?:/')
-    .replace(/(\/)?(\.)?:(\w+)(?:(\(.*?\)))?(\?)?/g, function(_, slash, format, key, capture, optional){
+    .replace(/(\/)?(\.)?:(\w+)(?:(\(.*?\)))?(\?)?(\*)?/g, function(_, slash, format, key, capture, optional, star){
       keys.push({ name: key, optional: !! optional });
       slash = slash || '';
       return ''
@@ -272,7 +272,8 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
         + '(?:'
         + (optional ? slash : '')
         + (format || '') + (capture || (format && '([^/.]+?)' || '([^/]+?)')) + ')'
-        + (optional || '');
+        + (optional || '')
+        + (star ? '(/*)' : '');
     })
     .replace(/([\/.])/g, '\\$1')
     .replace(/\*/g, '(.*)');


### PR DESCRIPTION
for example GET /user/:id*, \* become not greedy, currently if you pass GET /user/123 it'll consume "23", and with this commit it'll only consume the optional trailing "/" and beyond
