### PR TITLE
EventEmitter memory leak with successful sendfile

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -190,7 +190,7 @@ res.sendfile = function(path, options, fn){
     done = true;
 
     // clean up
-    req.socket.removeListener('error', error);
+    cleanup();
     if (!self.headerSent) self.removeHeader('Content-Disposition');
 
     // callback available
@@ -206,8 +206,13 @@ res.sendfile = function(path, options, fn){
   // streaming
   function stream() {
     if (done) return;
-    req.socket.removeListener('error', error);
+    cleanup();
     if (fn) self.on('finish', fn);
+  }
+
+  // cleanup
+  function cleanup() {
+    req.socket.removeListener('error', error);
   }
 
   // transfer
@@ -218,6 +223,7 @@ res.sendfile = function(path, options, fn){
   file.on('directory', next);
   file.on('stream', stream);
   file.pipe(this);
+  this.on('finish', cleanup);
 };
 
 /**


### PR DESCRIPTION
If sendfile is successful, the socket error listener doesn't get removed.
This leads to an EventEmitter memory leak (source: [StackOverflow](http://stackoverflow.com/questions/11605634/nodejs-express-set-server-possible-eventemitter-memory-leak-detected/11628001#11628001)):

```
 (node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace: 
    at Socket.<anonymous> (events.js:139:15)
    at ServerResponse.sendfile (/data/www/margintop/server/node_modules/express/lib/response.js:185:14)
    at /data/www/margintop/server/webserver/webserver.js:17:9
    at callbacks (/data/www/margintop/server/node_modules/express/lib/router/index.js:165:11)
    at param (/data/www/margintop/server/node_modules/express/lib/router/index.js:139:11)
    at pass (/data/www/margintop/server/node_modules/express/lib/router/index.js:146:5)
    at Router._dispatch (/data/www/margintop/server/node_modules/express/lib/router/index.js:173:4)
    at Object.router [as handle] (/data/www/margintop/server/node_modules/express/lib/router/index.js:33:10)
    at next (/data/www/margintop/server/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at multipart (/data/www/margintop/server/node_modules/express/node_modules/connect/lib/middleware/multipart.js:52:61)
```
