### PR TITLE
set the NODE_ENV to development for the development view cache test

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -57,8 +57,10 @@ describe('app.path()', function(){
 
 describe('in development', function(){
   it('should disable "view cache"', function(){
+    process.env.NODE_ENV = 'development';
     var app = express();
     app.enabled('view cache').should.be.false;
+    process.env.NODE_ENV = 'test';
   })
 })
 


### PR DESCRIPTION
The development view cache test was using 'test' as the NODE_ENV so I changed it to 'development'
