### PR TITLE
Updated references to jscoverage to use as a package dependency instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-cov: lib-cov
 	@EXPRESS_COV=1 $(MAKE) test REPORTER=html-cov > coverage.html
 
 lib-cov:
-	@jscoverage lib lib-cov
+	@./node_modules/.bin/jscoverage lib lib-cov
 
 benchmark:
 	@./support/bench

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "connect-redis": "*",
     "github-flavored-markdown": "*",
     "supertest": "0.0.1",
-    "jscoverage": "*"
+    "visionmedia-jscoverage": "*"
   },
   "keywords": [
     "express",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "should": "*",
     "connect-redis": "*",
     "github-flavored-markdown": "*",
-    "supertest": "0.0.1"
+    "supertest": "0.0.1",
+    "jscoverage": "*"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
Makes it easier to run "make test-cov" etc. when "jscoverage" is not in PATH
