### PR TITLE
ensuring that all callbacks passed to Router#route are functions and are defined

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -243,6 +243,12 @@ Router.prototype.route = function(method, path, callbacks){
   // ensure path was given
   if (!path) throw new Error('Router#' + method + '() requires a path');
 
+  // ensure all callbacks are functions
+  callbacks.forEach(function(cb){
+    if ('function' != typeof cb) 
+      throw new Error('Router#' + method + '() requires all callbacks to be functions');
+  });
+
   // create the route
   debug('defined %s %s', method, path);
   var route = new Route(method, path, callbacks, {

--- a/test/Router.js
+++ b/test/Router.js
@@ -76,4 +76,28 @@ describe('Router', function(){
       .expect('foo', done);
     })
   })
+
+  describe('.multiple callbacks', function(){
+    it('should throw if a callback is null', function(){
+      assert.throws(function(){
+        router.route('get', '/foo', null, function(){});
+      })
+    })
+
+    it('should throw if a callback is undefined', function(){
+      assert.throws(function(){
+        router.route('get', '/foo', undefined, function(){});
+      })
+    })
+
+    it('should throw if a callback is not a function', function(){
+      assert.throws(function(){
+        router.route('get', '/foo', 'not a function', function(){});
+      })
+    })
+
+    it('should not throw if all callbacks are functions', function(){
+      router.route('get', '/foo', function(){}, function(){});
+    })
+  })
 })


### PR DESCRIPTION
Currently express does not check passed callbacks for problems, which can result in bugs that are very hard to track down e.g.,:

``` js
var validate = require('./validate');

// Oops - misspelled hasCorrectParams
app.get('/foo', validate.hasCorectParams, function (req, res) {
  // ...
});
```

At this point this fails silently. Since `next` doesn't get called, the last handler never gets called either.

I adapted `Router#route` to throw an error if any of the passed callbacks are `null`, `undefined` or not a `function` in order to give immediate feedback for these kind of bugs.
