### PR TITLE
Allow colons in passwords for req.auth

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -393,8 +393,9 @@ req.__defineGetter__('auth', function(){
   auth = parts[1];
 
   // credentials
-  auth = new Buffer(auth, 'base64').toString().split(':');
-  return { username: auth[0], password: auth[1] };
+  auth = new Buffer(auth, 'base64').toString().match(/^([^:]*):(.*)$/);
+  if (!auth) return;
+  return { username: auth[1], password: auth[2] };
 });
 
 /**

--- a/test/req.auth.js
+++ b/test/req.auth.js
@@ -48,6 +48,36 @@ describe('req', function(){
       })
     })
 
+    describe('when encoded string is malformed', function(){
+      it('should return undefined', function(done){
+        var app = express();
+
+        app.get('/', function(req, res){
+          res.send(req.auth || 'none');
+        });
+
+        request(app)
+        .get('/')
+        .set('Authorization', 'Basic Z21ldGh2aW4=')
+        .expect('none', done)
+      })
+    })
+
+    describe('when password contains a colon', function(){
+      it('should return .username and .password', function(done){
+        var app = express();
+
+        app.get('/', function(req, res){
+          res.send(req.auth || 'none');
+        });
+
+        request(app)
+        .get('/')
+        .set('Authorization', 'Basic dG9iaTpmZXJyZXQ6ZmVycmV0')
+        .expect('{"username":"tobi","password":"ferret:ferret"}', done)
+      })
+    })
+
     it('should return .username and .password', function(done){
       var app = express();
 


### PR DESCRIPTION
Passwords in basic auth can contain colons (per RFC2617), while
usernames cannot, so assume everything after the colon is a password.
This makes req.auth return the correct value if the user uses a colon
in their password.
