### PR TITLE
add http verbs methods to Router

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -397,15 +397,18 @@ app.configure = function(env, fn){
 };
 
 /**
- * Delegate `.VERB(...)` calls to `.route(VERB, ...)`.
+ * Delegate `.VERB(...)` calls to `router.VERB(...)`.
  */
 
 methods.forEach(function(method){
   app[method] = function(path){
     if ('get' == method && 1 == arguments.length) return this.set(path);
-    var args = [method].concat([].slice.call(arguments));
+
+    // if no router attacked yet, attach the router
     if (!this._usedRouter) this.use(this.router);
-    this._router.route.apply(this._router, args);
+
+    // setup route
+    this._router[method].apply(this._router, arguments);
     return this;
   };
 });

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -4,6 +4,7 @@
 
 var Route = require('./route')
   , utils = require('../utils')
+  , methods = require('methods')
   , debug = require('debug')('express:router')
   , parse = require('connect').utils.parseUrl;
 
@@ -260,3 +261,11 @@ Router.prototype.route = function(method, path, callbacks){
   (this.map[method] = this.map[method] || []).push(route);
   return this;
 };
+
+methods.forEach(function(method){
+  Router.prototype[method] = function(path){
+    var args = [method].concat([].slice.call(arguments));
+    this.route.apply(this, args);
+    return this;
+  };
+});


### PR DESCRIPTION
By having the method verbs available on the router, users can set up
disjoint routers and organized paths easier.

It is now possible to have a .js file export the router.middleware and
attach these paths using an `app.use('/path', middleware)` call. This
means that any routes written in the separate file do not need to have a
full path hardcoded as they can be mounted by the application anywhere.

This is already possible using `router.route(verb, args)` however is
needlessly verbose without this patch.
