### PR TITLE
Allow more granular control over JSONP

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -236,7 +236,7 @@ var app = [
   , 'app.get(\'/users\', user.list);'
   , ''
   , 'http.createServer(app).listen(app.get(\'port\'), function(){'
-  , '  console.log("Express server listening on port " + app.get(\'port\'));'
+  , '  console.log(\'Express server listening on port \' + app.get(\'port\'));'
   , '});'
   , ''
 ].join(eol);

--- a/lib/response.js
+++ b/lib/response.js
@@ -96,31 +96,42 @@ res.send = require('response-send');
  */
 
 res.json = function(obj){
-  // allow status / body
-  if (2 == arguments.length) {
+  var options = {};
+  // allow status / body / options
+  if (arguments.length > 1) {
+    // res.json(body)
+    // res.json(status, body)
     // res.json(body, status) backwards compat
+    // res.json(body, options)
+    // res.json(status, body, options)
+
     if ('number' == typeof arguments[1]) {
       this.statusCode = arguments[1];
     } else {
-      this.statusCode = obj;
-      obj = arguments[1];
+      if ('number' == typeof obj) {
+        this.statusCode = obj;
+        obj = arguments[1];
+        if (arguments[2]) options = arguments[2];
+      } else {
+        if (arguments[1]) options = arguments[1];
+      }
     }
   }
 
   // settings
   var app = this.app
     , jsonp = app.get('jsonp callback')
-    , replacer = app.get('json replacer')
-    , spaces = app.get('json spaces')
+    , replacer = options.jsonReplacer || app.get('json replacer')
+    , spaces = options.jsonSpaces || app.get('json spaces')
     , body = JSON.stringify(obj, replacer, spaces)
-    , callback = this.req.query[app.get('jsonp callback name')];
+    , callback = this.req.query[options.jsonpCallbackName || app.get('jsonp callback name')];
 
   // content-type
   this.charset = this.charset || 'utf-8';
   this.set('Content-Type', 'application/json');
   
   // jsonp
-  if (callback && jsonp) {
+  if (callback && ((jsonp && options.jsonp !== false) || options.jsonp === true)) {
     this.set('Content-Type', 'text/javascript');
     body = callback.replace(/[^[]\w$.]/g, '') + '(' + body + ');';
   }


### PR DESCRIPTION
Proposed changes for #1240.  This adds an options argument to `Response.json()`:

```
res.json([status,] object[, options]);
```

Options are:

```
{
    jsonp: Boolean, // enable or disable JSONP output for this response
    jsonpCallbackName: String, // query string parameter to use for callback name
    jsonReplacer: Function || Array, // the replacer to send to JSON.stringify
    jsonSpaces: Boolean // tell JSON.stringify to pretty print
}
```

Each of these options overrides the corresponding global option.  If any option is omitted, we fall back to the global setting.
