### PR TITLE
Allow to pass configuration function to express()

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -35,12 +35,13 @@ exports.mime = connect.mime;
  * @api public
  */
 
-function createApplication() {
+function createApplication(fn) {
   var app = connect();
   utils.merge(app, proto);
   app.request = { __proto__: req };
   app.response = { __proto__: res };
   app.init();
+  fn && app.configure(fn);
   return app;
 }
 


### PR DESCRIPTION
The configure() function is quite handy, especially in CoffeeScript with `@` being used to access properties on this.

I find myself repeatedly creating an app and running configure() on it w/o an environment, just so I'll be in the app context and could use the `@` sugar, than running the rest of the code inside that function, e.g.:

``` coffee
app = express()
app.configure ->
  @use express.static __dirname
  @set '....'
  # ...
```

What if `express()` simply allowed to give it a function, and immediately execute it in the context of the app?

``` coffee
express ->
  @use express.static __dirname
  @set '....'
   # ...
```
