### PR TITLE
Change to crypto.pbkdf2 in Node v0.10 broke auth example

### DIFF
--- a/examples/auth/pass.js
+++ b/examples/auth/pass.js
@@ -31,7 +31,9 @@ var iterations = 12000;
 
 exports.hash = function (pwd, salt, fn) {
   if (3 == arguments.length) {
-    crypto.pbkdf2(pwd, salt, iterations, len, fn);
+    crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+      fn(err, (new Buffer(hash, 'binary')).toString('base64'));
+    });
   } else {
     fn = salt;
     crypto.randomBytes(len, function(err, salt){
@@ -39,7 +41,7 @@ exports.hash = function (pwd, salt, fn) {
       salt = salt.toString('base64');
       crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
         if (err) return fn(err);
-        fn(null, salt, hash);
+        fn(null, salt, (new Buffer(hash, 'binary')).toString('base64'));
       });
     });
   }


### PR DESCRIPTION
The function `crypto.pbkdf2` has changed from returning a String in Node v0.8 to a SlowBuffer in Node v0.10 (https://github.com/joyent/node/issues/5003) effectively breaking the authentication scheme used in the auth example (not to mention https://github.com/visionmedia/node-pwd).

The change causes the line `if (hash == user.hash) return fn(null, user);` in the app.js `authentication` function to always evaluate as `false` using Node v0.10 (https://github.com/visionmedia/express/issues/1559).

Using the recommendations from (https://github.com/joyent/node/issues/5003) I modified the hash function in pass.js to return a base64 encoded hash at all times fixing the issue using Node v0.10 and not breaking the example using Node v0.8 (tested both).
