### PR TITLE
Added "express --paas heroku" option which adds package.json entries for heroku deployment to work out-of-the-box

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -21,6 +21,7 @@ program
   .option('-J, --jshtml', 'add jshtml engine support (defaults to jade)')
   .option('-H, --hogan', 'add hogan.js engine support')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus) (defaults to plain css)')
+  .option('-p, --paas [platform]', 'add <platform> support (heroku) (defaults to generic support)')
   .option('-f, --force', 'force on non-empty directory')
   .parse(process.argv);
 
@@ -38,6 +39,8 @@ program.template = 'jade';
 if (program.ejs) program.template = 'ejs';
 if (program.jshtml) program.template = 'jshtml';
 if (program.hogan) program.template = 'hjs';
+
+if (program.heroku) program.paas = 'heroku';
 
 /**
  * Routes index template.
@@ -362,6 +365,13 @@ function createApplicationAt(path) {
         if (program.css) {
           pkg.dependencies[program.css] = '*';
         }
+    }
+
+    if (program.paas == 'heroku') {
+      pkg.engines = {
+        node: '0.8.x'
+      , npm:  '1.1.x'
+      }
     }
 
     write(path + '/package.json', JSON.stringify(pkg, null, 2));


### PR DESCRIPTION
I keep having to copy and paste the correct engines settings for package.json before deploying a new app to heroku. This pull request will make that easier. Simple code, although I may have over-thought the generality of the --paas switch.

----------------- Prior to this pull request the first deploy experience is as follows:

-----> Node.js app detected
-----> Resolving engine versions

```
   WARNING: No version of Node.js specified in package.json, see:
   https://devcenter.heroku.com/articles/nodejs-versions

   WARNING: The default version of Node.js and npm on Heroku will begin
   tracking the latest stable release starting September 1, 2012.

   Using Node.js version: 0.4.7
   Using npm version: 1.0.106
```

-----> Fetching Node.js binaries
-----> Vendoring node into slug
-----> Installing dependencies with npm
       npm ERR! error installing express@3.0.6 Error: Unsupported
       npm ERR! error installing express@3.0.6     at checkEngine (/tmp/node-npm-5DgI/lib/install.js:493:14)
       npm ERR! error installing express@3.0.6     at Array.0 (/tmp/node-npm-5DgI/node_modules/slide/lib/bind-actor.js:15:8)
       npm ERR! error installing express@3.0.6     at LOOP (/tmp/node-npm-5DgI/node_modules/slide/lib/chain.js:15:13)
       npm ERR! error installing express@3.0.6     at chain (/tmp/node-npm-5DgI/node_modules/slide/lib/chain.js:20:4)
       npm ERR! error installing express@3.0.6     at installOne_ (/tmp/node-npm-5DgI/lib/install.js:470:3)
       npm ERR! error installing express@3.0.6     at installOne (/tmp/node-npm-5DgI/lib/install.js:411:3)
       npm ERR! error installing express@3.0.6     at /tmp/node-npm-5DgI/lib/install.js:347:9
       npm ERR! error installing express@3.0.6     at /tmp/node-npm-5DgI/node_modules/slide/lib/async-map.js:54:35
       npm ERR! error installing express@3.0.6     at Array.forEach (native)
       npm ERR! error installing express@3.0.6     at /tmp/node-npm-5DgI/node_modules/slide/lib/async-map.js:54:11
       npm ERR! error rolling back express@3.0.6 Error: ENOTEMPTY, Directory not empty '/tmp/build_2tgwfkdt0s1k3/node_modules/express'
       npm ERR! Unsupported
       npm ERR! Not compatible with your version of node/npm: connect@2.7.2
       npm ERR! Required: {"node":">= 0.5.0"}
       npm ERR! Actual:   {"npm":"1.0.106","node":"0.4.7"}
