### PR TITLE
Fix arrays of paths and add test cases

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -61,10 +61,12 @@ Route.prototype.match = function(path){
       ? decodeURIComponent(m[i])
       : m[i];
 
-    if (key) {
-      params[key.name] = val;
-    } else {
-      params.push(val);
+    if (typeof val !== 'undefined') {
+      if (key) {
+        params[key.name] = val;
+      } else {
+        params.push(val);
+      }
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -259,7 +259,7 @@ exports.escape = function(html) {
 
 exports.pathRegexp = function(path, keys, sensitive, strict) {
   if (path instanceof RegExp) return path;
-  if (Array.isArray(path)) path = '(' + path.join('|') + ')';
+  if (Array.isArray(path)) path = '(?:' + path.join('|') + ')';
   path = path
     .concat(strict ? '' : '/?')
     .replace(/\/\(/g, '(?:/')

--- a/test/Router.js
+++ b/test/Router.js
@@ -2,7 +2,8 @@
 var express = require('../')
   , Router = express.Router
   , request = require('./support/http')
-  , assert = require('assert');
+  , assert = require('assert')
+  , should = require('should');
 
 describe('Router', function(){
   var router, app;
@@ -98,6 +99,29 @@ describe('Router', function(){
 
     it('should not throw if all callbacks are functions', function(){
       router.route('get', '/foo', function(){}, function(){});
+    })
+  })
+
+  describe('.arrays of paths', function(){
+    it('should match all paths', function(){
+      var route;
+
+      router.route('get', ['/:id/explain/:section', '/:id', '/:id/edit/:section'], function(){});
+
+      route = router.match('get', '/id_val');
+      route.params.id.should.equal('id_val');
+
+      route = router.match('get', '/id_val/edit/section_val');
+      route.params.id.should.equal('id_val');
+      route.params.section.should.equal('section_val');
+
+      route = router.match('get', '/id_val/explain/section_val');
+      route.params.id.should.equal('id_val');
+      route.params.section.should.equal('section_val');
+    })
+    it('should not match other paths', function(){
+      router.route('get', ['/:id/explain/:section', '/:id', '/:id/edit/:section'], function(){});
+      should.not.exist(router.match('get', '/id_val/strange_action/section_val'));
     })
   })
 })


### PR DESCRIPTION
In 28d7750eda15594a551ce834c16c168f55bca502, support for routing arrays of paths was introduced:

```
app.get(['/about', '/contact', '/imprint'], function () {
  // …
});
```

Unfortunately, params are not mapped correctly in this case. Moreover, there are no test cases for this feature. This pull request fixes both.
