### PR TITLE
Fix signed cookie prefix

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -538,7 +538,7 @@ res.cookie = function(name, val, options){
   var signed = options.signed;
   if (signed && !secret) throw new Error('connect.cookieParser("secret") required for signed cookies');
   if ('object' == typeof val) val = 'j:' + JSON.stringify(val);
-  if (signed) val = utils.sign(val, secret);
+  if (signed) val = 's:' + utils.sign(val, secret);
   if ('maxAge' in options) options.expires = new Date(Date.now() + options.maxAge);
   if (null == options.path) options.path = '/';
   this.set('Set-Cookie', cookie.serialize(name, String(val), options));

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -1,0 +1,52 @@
+
+var express = require('../')
+  , request = require('./support/http');
+
+describe('req', function(){
+  describe('.signedCookies', function(){
+    it('should return a signed JSON cookie', function(done){
+      var app = express()
+        , cookieHeader
+        , val;
+
+      app.use(express.cookieParser('secret'));
+
+      app.use(function(req, res){
+        res.send(req.signedCookies);
+      });
+
+      app.response.req = { secret: 'secret' };
+      app.response.cookie('obj', { foo: 'bar' }, { signed: true });
+      cookieHeader = app.response.get('set-cookie');
+
+      val = JSON.stringify({ obj: { foo: 'bar' } });
+      request(app)
+      .get('/')
+      .set('Cookie', cookieHeader)
+      .expect(val, done);
+    })
+
+    it('should return a signed cookie', function(done){
+      var app = express()
+        , cookieHeader
+        , val;
+
+      app.use(express.cookieParser('secret'));
+
+      app.use(function(req, res){
+        res.send(req.signedCookies);
+      });
+
+      app.response.req = { secret: 'secret' };
+      app.response.cookie('foo', 'bar', { signed: true });
+      cookieHeader = app.response.get('set-cookie');
+
+      val = JSON.stringify({ foo: 'bar' });
+      request(app)
+      .get('/')
+      .set('Cookie', cookieHeader)
+      .expect(val, done);
+    })
+  })
+})
+

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -109,7 +109,7 @@ describe('res', function(){
         .end(function(err, res){
           var val = res.headers['set-cookie'][0];
           val = cookie.parse(val.split('.')[0]);
-          val.user.should.equal('j:{"name":"tobi"}');
+          val.user.should.equal('s:j:{"name":"tobi"}');
           done();
         })
       })
@@ -128,7 +128,7 @@ describe('res', function(){
         request(app)
         .get('/')
         .end(function(err, res){
-          var val = ['name=tobi.xJjV2iZ6EI7C8E5kzwbfA9PVLl1ZR07UTnuTgQQ4EnQ; Path=/'];
+          var val = ['name=s%3Atobi.xJjV2iZ6EI7C8E5kzwbfA9PVLl1ZR07UTnuTgQQ4EnQ; Path=/'];
           res.headers['set-cookie'].should.eql(val);
           done();
         })


### PR DESCRIPTION
Updated res.cookie to prefix signed cookies with 's:' so that req.signedCookies would populate properly.
