### PR TITLE
FIX cjk-filename-issue in res.attachment

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -365,7 +365,7 @@ res.download = function(path, filename, fn){
   }
 
   filename = filename || path;
-  this.set('Content-Disposition', 'attachment; filename="' + basename(filename) + '"');
+  this.attachment(filename);
   return this.sendfile(path, fn);
 };
 
@@ -487,9 +487,18 @@ res.format = function(obj){
 
 res.attachment = function(filename){
   if (filename) this.type(extname(filename));
-  this.set('Content-Disposition', filename
-    ? 'attachment; filename="' + basename(filename) + '"'
-    : 'attachment');
+
+  // FIX CJK filename issue.
+  var ua = this.req.headers['user-agent'];
+  if (/firefox/i.test(ua)) {
+    this.set('Content-Disposition', filename
+      ? 'attachment; filename*="' + encodeURI(basename(filename)) + '"'
+      : 'attachment');
+  } else {
+    this.set('Content-Disposition', filename
+      ? 'attachment; filename="' + encodeURI(basename(filename)) + '"'
+      : 'attachment');
+  }
   return this;
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -486,13 +486,17 @@ res.format = function(obj){
  */
 
 res.attachment = function(filename){
-  if (filename) this.type(extname(filename));
+  if (filename) {
+    this.type(extname(filename));
+  }
 
   // FIX CJK filename issue.
+  // @see http://php.net/manual/en/rar.examples.php
+  // @see http://greenbytes.de/tech/tc2231/#attwithfnrawpctenclong
   var ua = this.req.headers['user-agent'];
-  if (/firefox/i.test(ua)) {
+  if (/(firefox|opera)/i.test(ua)) {
     this.set('Content-Disposition', filename
-      ? 'attachment; filename*="' + encodeURI(basename(filename)) + '"'
+      ? 'attachment; filename*=UTF-8\'\'' + encodeURI(basename(filename))
       : 'attachment');
   } else {
     this.set('Content-Disposition', filename


### PR DESCRIPTION
the `res.attachment` function didn't set the correct response header, and this is only an minor fix.
