### PR TITLE
Inherit settings from parent application using [[Prototype]]

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -60,6 +60,7 @@ app.defaultConfiguration = function(){
     this.request.__proto__ = parent.request;
     this.response.__proto__ = parent.response;
     this.engines.__proto__ = parent.engines;
+    this.settings.__proto__ = parent.settings;
   });
 
   // router
@@ -250,11 +251,7 @@ app.param = function(name, fn){
 
 app.set = function(setting, val){
   if (1 == arguments.length) {
-    if (this.settings.hasOwnProperty(setting)) {
-      return this.settings[setting];
-    } else if (this.parent) {
-      return this.parent.set(setting);
-    }
+    return this.settings[setting];
   } else {
     this.settings[setting] = val;
     return this;


### PR DESCRIPTION
It seems like the current code implements the exact same behavior as using [[Prototype]], so why not use it?
