### PR TITLE
Use End-of-line Node constant

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -30,7 +30,7 @@ var path = program.args.shift() || '.';
 
 // end-of-line code
 
-var eol = 'win32' == os.platform() ? '\r\n' : '\n'
+var eol = os.EOL
 
 // Template engine
 


### PR DESCRIPTION
Use End-of-line Node constant on OS module, avoiding repeating code:

```
// express/bin/express
var eol = 'win32' == os.platform() ? '\r\n' : '\n'

// node/lib/os.js
exports.EOL = process.platform === 'win32' ? '\r\n' : '\n';
```
