### PR TITLE
Fix explicit .js on project creation

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -345,7 +345,7 @@ function createApplicationAt(path) {
         name: 'application-name'
       , version: '0.0.1'
       , private: true
-      , scripts: { start: 'node app' }
+      , scripts: { start: 'node app.js' }
       , dependencies: {
         express: version
       }


### PR DESCRIPTION
i'm not sure if there's a reason to prefer `node app` over `node app.js`.. anyway this fixes scripts.start in some situations where you're not running `npm start` directly 
