### PR TITLE
creating configurable json prefix

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -182,7 +182,8 @@ res.json = function(obj){
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(obj, replacer, spaces);
+  var prefix = app.get('json prefix') || '';
+  var body = prefix + JSON.stringify(obj, replacer, spaces);
 
   // content-type
   this.charset = this.charset || 'utf-8';

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -124,6 +124,45 @@ describe('res', function(){
         });
       })
     })
+
+    describe('"json prefix" setting', function(){
+      it('should be undefined by default', function(){
+        var app = express();
+        assert(undefined === app.get('json prefix'));
+      })
+
+      it('should not modify response if undefined', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.json({ name: 'tobi' });
+        });
+
+        request(app)
+        .get('/')
+        .end(function(err, res){
+          res.text.should.match(/^\s*\{\s*\"name\"\:\s*\"tobi\"\s*\}\s*$/);
+          done();
+        })
+      })
+
+      it('should prefix json responses if set', function(done){
+        var app = express();
+
+        app.set('json prefix', ')]},\n');
+
+        app.use(function(req, res){
+          res.json({ name: 'tobi' });
+        });
+
+        request(app)
+        .get('/')
+        .end(function(err, res){
+          res.text.should.match(/^\)\]\},\n/);
+          done();
+        })
+      })
+    })
   })
   
   describe('.json(status, object)', function(){


### PR DESCRIPTION
example usage: `app.set("json prefix", ")]},\n");`

Created in order to be able to follow [angular's advice](http://docs.angularjs.org/api/ng.$http) regarding JSON Vulnerability protection.
