### PR TITLE
[WIP] Add app.subroute option for method chaining middleware for routes, as well as automatic OPTIONS responses and 405 Method Not Allowed error codes

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -8,6 +8,8 @@ var connect = require('connect')
   , middleware = require('./middleware')
   , debug = require('debug')('express:application')
   , locals = require('./utils').locals
+  , sendOptions = require('./utils').sendOptions
+  , methodNotAllowed = require('./utils').methodNotAllowed
   , View = require('./view')
   , utils = connect.utils
   , path = require('path')
@@ -435,6 +437,62 @@ app.all = function(path){
 // del -> delete alias
 
 app.del = app.delete;
+
+app.subroute = function (routes) {
+  return new Subrouter(this, routes)
+}
+
+function Subrouter(app, routes) {
+  this.app = app;
+  this.routes = Array.isArray(routes) ? routes : [routes];
+
+  this.methods = {};
+}
+
+methods.concat('all').forEach(function (method) {
+  Subrouter.prototype[method] = function () {
+    var app = this.app;
+    var args = [].slice.call(arguments);
+
+    this.routes.forEach(function (route) {
+      app[method].apply(app, [route].concat(args));
+    })
+
+    if (method !== 'all') this.methods[method] = true;
+    if (method === 'get') this.methods.head = true;
+
+    return this
+  }
+})
+
+Subrouter.prototype.use = Subrouter.prototype.all
+Subrouter.prototype.del = Subrouter.prototype.delete
+
+// Must be set last
+Subrouter.prototype.end = function () {
+  if (!this.methods.options) {
+    this.methods.options = true;
+    this.options(sendOptions(this.methods));
+  }
+
+  this.use(methodNotAllowed);
+
+  return this
+}
+
+// Must be set immediately before `end()`
+Subrouter.prototype.allow = function (method) {
+  this.methods[method.toLowerCase()] = true;
+
+  return this
+}
+
+// Must be set immediately before `end()`
+Subrouter.prototype.disallow = function (method) {
+  delete this.methods[method.toLowerCase()];
+
+  return this
+}
 
 /**
  * Render the given view `name` name with `options`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,8 +20,8 @@ exports.etag = function(body){
 
 /**
  * Make `locals()` bound to the given `obj`.
- *  
- * This is used for `app.locals` and `res.locals`. 
+ *
+ * This is used for `app.locals` and `res.locals`.
  *
  * @param {Object} obj
  * @return {Function}
@@ -279,4 +279,43 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
     .replace(/([\/.])/g, '\\$1')
     .replace(/\*/g, '(.*)');
   return new RegExp('^' + path + '$', sensitive ? '' : 'i');
+}
+
+/**
+ * Create a middleware function to send
+ * an Allow header for an OPTIONS request.
+ *
+ * @param {String|Array|Object} methods
+ * @return {function} middleware
+ */
+
+exports.sendOptions = function(methods){
+  if (Object(methods) === methods) {
+    methods = Object.keys(methods).filter(function(x) {
+      return methods[x];
+    })
+  }
+
+  if (Array.isArray(methods)) {
+    methods = methods.map(function(x) {
+      return x.toUpperCase();
+    }).join(',');
+  }
+
+  return function(req, res, next) {
+    res.setHeader('Allow', methods);
+    res.end();
+  }
+}
+
+/**
+ * Middleware to send a 405 Method Not Allowed response
+ * instead of a 404 page not found.
+ * Should use connect.utils.error but it isn't public.
+ */
+
+exports.methodNotAllowed = function(req, res, next) {
+  var err = new Error();
+  err.status = 405;
+  next(err);
 }

--- a/test/app.subroute.js
+++ b/test/app.subroute.js
@@ -1,0 +1,88 @@
+var express = require('../')
+  , request = require('./support/http')
+  , methods = require('methods');
+
+describe('app.subroute.js', function(){
+  describe('methods supported', function(){
+    methods.forEach(function(method){
+      it('should include ' + method.toUpperCase(), function(done){
+        if (method === 'delete') method = 'del';
+        var app = express();
+        var calls = [];
+
+        app.subroute('/foo')[method](function(req, res){
+          if ('head' == method) {
+            res.end();
+          } else {
+            res.end(method);
+          }
+        }).end();
+
+        request(app)
+        [method]('/foo')
+        .expect('head' == method ? '' : method, done);
+      })
+    })
+  })
+
+  describe('options supported', function(){
+    methods.forEach(function(method){
+      it('should include ' + method.toUpperCase(), function(done){
+        if (method === 'delete') method = 'del';
+        var app = express();
+        var calls = [];
+
+        if (method !== 'options') {
+          app.subroute('/foo')[method](function(req, res){
+            if ('head' == method) {
+              res.end();
+            } else {
+              res.end(method);
+            }
+          }).end();
+        } else {
+          app.subroute('/foo').end();
+        }
+
+        request(app)
+        .options('/foo')
+        .expect('Allow', method == 'options' ? 'OPTIONS'
+          : method == 'del' ? 'DELETE,OPTIONS'
+          : method == 'get' ? 'GET,HEAD,OPTIONS'
+          : method.toUpperCase() + ',OPTIONS', done);
+      })
+    })
+  })
+
+  it('should disallow methods', function(done){
+    var app = express();
+    var calls = [];
+
+    app.subroute('/foo').get(function(req, res){
+      res.end('get');
+    }).end();
+
+    request(app)
+    .post('/foo')
+    .expect(405, done);
+  })
+
+  /*
+  it('show allow HEAD for GET', function(done){
+    var app = express();
+    var calls = [];
+
+    app.subroute('/foo').get(function(req, res){
+      if (req.method === 'HEAD') {
+        res.end();
+      } else {
+        res.end('get');
+      }
+    }).end();
+
+    request(app)
+    .head('/foo')
+    .expect(200, done);
+  })
+  */
+})


### PR DESCRIPTION
```
app.subroute('/foo')
  .use(allMiddleware)
  .get(getMiddleware)
  .post(postMiddleware)
  .all(allMiddleware2)
  .end()
```

Will be equivalent to:

```
app.all('/foo', allMiddleware)
app.get('/foo', getMiddleware)
app.post('/foo', postMiddleware)
app.all('/foo', allMiddleware2)
app.options('/foo', function(req, res, next){
  res.setHeader('Allow', 'GET,HEAD,POST,OPTIONS')
  res.end()
})
app.all('/foo', function(req, res, next){
  var err = new Error()
  err.status = 405
  next(err)
})
```

`.end()` adds the `app.options()` and the last `app.all()` middleware and is completely optional.
There is also a `app.subroute().allow()` and `disallow()` method to add/remove methods from `app.subroute().options()`.

This kind of implements @guille's #1501 alternative route syntax.
This also alleviates #1499 405 Method Not Allowed routing.

There are, however, issues with this code. If you're interested in merging this, I can work on it more, otherwise I'm not.
- If a response is sent via `app.subroute().all`, that method will not be added to `OPTIONS` since express doesn't know what method was used. 
- I was under the impression that `app.get` accepted `HEAD` requests but doesn't send a body as per HTTP spec, but I guess that isn't the case in express (I have a test commented out). Not sure how to handle it.
- All routes have to be declared in the same `app.subroute()` for `OPTIONS` to work. 

Also `routes` for `app.subroute(routes)` can be an array, though I'm not sure if you'd want that.
I added that because in my case, I have a lot of similar routes.

Then there's less important issues like I don't know where to put stuff, and coding styles.

Let me know what you think.
