### PR TITLE
Circular Express reference in createServer()

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -42,6 +41,7 @@ function createApplication() {
   utils.merge(app, proto);
   app.request = { __proto__: req };
   app.response = { __proto__: res };
+  app.express = exports;
   app.init();
   return app;
 }


### PR DESCRIPTION
If an Express server is created and returned from another project we loose the reference to Express itself. This way we can carry it around.

Example

``` javascript
var myProject = require('myProject')
  , app = myProject.server();  // returned Express app

app.configure(function(){
  app.use(app.express.bodyParser());
  /* ... */
});

app.listen(3000);
```

We can do `app.express`
