### PR TITLE
Removed old references to viewCallbacks

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -34,7 +34,6 @@ app.init = function(){
   this.cache = {};
   this.settings = {};
   this.engines = {};
-  this.viewCallbacks = [];
   this.defaultConfiguration();
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,8 +29,6 @@ exports.etag = function(body){
  */
 
 exports.locals = function(obj){
-  obj.viewCallbacks = obj.viewCallbacks || [];
-
   function locals(obj){
     for (var key in obj) locals[key] = obj[key];
     return obj;


### PR DESCRIPTION
Was part of the deprecated locals.use() functionality, looks like its not needed anymore.
