### PR TITLE
Escape URLs in text/plain res.redirect response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -655,7 +655,7 @@ res.redirect = function(url){
   // Support text/{plain,html} by default
   this.format({
     text: function(){
-      body = statusCodes[status] + '. Redirecting to ' + url;
+      body = statusCodes[status] + '. Redirecting to ' + encodeURI(url);
     },
 
     html: function(){

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -287,6 +287,23 @@ describe('res', function(){
         done();
       })
     })
+
+    it('should encode the url', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect('http://example.com/?param=<script>alert("hax");</script>');
+      });
+
+      request(app)
+      .get('/')
+      .set('Host', 'http://example.com')
+      .set('Accept', 'text/plain, */*')
+      .end(function(err, res){
+        res.text.should.equal('Moved Temporarily. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E');
+        done();
+      })
+    })
   })
 
   describe('when accepting neither text or html', function(){


### PR DESCRIPTION
Escape the URL printed by res.redirect using URL encoding. This
prevents some browsers (primarily old versions of IE) from attempting
to sniff the Content-Type and evaluate it as HTML, which causes a
cross-site scripting vulnerability.
