### PR TITLE
Plugins

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -135,6 +135,24 @@ app.use = function(route, fn){
 };
 
 /**
+ * Call the given plugin function `fn` with
+ * `this` as a reference to the app. Every parameter
+ * after `fn` will be passed to the plugin.
+ *
+ * @param {Function} fn
+ * @param {...object} args
+ * @return {app} for chaining
+ * @api public
+ */
+
+app.plugin = function(fn){
+  if ('function' != typeof fn) throw new Error('callback function required');
+  Array.prototype.shift.apply(arguments).apply(this, arguments);
+
+  return this;
+};
+
+/**
  * Register the given template engine callback `fn`
  * as `ext`.
  *

--- a/test/app.plugin.js
+++ b/test/app.plugin.js
@@ -9,8 +9,8 @@ describe('app', function(){
         , plugin = function plugin(param0, param1, param2) {
 	        	this.should.equal(app);
 	        	param0.should.eql(params[0]);
-	        	param0.should.eql(params[1]);
-	        	param0.should.eql(params[2]);
+	        	param1.should.eql(params[1]);
+	        	param2.should.eql(params[2]);
 	        }
 	      , params = ["param0", "param1", "param2"];
 

--- a/test/app.plugin.js
+++ b/test/app.plugin.js
@@ -1,0 +1,20 @@
+
+var express = require('../')
+  , request = require('./support/http');
+
+describe('app', function(){
+  describe('.plugin(plugin, param...)', function(){
+    it('should execute the plugin fn with this and param...', function(){
+      var app = express()
+        , plugin = function plugin(param0, param1, param2) {
+	        	this.should.equal(app);
+	        	param0.should.eql(params[0]);
+	        	param0.should.eql(params[1]);
+	        	param0.should.eql(params[2]);
+	        }
+	      , params = ["param0", "param1", "param2"];
+
+      app.plugin(plugin, params[0], params[1], params[2]);
+    })
+  })
+})


### PR DESCRIPTION
Sometimes middleware just isn't enough. Sometimes you _need_ to extend express.
This PR implements a clean way to do so.

``` javascript
function nyancat(exclamation) {
  this.nyan = function() {
    console.log("-> " + exclamation);
  };
}

app.plugin(nyancat, "Nyan!"); // -> Nyan!
```
