### PR TITLE
Allow setting an array of header values in the response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -510,12 +510,12 @@ res.attachment = function(filename){
  */
 
 res.set =
-res.header = function(field, val){
+res.header = function header(field, val){
   if (2 == arguments.length) {
-    this.setHeader(field, '' + val);
+    this.setHeader(field, Array.isArray(val) ? val.map(String) : String(val));
   } else {
     for (var key in field) {
-      this.setHeader(key, '' + field[key]);
+      header.call(this, key, field[key]);
     }
   }
   return this;

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -24,6 +24,27 @@ describe('res', function(){
       res.get('ETag').should.equal('123');
     })
   })
+
+  describe('.set(field, values)', function(){
+    it('should set multiple response header fields', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Set-Cookie', ["type=ninja", "language=javascript"]);
+        res.send(res.get('Set-Cookie'));
+      });
+
+      request(app)
+      .get('/')
+      .expect('["type=ninja","language=javascript"]', done);
+    })
+
+    it('should coerce to an array of strings', function(){
+      res.headers = {};
+      res.set('ETag', [123, 456]);
+      JSON.stringify(res.get('ETag')).should.equal('["123","456"]');
+    })
+  })
   
   describe('.set(object)', function(){
     it('should set multiple fields', function(done){


### PR DESCRIPTION
Make setting multiple header values using an array work as expected.
If the header value is an array, coerce the values to strings instead
of the entire array.

Fixes #1419.
