### PR TITLE
Consider X-Forwarded-Host if proxy is trusted

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -440,7 +440,9 @@ req.__defineGetter__('path', function(){
  */
 
 req.__defineGetter__('host', function(){
-  return this.get('Host').split(':')[0];
+  var trustProxy = this.app.get('trust proxy');
+  return (trustProxy && this.get('X-Forwarded-Host') || this.get('Host'))
+    .split(':')[0];
 });
 
 /**


### PR DESCRIPTION
When `trust proxy` is enabled, the protocol and the remote address are already taken from the `X-Forwarded-*` headers. This patch additionally does that for the `Host` header.
