### PR TITLE
app.set('explicit routing')

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -404,7 +404,7 @@ methods.forEach(function(method){
   app[method] = function(path){
     if ('get' == method && 1 == arguments.length) return this.set(path);
     var args = [method].concat([].slice.call(arguments));
-    if (!this._usedRouter) this.use(this.router);
+    if (!this._usedRouter && !this.settings['explicit routing']) this.use(this.router);
     this._router.route.apply(this._router, args);
     return this;
   };

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -48,7 +48,7 @@ describe('app.router', function(){
       calls.push('before');
       next();
     });
-    
+
     app.use(app.router);
 
     app.use(function(req, res, next){
@@ -68,7 +68,7 @@ describe('app.router', function(){
       done();
     })
   })
-  
+
   it('should be auto .use()d on the first app.VERB() call', function(done){
     var app = express();
 
@@ -78,7 +78,7 @@ describe('app.router', function(){
       calls.push('before');
       next();
     });
-    
+
     app.get('/', function(req, res, next){
       calls.push('GET /')
       next();
@@ -97,6 +97,75 @@ describe('app.router', function(){
     })
   })
 
+  it('should not be auto .use()d on the first app.VERB() call with explicit routing', function(done) {
+    var app = express();
+
+    app.set('explicit routing', true);
+
+    var calls = [];
+
+    app.use(function(req, res, next) {
+      calls.push('middleware 1');
+      next();
+    });
+
+    app.get('/', function(req, res, next) {
+      calls.push('route');
+      res.end();
+      next();
+    });
+
+    app.use(function(req, res, next) {
+      calls.push('middleware 2');
+      res.end();
+      next();
+    });
+
+    request(app)
+    .get('/')
+    .end(function(res) {
+      calls.should.eql(['middleware 1', 'middleware 2']);
+      done();
+    });
+  });
+
+  it('should be inserted at a specific point with explicit routing', function(done) {
+    var app = express();
+
+    app.set('explicit routing', true);
+
+    var calls = [];
+
+    app.use(function(req, res, next) {
+      calls.push('middleware 1');
+      next();
+    });
+
+    app.get('/', function(req, res, next) {
+      calls.push('route');
+      next();
+    });
+
+    app.use(function(req, res, next) {
+      calls.push('middleware 2');
+      next();
+    });
+
+    app.use(app.router);
+
+    app.use(function(req, res, next) {
+      calls.push('middleware 3');
+      res.end();
+    });
+
+    request(app)
+    .get('/')
+    .end(function(res) {
+      calls.should.eql(['middleware 1', 'middleware 2', 'route', 'middleware 3']);
+      done();
+    });
+  });
+
   describe('when given a regexp', function(){
     it('should match the pathname only', function(done){
       var app = express();
@@ -109,7 +178,7 @@ describe('app.router', function(){
       .get('/user/12?foo=bar')
       .expect('user', done);
     })
-    
+
     it('should populate req.params with the captures', function(done){
       var app = express();
 
@@ -124,15 +193,15 @@ describe('app.router', function(){
       .expect('editing user 10', done);
     })
   })
-  
+
   describe('when given an array', function(){
     it('should match all paths in the array', function(done){
       var app = express();
-      
+
       app.get(['/one', '/two'], function(req, res){
         res.end('works');
       });
-      
+
       request(app)
       .get('/one')
       .expect('works', function() {
@@ -155,7 +224,7 @@ describe('app.router', function(){
       .get('/USER')
       .expect('tj', done);
     })
-    
+
     describe('when "case sensitive routing" is enabled', function(){
       it('should match identical casing', function(done){
         var app = express();
@@ -170,7 +239,7 @@ describe('app.router', function(){
         .get('/uSer')
         .expect('tj', done);
       })
-      
+
       it('should not match otherwise', function(done){
         var app = express();
 
@@ -199,7 +268,7 @@ describe('app.router', function(){
       .get('/user/')
       .expect('tj', done);
     })
-    
+
     describe('when "strict routing" is enabled', function(){
       it('should match trailing slashes', function(done){
         var app = express();
@@ -214,7 +283,7 @@ describe('app.router', function(){
         .get('/user/')
         .expect('tj', done);
       })
-      
+
       it('should match no slashes', function(done){
         var app = express();
 
@@ -228,7 +297,7 @@ describe('app.router', function(){
         .get('/user')
         .expect('tj', done);
       })
-      
+
       it('should fail when omitting the trailing slash', function(done){
         var app = express();
 
@@ -242,7 +311,7 @@ describe('app.router', function(){
         .get('/user')
         .expect(404, done);
       })
-      
+
       it('should fail when adding the trailing slash', function(done){
         var app = express();
 
@@ -275,7 +344,7 @@ describe('app.router', function(){
       .expect(404, done);
     });
   })
-  
+
   it('should allow literal "."', function(done){
     var app = express();
 
@@ -303,7 +372,7 @@ describe('app.router', function(){
       .get('/user/tj.json')
       .expect('tj', done);
     })
-    
+
     it('should work with several', function(done){
       var app = express();
 
@@ -346,7 +415,7 @@ describe('app.router', function(){
       .get('/api/users/0.json')
       .expect('users/0.json', done);
     })
-    
+
     it('should not be greedy immediately after param', function(done){
       var app = express();
 
@@ -370,7 +439,7 @@ describe('app.router', function(){
       .get('/user/122/aaa')
       .expect('122', done);
     })
-    
+
     it('should span multiple segments', function(done){
       var app = express();
 
@@ -382,7 +451,7 @@ describe('app.router', function(){
       .get('/file/javascripts/jquery.js')
       .expect('javascripts/jquery.js', done);
     })
-    
+
     it('should be optional', function(done){
       var app = express();
 
@@ -394,7 +463,7 @@ describe('app.router', function(){
       .get('/file/')
       .expect('', done);
     })
-    
+
     it('should require a preceeding /', function(done){
       var app = express();
 
@@ -420,7 +489,7 @@ describe('app.router', function(){
       .get('/user/tj')
       .expect('tj', done);
     })
-    
+
     it('should match a single segment only', function(done){
       var app = express();
 
@@ -432,7 +501,7 @@ describe('app.router', function(){
       .get('/user/tj/edit')
       .expect(404, done);
     })
-    
+
     it('should allow several capture groups', function(done){
       var app = express();
 
@@ -459,7 +528,7 @@ describe('app.router', function(){
       .get('/user/tj')
       .expect('viewing tj', done);
     })
-    
+
     it('should populate the capture group', function(done){
       var app = express();
 
@@ -473,7 +542,7 @@ describe('app.router', function(){
       .expect('editing tj', done);
     })
   })
-  
+
   describe('.:name', function(){
     it('should denote a format', function(done){
       var app = express();
@@ -491,7 +560,7 @@ describe('app.router', function(){
       });
     })
   })
-  
+
   describe('.:name?', function(){
     it('should denote an optional format', function(done){
       var app = express();
@@ -509,7 +578,7 @@ describe('app.router', function(){
       });
     })
   })
-  
+
   describe('when next() is called', function(){
     it('should continue lookup', function(done){
       var app = express()
@@ -528,7 +597,7 @@ describe('app.router', function(){
         calls.push('/foo');
         next();
       });
-      
+
       app.get('/foo', function(req, res, next){
         calls.push('/foo 2');
         res.end('done');
@@ -542,7 +611,7 @@ describe('app.router', function(){
       })
     })
   })
-  
+
   describe('when next(err) is called', function(){
     it('should break out of app.router', function(done){
       var app = express()
@@ -561,7 +630,7 @@ describe('app.router', function(){
         calls.push('/foo');
         next(new Error('fail'));
       });
-      
+
       app.get('/foo', function(req, res, next){
         assert(0);
       });


### PR DESCRIPTION
Patch for #1404

Includes tests & implementation.

Leaves implicit .use() behavior alone for existing projects; won't break anything.

``` js
app.set('explicit routing', true);
app.get('/', log('route'));
app.use(log('middleware'));
app.use(app.router);

//   GET /   -->  'middleware', 'route'
```
