### PR TITLE
Fix for Accept header parsing for custom accept parameters

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -202,7 +202,7 @@ req.__defineGetter__('acceptedLanguages', function(){
   var accept = this.get('Accept-Language');
   return accept
     ? utils
-      .parseQuality(accept)
+      .parseParams(accept)
       .map(function(obj){
         return obj.value;
       })
@@ -226,7 +226,7 @@ req.__defineGetter__('acceptedCharsets', function(){
   var accept = this.get('Accept-Charset');
   return accept
     ? utils
-      .parseQuality(accept)
+      .parseParams(accept)
       .map(function(obj){
         return obj.value;
       })

--- a/lib/response.js
+++ b/lib/response.js
@@ -462,14 +462,14 @@ res.format = function(obj){
   this.set('Vary', 'Accept');
 
   if (key) {
-    this.set('Content-Type', normalizeType(key));
+    this.set('Content-Type', normalizeType(key).value);
     obj[key](req, this, next);
   } else if (fn) {
     fn();
   } else {
     var err = new Error('Not Acceptable');
     err.status = 406;
-    err.types = normalizeTypes(keys);
+    err.types = normalizeTypes(keys).map(function (r) { return r.value; });
     next(err);
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,12 +75,12 @@ exports.flatten = function(arr, ret){
  * Normalize the given `type`, for example "html" becomes "text/html".
  *
  * @param {String} type
- * @return {String}
+ * @return {Object}
  * @api private
  */
 
 exports.normalizeType = function(type){
-  return ~type.indexOf('/') ? type : mime.lookup(type);
+  return ~type.indexOf('/') ? acceptParams(type) : {value: mime.lookup(type), params: {}};
 };
 
 /**
@@ -95,9 +95,7 @@ exports.normalizeTypes = function(types){
   var ret = [];
 
   for (var i = 0; i < types.length; ++i) {
-    ret.push(~types[i].indexOf('/')
-      ? acceptParams(types[i])
-      : {value: mime.lookup(types[i]), params: {}});
+    ret.push(exports.normalizeType(types[i]));
   }
 
   return ret;
@@ -148,18 +146,25 @@ exports.accepts = function(type, str){
 /**
  * Check if `type` array is acceptable for `other`.
  *
- * @param {Array} type
+ * @param {Object} type
  * @param {Object} other
  * @return {Boolean}
  * @api private
  */
 
 exports.accept = function(type, other){
-  tp = type.value.split('/');
+  var tp = type.value.split('/');
   return (tp[0] == other.type || '*' == other.type)
     && (tp[1] == other.subtype || '*' == other.subtype) && paramsEql(type.params, other.params);
 };
 
+/**
+ * Check if accept params are equal
+ *
+ * @param {Object} typePms
+ * @param {Object} otherPms
+ * @return {Boolean}
+ */
 function paramsEql (typePms, otherPms){
     return !Object.keys(typePms).some(function(k) {
         return typePms[k] != otherPms[k];
@@ -191,11 +196,11 @@ exports.parseAccept = function(str){
 
 /**
  * Parse quality `str`, returning an
- * array of objects with `.value` and
- * `.quality`.
+ * array of objects with `.value`,
+ * `.quality` and optional `.params`
  *
- * @param {Type} name
- * @return {Type}
+ * @param {String} str
+ * @return {Array}
  * @api private
  */
 
@@ -212,8 +217,8 @@ exports.parseParams = function(str){
 };
 
 /**
- * Parse quality `str` returning an
- * object with `.value` and `.quality`.
+ * Parse accept params `str` returning an
+ * object with `.value`, `.quality` and `.params`.
  *
  * @param {String} str
  * @return {Object}
@@ -221,7 +226,7 @@ exports.parseParams = function(str){
  */
 
 function acceptParams(str) {
-  var parts = str.split(/ *; */)
+  var parts = str.split(/ *; */),
       params = {value: parts[0], quality: 1, params: {}};
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -229,9 +229,8 @@ function acceptParams(str) {
   var parts = str.split(/ *; */),
       params = {value: parts[0], quality: 1, params: {}};
 
-
-  if (parts[1]) {
-      var pms = parts[1].split(/ *= */);
+  for(var i=1; i < parts.length; i++) {
+      var pms = parts[i].split(/ *= */);
       if (pms[0] == "q") {
           params.quality = parseFloat(pms[1]);
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,8 +96,8 @@ exports.normalizeTypes = function(types){
 
   for (var i = 0; i < types.length; ++i) {
     ret.push(~types[i].indexOf('/')
-      ? types[i]
-      : mime.lookup(types[i]));
+      ? acceptParams(types[i])
+      : {value: mime.lookup(types[i]), params: {}});
   }
 
   return ret;
@@ -123,7 +123,7 @@ exports.acceptsArray = function(types, str){
 
   for (var i = 0; i < len; ++i) {
     for (var j = 0, jlen = types.length; j < jlen; ++j) {
-      if (exports.accept(normalized[j].split('/'), accepted[i])) {
+      if (exports.accept(normalized[j], accepted[i])) {
         return types[j];
       }
     }
@@ -155,9 +155,16 @@ exports.accepts = function(type, str){
  */
 
 exports.accept = function(type, other){
-  return (type[0] == other.type || '*' == other.type)
-    && (type[1] == other.subtype || '*' == other.subtype);
+  tp = type.value.split('/');
+  return (tp[0] == other.type || '*' == other.type)
+    && (tp[1] == other.subtype || '*' == other.subtype) && paramsEql(type.params, other.params);
 };
+
+function paramsEql (typePms, otherPms){
+    return !Object.keys(typePms).some(function(k) {
+        return typePms[k] != otherPms[k];
+    });
+}
 
 /**
  * Parse accept `str`, returning
@@ -173,7 +180,7 @@ exports.accept = function(type, other){
 
 exports.parseAccept = function(str){
   return exports
-    .parseQuality(str)
+    .parseParams(str)
     .map(function(obj){
       var parts = obj.value.split('/');
       obj.type = parts[0];
@@ -192,10 +199,10 @@ exports.parseAccept = function(str){
  * @api private
  */
 
-exports.parseQuality = function(str){
+exports.parseParams = function(str){
   return str
     .split(/ *, */)
-    .map(quality)
+    .map(acceptParams)
     .filter(function(obj){
       return obj.quality;
     })
@@ -213,15 +220,21 @@ exports.parseQuality = function(str){
  * @api private
  */
 
-function quality(str) {
+function acceptParams(str) {
   var parts = str.split(/ *; */)
-    , val = parts[0];
+      params = {value: parts[0], quality: 1, params: {}};
 
-  var q = parts[1]
-    ? parseFloat(parts[1].split(/ *= */)[1])
-    : 1;
 
-  return { value: val, quality: q };
+  if (parts[1]) {
+      var pms = parts[1].split(/ *= */);
+      if (pms[0] == "q") {
+          params.quality = parseFloat(pms[1]);
+      } else {
+          params.params[pms[0]] = pms[1];
+      }
+  }
+
+  return params;
 }
 
 /**

--- a/test/utils.js
+++ b/test/utils.js
@@ -49,28 +49,36 @@ describe('utils.escape(html)', function(){
   })
 })
 
-describe('utils.parseQuality(str)', function(){
+describe('utils.parseParams(str)', function(){
   it('should default quality to 1', function(){
-    utils.parseQuality('text/html')
-      .should.eql([{ value: 'text/html', quality: 1 }]);
+    utils.parseParams('text/html')
+      .should.eql([{ value: 'text/html', quality: 1, params: {}}]);
   })
   
   it('should parse qvalues', function(){
-    utils.parseQuality('text/html; q=0.5')
-      .should.eql([{ value: 'text/html', quality: 0.5 }]);
+    utils.parseParams('text/html; q=0.5')
+      .should.eql([{ value: 'text/html', quality: 0.5, params: {}}]);
 
-    utils.parseQuality('text/html; q=.2')
-      .should.eql([{ value: 'text/html', quality: 0.2 }]);
+    utils.parseParams('text/html; q=.2')
+      .should.eql([{ value: 'text/html', quality: 0.2, params: {}}]);
   })
-  
+
+  it('should parse accept parameters', function(){
+    utils.parseParams('application/json; ver=2.0')
+      .should.eql([{ value: 'application/json', quality: 1, params: {ver: "2.0"}}]);
+
+    utils.parseParams('text/html; level=2')
+      .should.eql([{ value: 'text/html', quality: 1, params: {level: "2"}}]);
+  })
+
   it('should work with messed up whitespace', function(){
-    utils.parseQuality('text/html   ;  q =   .2')
-      .should.eql([{ value: 'text/html', quality: 0.2 }]);
+    utils.parseParams('text/html   ;  q =   .2')
+      .should.eql([{ value: 'text/html', quality: 0.2, params: {}}]);
   })
   
   it('should work with multiples', function(){
     var str = 'da, en;q=.5, en-gb;q=.8';
-    var arr = utils.parseQuality(str);
+    var arr = utils.parseParams(str);
     arr[0].value.should.equal('da');
     arr[1].value.should.equal('en-gb');
     arr[2].value.should.equal('en');
@@ -78,7 +86,7 @@ describe('utils.parseQuality(str)', function(){
   
   it('should sort by quality', function(){
     var str = 'text/plain;q=.2, application/json, text/html;q=0.5';
-    var arr = utils.parseQuality(str);
+    var arr = utils.parseParams(str);
     arr[0].value.should.equal('application/json');
     arr[1].value.should.equal('text/html');
     arr[2].value.should.equal('text/plain');
@@ -86,7 +94,7 @@ describe('utils.parseQuality(str)', function(){
   
   it('should exclude those with a quality of 0', function(){
     var str = 'text/plain;q=.2, application/json, text/html;q=0';
-    var arr = utils.parseQuality(str);
+    var arr = utils.parseParams(str);
     arr.should.have.length(2);
   })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -67,8 +67,10 @@ describe('utils.parseParams(str)', function(){
     utils.parseParams('application/json; ver=2.0')
       .should.eql([{ value: 'application/json', quality: 1, params: {ver: "2.0"}}]);
 
-    utils.parseParams('text/html; level=2')
-      .should.eql([{ value: 'text/html', quality: 1, params: {level: "2"}}]);
+    utils.parseParams('text/html; q=0.5; level=2')
+      .should.eql([{ value: 'text/html', quality: 0.5, params: {level: "2"}}]);
+    utils.parseParams('text/html;q=.2;ver=beta')
+      .should.eql([{ value: 'text/html', quality: 0.2, params: {ver: "beta"}}]);
   })
 
   it('should work with messed up whitespace', function(){


### PR DESCRIPTION
According to RFC2616 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) Accept header may contain different accept-params besides quality. Take a look at example from RFC:
`Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,
               text/html;level=2;q=0.4, */*;q=0.5`

With current implementation such header will be parsed incorrectly (level=1 in text/html;level=1 will be parsed as quality). This PR adds better support for such parameters by adding 'params' field to Accept type object, and using it in negotiation.

Also, did you consider to use https://github.com/federomero/negotiator?
