### PR TITLE
callback&&callback({data:'here'}) JSONP format support

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -234,7 +234,11 @@ res.jsonp = function(obj){
   // jsonp
   if (callback) {
     this.set('Content-Type', 'text/javascript');
-    body = callback.replace(/[^\[\]\w$.]/g, '') + '(' + body + ');';
+    var callback_name = callback.replace(/[^\[\]\w$.]/g, '');
+    if (app.enabled('jsonp callback long')) {
+      callback_name += '&&' + callback_name;
+    }
+    body = callback_name + '(' + body + ');';
   }
 
   return this.send(body);

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -21,6 +21,23 @@ describe('res', function(){
       })
     })
 
+    it('should respond with jsonp with long callback', function(done){
+      var app = express();
+      app.enable('jsonp callback long');
+
+      app.use(function(req, res){
+        res.jsonp({ count: 1 });
+      });
+
+      request(app)
+      .get('/?callback=something')
+      .end(function(err, res){
+        res.headers.should.have.property('content-type', 'text/javascript; charset=utf-8');
+        res.text.should.equal('something&&something({"count":1});');
+        done();
+      })
+    })
+
     it('should allow renaming callback', function(done){
       var app = express();
 


### PR DESCRIPTION
Currently JSONP only supports callback({data:'here'}) format.

This pull request adds callback&&callback({data:'here'}) format support.

Activate this format using
app.enable('jsonp callback long');
