### PR TITLE
Improved app.set to handle object parameter

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -253,10 +253,15 @@ app.param = function(name, fn){
 
 app.set = function(setting, val){
   if (1 == arguments.length) {
-    if (this.settings.hasOwnProperty(setting)) {
-      return this.settings[setting];
-    } else if (this.parent) {
-      return this.parent.set(setting);
+    if ('string' == typeof setting) {
+      if (this.settings.hasOwnProperty(setting)) {
+        return this.settings[setting];
+      } else if (this.parent) {
+        return this.parent.set(setting);
+      }
+    } else {
+      utils.merge(this.settings, setting);
+      return this;
     }
   } else {
     this.settings[setting] = val;

--- a/lib/application.js
+++ b/lib/application.js
@@ -259,7 +259,7 @@ app.set = function(setting, val){
       } else if (this.parent) {
         return this.parent.set(setting);
       }
-    } else {
+    } else if ('object' == typeof setting) {
       utils.merge(this.settings, setting);
       return this;
     }


### PR DESCRIPTION
Many `app.set`s look a bit ugly.
It can be cleaner if app.set handles object parameter.

For example,

``` javascript
app.set("db_one", "123.123.123.121");
app.set("db_two", "123.123.123.122");
app.set("db_three", "123.123.123.123");
app.set("db_four", "123.123.123.124");
```

above can be rewritten as below

``` javascript
app.set({
  db_one: "123.123.123.121",
  db_two: "123.123.123.122",
  db_three: "123.123.123.123",
  db_four: "123.123.123.124",
  ...
});
```

In addition, this also enables below use case.

``` javascript
// conf.js
module.exports = {
  db_one: "123.123.123.121",
  db_two: "123.123.123.122",
  db_three: "123.123.123.123",
  db_four: "123.123.123.124",
};
```

``` javascript
// during app configuration
app.set(require('./conf'));
```
