### PR TITLE
Fix Dotted Relative Redirects in Applications Mounted on Nested Paths

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -638,20 +638,6 @@ res.location = function(url){
 
     // relative to path
     if ('.' == url[0]) {
-      /*
-       * Originally, req.path was used, which is rooted within the
-       * application's mount point path. In these mounted applications,
-       * relative redirects would fail. For example, for an application
-       * nested at /foo/bear/leaf, a redirect to ./baz would result in a
-       * redirect to //./baz (which most browsers will interpret as a protocol
-       * token). Even if we collapse the redundant slashes, this would still
-       * compute the URL as /./baz for a relative redirect within
-       * /foo/bear/leaf. This comes with a few advantages, one being that
-       * applications may now be mounted at several paths, and relative
-       * redirects will work provided they use dotted notation. Additionally,
-       * no other behaviors are affected by this change--we are only expanding
-       * the functional scope of this method.
-       */
       path = req.originalUrl.split('?')[0]
       url =  path + ('/' == path[path.length - 1] ? '' : '/') + url;
       // relative to mount-point

--- a/lib/response.js
+++ b/lib/response.js
@@ -634,7 +634,13 @@ res.location = function(url){
 
   // relative
   if (!~url.indexOf('://') && 0 != url.indexOf('//')) {
-    var path = app.path();
+    /*
+     * Allows relative redirects for applications mounted at multiple paths by
+     * relying on the request (which can be safely assumed is valid since it
+     * been satisfied) path, rather than the path "baked in" to the instance.
+     */
+    //var path = app.path();
+    var path = req.originalUrl.split('?')[0]
 
     // relative to path
     if ('.' == url[0]) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -634,19 +634,29 @@ res.location = function(url){
 
   // relative
   if (!~url.indexOf('://') && 0 != url.indexOf('//')) {
-    /*
-     * Allows relative redirects for applications mounted at multiple paths by
-     * relying on the request (which can be safely assumed is valid since it
-     * been satisfied) path, rather than the path "baked in" to the instance.
-     */
-    //var path = app.path();
-    var path = req.originalUrl.split('?')[0]
+    var path
 
     // relative to path
     if ('.' == url[0]) {
-      url = req.path + '/' + url;
-    // relative to mount-point
+      /*
+       * Originally, req.path was used, which is rooted within the
+       * application's mount point path. In these mounted applications,
+       * relative redirects would fail. For example, for an application
+       * nested at /foo/bear/leaf, a redirect to ./baz would result in a
+       * redirect to //./baz (which most browsers will interpret as a protocol
+       * token). Even if we collapse the redundant slashes, this would still
+       * compute the URL as /./baz for a relative redirect within
+       * /foo/bear/leaf. This comes with a few advantages, one being that
+       * applications may now be mounted at several paths, and relative
+       * redirects will work provided they use dotted notation. Additionally,
+       * no other behaviors are affected by this change--we are only expanding
+       * the functional scope of this method.
+       */
+      path = req.originalUrl.split('?')[0]
+      url =  path + ('/' == path[path.length - 1] ? '' : '/') + url;
+      // relative to mount-point
     } else if ('/' != url[0]) {
+      path = app.path();
       url = path + '/' + url;
     }
   }

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -9,6 +9,10 @@ describe('req', function(){
         , cookieHeader
         , val;
 
+      /* So we use the same serialization for expected results. */
+      var replacer = app.get('json replacer')
+        , spaces = app.get('json spaces');
+
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
@@ -19,7 +23,7 @@ describe('req', function(){
       app.response.cookie('obj', { foo: 'bar' }, { signed: true });
       cookieHeader = app.response.get('set-cookie');
 
-      val = JSON.stringify({ obj: { foo: 'bar' } });
+      val = JSON.stringify({ obj: { foo: 'bar' } }, replacer, spaces);
       request(app)
       .get('/')
       .set('Cookie', cookieHeader)
@@ -31,6 +35,10 @@ describe('req', function(){
         , cookieHeader
         , val;
 
+      /* So we use the same serialization for expected results. */
+      var replacer = app.get('json replacer')
+        , spaces = app.get('json spaces');
+
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
@@ -41,7 +49,7 @@ describe('req', function(){
       app.response.cookie('foo', 'bar', { signed: true });
       cookieHeader = app.response.get('set-cookie');
 
-      val = JSON.stringify({ foo: 'bar' });
+      val = JSON.stringify({ foo: 'bar' }, replacer, spaces);
       request(app)
       .get('/')
       .set('Cookie', cookieHeader)

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -12,7 +12,7 @@ describe('req', function(){
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
-        res.send(JSON.stringify(req.signedCookies));
+        res.send(req.signedCookies);
       });
 
       app.response.req = { secret: 'secret' };
@@ -34,7 +34,7 @@ describe('req', function(){
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
-        res.send(JSON.stringify(req.signedCookies));
+        res.send(req.signedCookies);
       });
 
       app.response.req = { secret: 'secret' };

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -12,7 +12,7 @@ describe('req', function(){
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
-        res.send(req.signedCookies);
+        res.send(JSON.stringify(req.signedCookies));
       });
 
       app.response.req = { secret: 'secret' };
@@ -34,7 +34,7 @@ describe('req', function(){
       app.use(express.cookieParser('secret'));
 
       app.use(function(req, res){
-        res.send(req.signedCookies);
+        res.send(JSON.stringify(req.signedCookies));
       });
 
       app.response.req = { secret: 'secret' };

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -174,31 +174,31 @@ describe('res', function(){
 
     /* The requisite test fixtures are repetitive. */
     var makeApp = function (depth, parent) {
-      var app = express()
+      var app = express();
 
       if (parent) {
-        parent.use('/depth' + depth, app)
+        parent.use('/depth' + depth, app);
       }
 
       app.get('/', function (req, res) {
-        res.redirect('./index')
-      })
+        res.redirect('./index');
+      });
 
       app.get('/index', function (req, res) {
-        res.json({depth : depth, content : 'index'})
-      })
+        res.json({depth : depth, content : 'index'});
+      });
 
-      return app
+      return app;
     }
 
-    var root = makeApp(0)
-    var depth1 = makeApp(1, root)
-    var depth2 = makeApp(2, depth1)
-    var depth3 = makeApp(3, depth2)
+    var root = makeApp(0);
+    var depth1 = makeApp(1, root);
+    var depth2 = makeApp(2, depth1);
+    var depth3 = makeApp(3, depth2);
 
     /* Special cases for alias paths. */
-    root.use('/depth2', depth2)
-    root.use('/depth3', depth3)
+    root.use('/depth2', depth2);
+    root.use('/depth3', depth3);
 
     /*
      * The resulting structure resembles the following.
@@ -217,8 +217,8 @@ describe('res', function(){
       request(root)
         .get('/')
         .end(function (err, res) {
-          res.headers.location.search(/^\/{2}/).should.equal(-1)
-          done()
+          res.headers.location.search(/^\/{2}/).should.equal(-1);
+          done();
         })
     })
 
@@ -226,20 +226,20 @@ describe('res', function(){
       request(root)
         .get('/depth1')
         .end(function(err, res) {
-          res.headers.should.have.property('location', '/depth1/./index')
-        })
+          res.headers.should.have.property('location', '/depth1/./index');
+        });
 
       request(root)
         .get('/depth1/depth2')
         .end(function(err, res) {
-          res.headers.should.have.property('location', '/depth1/depth2/./index')
+          res.headers.should.have.property('location', '/depth1/depth2/./index');
         })
 
       request(root)
         .get('/depth1/depth2/depth3')
         .end(function(err, res) {
-          res.headers.should.have.property('location', '/depth1/depth2/depth3/./index')
-          done()
+          res.headers.should.have.property('location', '/depth1/depth2/depth3/./index');
+          done();
         })
     })
 
@@ -247,14 +247,14 @@ describe('res', function(){
       request(root)
         .get('/depth2')
         .end(function (err, res) {
-          res.headers.should.have.property('location', '/depth2/./index')
+          res.headers.should.have.property('location', '/depth2/./index');
         })
 
       request(root)
         .get('/depth3')
         .end(function (err, res) {
-          res.headers.should.have.property('location', '/depth3/./index')
-          done()
+          res.headers.should.have.property('location', '/depth3/./index');
+          done();
         })
     })
 

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -74,7 +74,7 @@ describe('res', function(){
       })
     })
   })
-  
+
   describe('when accepting html', function(){
     it('should respond with html', function(done){
       var app = express();
@@ -110,7 +110,7 @@ describe('res', function(){
       })
     })
   })
-  
+
   describe('when accepting text', function(){
     it('should respond with text', function(done){
       var app = express();
@@ -168,5 +168,95 @@ describe('res', function(){
         done();
       })
     })
+  })
+
+  describe('responses redirected to dotted relative paths', function () {
+
+    /* The requisite test fixtures are repetitive. */
+    var makeApp = function (depth, parent) {
+      var app = express()
+
+      if (parent) {
+        parent.use('/depth' + depth, app)
+      }
+
+      app.get('/', function (req, res) {
+        res.redirect('./index')
+      })
+
+      app.get('/index', function (req, res) {
+        res.json({depth : depth, content : 'index'})
+      })
+
+      return app
+    }
+
+    var root = makeApp(0)
+    var depth1 = makeApp(1, root)
+    var depth2 = makeApp(2, depth1)
+    var depth3 = makeApp(3, depth2)
+
+    /* Special cases for alias paths. */
+    root.use('/depth2', depth2)
+    root.use('/depth3', depth3)
+
+    /*
+     * The resulting structure resembles the following.
+     *
+     * /                     -> root
+     *
+     * /depth1               -> depth1
+     * /depth1/depth2        -> depth2
+     * /depth1/depth2/depth3 -> depth3
+     *
+     * /depth2               -> depth2
+     * /depth3               -> depth3
+     */
+
+    it('should not contain redundant leading slashes in the location header', function (done) {
+      request(root)
+        .get('/')
+        .end(function (err, res) {
+          res.headers.location.search(/^\/{2}/).should.equal(-1)
+          done()
+        })
+    })
+
+    it('should preserve context when redirecting nested applications at any depth', function(done){
+      request(root)
+        .get('/depth1')
+        .end(function(err, res) {
+          res.headers.should.have.property('location', '/depth1/./index')
+        })
+
+      request(root)
+        .get('/depth1/depth2')
+        .end(function(err, res) {
+          res.headers.should.have.property('location', '/depth1/depth2/./index')
+        })
+
+      request(root)
+        .get('/depth1/depth2/depth3')
+        .end(function(err, res) {
+          res.headers.should.have.property('location', '/depth1/depth2/depth3/./index')
+          done()
+        })
+    })
+
+    it('should redirect correctly for nested applications that have been remounted', function (done) {
+      request(root)
+        .get('/depth2')
+        .end(function (err, res) {
+          res.headers.should.have.property('location', '/depth2/./index')
+        })
+
+      request(root)
+        .get('/depth3')
+        .end(function (err, res) {
+          res.headers.should.have.property('location', '/depth3/./index')
+          done()
+        })
+    })
+
   })
 })


### PR DESCRIPTION
In order to cope with visitors to nested applications, where the path is missing the trailing slash, and serve static resources it is helpful to redirect to the canonical resource so the browser will then resolve relative resources at the correct location. (For background, see [_Relative URLs and trailing slashes_](http://stackoverflow.com/questions/5457885/relative-urls-and-trailing-slashes) on Stack Overflow, and [this discussion](http://stackoverflow.com/questions/10867052/cannot-serve-static-files-with-express-routing-and-no-trailing-slash) about serving static resources under those conditions.)

In other words, if the user visits `http://localhost:3000/foo/bear/leaf`, and the markup rendered for that location references a file called `styles.css`, the browser will attempt to resolve that file to `http://localhost:3000/foo/bear/styles.css`. Obviously, [`req.path`](http://expressjs.com/api.html#req.path) is of little use, as it is scoped to the path at which the application is mounted (it will contain `/`).

That issue would be easily solved with `res.redirect('./index')` in a route for `/`, but the destination URL is [computed incorrectly by the current version of `res.location`](https://github.com/visionmedia/express/blob/a4b2e48dfea095f722a17b6b6d89e0a2ccee3fad/lib/response.js#L637) (again, it uses the application's mount point).

To illustrate this problem, start with the following setup and assume `server` is the listening Express application.

``` javascript
var foo = express()
server.use('/foo', foo)

var bear = express()
foo.use('/bear', bear)

var leaf = express()
bear.use('/leaf', leaf)

leaf.get('/', function (req, res) {
  res.redirect('./index')
})

leaf.get('/index', function (req, res) {
  res.send('Sending /index...')
})
```

We can use cURL to see the incorrect redirection.

```
$ curl localhost:3000/foo/bear/leaf
Moved Temporarily. Redirecting to //./index
```

The problem is further exacerbated by the redundant `//` (the browser interprets this as a terminator for the URL protocol, then tries to resolve the path to `http://.index`).

My fix is simple: as the documentation specifies this type of redirect is relative to the _path_ and not the _mount point_, we should rely on [`req.originalUrl`](http://expressjs.com/api.html#req.originalUrl) to compute the redirect, and check if `req.originalUrl` has a trailing slash before appending another one between it and the relative redirection target.

With this change in place, you'll see we get the correct redirection.

```
$ curl localhost:3000/foo/bear/leaf
Moved Temporarily. Redirecting to /foo/bear/leaf/./index
```

See also: my comments in the patch.
