### PR TITLE
Add full extname support to the "view engine" setting; e.g., ".jade".

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -38,7 +38,7 @@ function View(name, options) {
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
   var ext = this.ext = extname(name);
-  if (!ext) name += (ext = this.ext = '.' + this.defaultEngine);
+  if (!ext) name += (ext = this.ext = ('.' != this.defaultEngine[0] ? '.' : '') + this.defaultEngine);
   this.engine = engines[ext] || (engines[ext] = require(ext.slice(1)).__express);
   this.path = this.lookup(name);
 }


### PR DESCRIPTION
This allows View to support a `defaultEngine` (a.k.a. an app's "view engine" setting) which contains a ".", for example:

``` javascript
app.engine('.jade', jadeEngine);
app.set('view engine', '.jade');
```

This brings View's handling of template filename extensions to parity with `app.engine()`. This allows an app's "view engine" setting to be a full extension name, including the ".".

I ran into this issue when trying to extract the configuration for the default view extension name into a config file and represent it as a variable when configuring my Express app. I realized that an app's `engine()` registration and "view engine" setting do not behave the same; this give them parity.
