### PR TITLE
change crc generator because of license issue

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@
  */
 
 var mime = require('connect').mime
-  , crc = require('crc');
+  , crc32 = require('buffer-crc32');
 
 /**
  * Return ETag for `body`.
@@ -15,9 +15,7 @@ var mime = require('connect').mime
  */
 
 exports.etag = function(body){
-  return '"' + (Buffer.isBuffer(body)
-    ? crc.buffer.crc32(body)
-    : crc.crc32(body)) + '"';
+  return '"' + crc32.signed(body) + '"';
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "range-parser": "0.0.4",
     "mkdirp": "0.3.3",
     "cookie": "0.0.4",
-    "crc": "0.2.0",
+    "buffer-crc32": "0.1.1",
     "fresh": "0.1.0",
     "methods": "0.0.1",
     "send": "0.1.0",

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,26 @@
 var utils = require('../lib/utils')
   , assert = require('assert');
 
+describe('utils.etag(body)', function(){
+
+  var str = 'Hello CRC';
+  var strUTF8 = '<!DOCTYPE html>\n<html>\n<head>\n</head>\n<body><p>自動販売</p></body></html>';
+  
+  it('should support strings', function(){
+    utils.etag(str).should.eql('"-2034458343"');
+  })
+
+  it('should support utf8 strings', function(){
+    utils.etag(strUTF8).should.eql('"1395090196"');
+  })
+
+  it('should support buffer', function(){
+    utils.etag(new Buffer(strUTF8)).should.eql('"1395090196"');
+    utils.etag(new Buffer(str)).should.eql('"-2034458343"');
+  })
+
+})
+
 describe('utils.isAbsolute()', function(){
   it('should support windows', function(){
     assert(utils.isAbsolute('c:\\'));


### PR DESCRIPTION
Hi,

at the moment I´m in the process of introducing express as a open source software module to our company. In this process I need to check that the software I´m going to introduce has a valid licence statement.

It turns out that one of the modules express depends on (node-crc) might have a license issue. There are more information here: https://github.com/alexgorbatchev/node-crc/issues/2

I also did some tests against node-crc and other implementations and discovered that compared to CRC32 implementation in PHP the check-sums are different. I´m not an expert on CRC checks but I thing it has something to do with the CRC table that is used.

Here is a gist with my checks: https://gist.github.com/4124412

As you can see in example 1 and 2 buffer-crc32 generates the same check-sums like the PHP implementation (both tested on 64bit).

It would be very nice if this issue could be resolved by switching over to buffer-crc32.
