### PR TITLE
bin/express now generates a .gitignore for node_modules

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -364,8 +364,15 @@ function createApplicationAt(path) {
         }
     }
 
+    // git support
+    var gitignore = [
+      'node_modules/',
+      ''
+    ].join(eol);
+
     write(path + '/package.json', JSON.stringify(pkg, null, 2));
     write(path + '/app.js', app);
+    write(path + '/.gitignore', gitignore);
   });
 }
 


### PR DESCRIPTION
I love the generator feature. Each time I use it I create myself a .gitignore that excludes node_modules. So here's a simple patch for that by default. Enjoy!

I've manually verified that the changes work.
