### PR TITLE
make application routing callback behave the same as middleware

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -158,7 +158,7 @@ Router.prototype._dispatch = function(req, res, next){
         } else if (err && fn) {
           if (fn.length < 4) return callbacks(err);
           fn(err, req, res, callbacks);
-        } else if (fn) {
+        } else if (fn && fn.length < 4) {
           fn(req, res, callbacks);
         } else {
           nextRoute(err);

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -158,8 +158,9 @@ Router.prototype._dispatch = function(req, res, next){
         } else if (err && fn) {
           if (fn.length < 4) return callbacks(err);
           fn(err, req, res, callbacks);
-        } else if (fn && fn.length < 4) {
-          fn(req, res, callbacks);
+        } else if (fn) {
+          if (fn.length < 4) return fn(req, res, callbacks);
+          callbacks();
         } else {
           nextRoute(err);
         }

--- a/test/app.routingCallback.js
+++ b/test/app.routingCallback.js
@@ -1,0 +1,37 @@
+var express = require('../')
+  , request = require('./support/http');
+
+describe('app', function(){
+  describe('.get', function(){
+    it('should only call an error handling routing callback when an error is propagated', function(done){
+      var app = express();
+
+      app.get('/', function(req, res, next){
+        req.thruSecondCallback = false;
+        req.thruThirdCallback = false;
+        req.thruFourthCallback = false;
+        next(new Error('fabricated error'));
+      }, function(req, res, next) {
+        req.thruSecondCallback = true;
+        next();
+      }, function(err, req, res, next){
+        err.message.should.equal('fabricated error');
+        req.thruThirdCallback = true;
+        next();
+      }, function(err, req, res, next){
+        req.thruFourthCallback = true;
+        next();
+      }, function(req, res){
+        req.thruSecondCallback.should.equal(false);
+        req.thruThirdCallback.should.equal(true);
+        req.thruFourthCallback.should.equal(false);
+        res.status(204);
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(204, done);
+    })
+  })
+})


### PR DESCRIPTION
Hi, there. I have a question about implementing an application routing callback with the first parameter being err.

The API Reference says under the section of app.VERB(path, [callback...], callback)：

|  Multiple callbacks may be give, all are treated equally, and behave just like middleware, 
|  with the one exception that these callbacks may invoke next('route') to bypass the remaining route callback(s). 

But when it comes to error handling, application routing callback behaves a little differently than middleware.

In the case of middleware, if it's declared with the first parameter being err, it won't be called (will be skipped) if there's no error generated above this middleware. I can see that from the source code of connect (lib/proto.js):

      var arity = layer.handle.length;
      if (err) {
        if (arity === 4) {
          layer.handle(err, req, res, next);
        } else {
          next(err);
        }
      } else if (arity < 4) {
        layer.handle(req, res, next);
      } else {
        next();
      }

But in the case of application routing callback, the source code of express (lib/router/index.js) says:

    function callbacks(err) {
      var fn = route.callbacks[i++];
      try {
        if ('route' == err) {
          nextRoute();
        } else if (err && fn) {
          if (fn.length < 4) return callbacks(err);
          fn(err, req, res, callbacks);
        } else if (fn) {
          fn(req, res, callbacks);
        } else {
          nextRoute(err);
        }
      } catch (err) {
        callbacks(err);
      }
    }

if callbacks() is called without an err, the code path goes to this branch:

        else if (fn) {
          fn(req, res, callbacks);
        } 

Whether fn is implemented with the first parameter being err or not, it always gets called with (req, res, callbacks).

Suppose we implement fn with an err parameter, i.e. function (err, req, res, next) { ... }  , then we should be careful, if there are less than 4 arguments passed we have to shift the arguments one position to the right. This is really a burden for application developers.

Couldn't it be better if we make application routing callback behave the same as middleware? We can change the code to:

        else if (fn && fn.length < 4) {
          fn(req, res, callbacks);
        }

That's what this commit is about.
