### PR TITLE
Add a 'jsonp force 200' setting to force an HTTP 200 JSONP response

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -80,6 +80,7 @@ app.defaultConfiguration = function(){
   // default configuration
   this.set('views', process.cwd() + '/views');
   this.set('jsonp callback name', 'callback');
+  this.disable('jsonp force 200');
 
   this.configure('development', function(){
     this.set('json spaces', 2);

--- a/lib/response.js
+++ b/lib/response.js
@@ -231,6 +231,7 @@ res.jsonp = function(obj){
   
   // jsonp
   if (callback) {
+    if (app.get('jsonp force 200')) this.statusCode = 200;
     this.set('Content-Type', 'text/javascript');
     var cb = callback.replace(/[^\[\]\w$.]/g, '');
     body = cb + ' && ' + cb + '(' + body + ');';

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -178,8 +178,57 @@ describe('res', function(){
         });
       })
     })
+
+    describe('"jsonp force 200" setting', function(){
+      it('should default to false', function(){
+        var app = express();
+        app.get('jsonp force 200').should.be.false;
+      })
+
+      describe('when set to true', function(){
+        it('should set the .statusCode to 200 with callback', function(done){
+          var app = express();
+
+          app.enable('jsonp force 200');
+
+          app.use(function(req, res){
+            res.statusCode = 500;
+            res.jsonp({ error: 'message' });
+          });
+
+          request(app)
+          .get('/?callback=something')
+          .end(function(err, res){
+            app.get('jsonp force 200').should.be.true;
+            res.statusCode.should.equal(200);
+            res.text.should.equal('something && something({"error":"message"});');
+            done();
+          });
+        })
+
+        it('should not change the .statusCode without a callback', function(done){
+          var app = express();
+
+          app.enable('jsonp force 200');
+
+          app.use(function(req, res){
+            res.statusCode = 500;
+            res.jsonp({ error: 'message' });
+          });
+
+          request(app)
+          .get('/')
+          .end(function(err, res){
+            app.get('jsonp force 200').should.be.true;
+            res.statusCode.should.equal(500);
+            res.text.should.equal('{"error":"message"}');
+            done();
+          })
+        })
+      })
+    })
   })
-  
+
   describe('.json(status, object)', function(){
     it('should respond with json and set the .statusCode', function(done){
       var app = express();


### PR DESCRIPTION
```
app.enable('jsonp force 200');
app.use(function(req, res){
  res.statusCode = 500;
  res.jsonp({ error: 'message' });
});
```

and

```
curl -is http://localhost:3000/?callback=something

HTTP/1.1 200 OK

something && something({
  "error": "message"
});
```

This is useful because browsers are unable to respond to non-200 JSONP responses. A good way to inform browsers of the actual HTTP status code is to include it in the JSON response, e.g.

```
cb && cb({"code":400,"message":"Invalid params"})`.
```
