### PR TITLE
Make vhost example work on localhost

### DIFF
--- a/examples/vhost/index.js
+++ b/examples/vhost/index.js
@@ -18,7 +18,7 @@ one.get('/', function(req, res){
 });
 
 one.get('/:sub', function(req, res){
-  res.send('requsted ' + req.params.sub);
+  res.send('requested ' + req.params.sub);
 });
 
 // App two
@@ -34,8 +34,9 @@ two.get('/', function(req, res){
 var redirect = express();
 
 redirect.all('*', function(req, res){
-  console.log(req.subdomains);
-  res.redirect('http://localhost:3000/' + req.subdomains[0]);
+  var subdomains = req.host.split('.');
+  console.log(subdomains);
+  res.redirect('http://localhost:3000/' + subdomains[0]);
 });
 
 // Main app


### PR DESCRIPTION
Since req.subdomains doesn't return the last two parts of the domain,
subdomains of localhost won't show up in the array. Parse the host
directly to get the first part instead.

I think express needs a more flexible API for req.subdomains, since
ignoring the last two parts often doesn't make sense. I'm not sure how
it's typically used, but it would seem more useful to just return all
the parts of the domain.
