### PR TITLE
fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - "0.8"
+  - "0.10"


### PR DESCRIPTION
now the version-number has to be wrapped by quotes (they changed this at some time i guess?)

see: http://about.travis-ci.org/docs/user/languages/javascript-with-nodejs/
