### PR TITLE
Bugfix in Route.match

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -48,6 +48,7 @@ function Route(method, path, callbacks, options) {
  */
 
 Route.prototype.match = function(path){
+  this.regexp.lastIndex = 0;
   var keys = this.keys
     , params = this.params = []
     , m = this.regexp.exec(path);


### PR DESCRIPTION
After every call to RegExp.exec you must reset the match index
otherwise on subsequent call it won't match.
You can test it with curl -I address
it keeps returning 200, 404, 200, 404...
