### PR TITLE
Added view option to ignore the physical files

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -485,6 +485,7 @@ app.render = function(name, options, fn){
     view = new View(name, {
       defaultEngine: this.get('view engine'),
       root: this.get('views'),
+      enableVirtual: this.get('enableVirtual'),
       engines: engines
     });
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -34,6 +34,7 @@ module.exports = View;
 
 function View(name, options) {
   options = options || {};
+  this.options = options;
   this.name = name;
   this.root = options.root;
   var engines = options.engines;
@@ -55,13 +56,15 @@ function View(name, options) {
 View.prototype.lookup = function(path){
   var ext = this.ext;
 
+  if(this.options.enableVirtual) return path;
+
   // <path>.<engine>
   if (!utils.isAbsolute(path)) path = join(this.root, path);
   if (exists(path)) return path;
 
   // <path>/index.<engine>
   path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path) || this.options.enableVirtual) return path;
+  if (exists(path)) return path;
 };
 
 /**

--- a/lib/view.js
+++ b/lib/view.js
@@ -24,7 +24,8 @@ module.exports = View;
  *
  *   - `defaultEngine` the default template engine name 
  *   - `engines` template engine require() cache 
- *   - `root` root path for view lookup 
+ *   - `root` root path for view lookup
+ *   - 'enableVirtual' if true will not check for view existence on the file system
  *
  * @param {String} name
  * @param {Object} options
@@ -60,7 +61,7 @@ View.prototype.lookup = function(path){
 
   // <path>/index.<engine>
   path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
+  if (exists(path) || this.options.enableVirtual) return path;
 };
 
 /**


### PR DESCRIPTION
Just a couple small changes to make it possible to have views stored in a database or in memory if the view engine supports it.

app.set('enableVirtual',true); 

during view setup will make it so that the file system isn't checked, and the input template path is not expanded to an absolute path.
