### PR TITLE
Very small usage message change for express CLI

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -16,6 +16,7 @@ var exec = require('child_process').exec
 
 program
   .version(version)
+  .usage('[options] [<directory>]')
   .option('-s, --sessions', 'add session support')
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('-J, --jshtml', 'add jshtml engine support (defaults to jade)')

--- a/bin/express
+++ b/bin/express
@@ -16,7 +16,7 @@ var exec = require('child_process').exec
 
 program
   .version(version)
-  .usage('[options] [<directory>]')
+  .usage('[options] [directory]')
   .option('-s, --sessions', 'add session support')
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('-J, --jshtml', 'add jshtml engine support (defaults to jade)')

--- a/bin/express
+++ b/bin/express
@@ -16,7 +16,7 @@ var exec = require('child_process').exec
 
 program
   .version(version)
-  .usage('[options] [directory]')
+  .usage('[options] [path]')
   .option('-s, --sessions', 'add session support')
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('-J, --jshtml', 'add jshtml engine support (defaults to jade)')


### PR DESCRIPTION
Adds directory option to express -h usage info: 'express [options] [<directory>]
