### PR TITLE
introducing view constructor configuration

### DIFF
--- a/examples/view-constructor/github-view.js
+++ b/examples/view-constructor/github-view.js
@@ -1,0 +1,33 @@
+
+/**
+ * Module dependencies.
+ */
+
+var http = require('http')
+  , path = require('path')
+  , extname = path.extname
+
+// defining the new View constructor that only knows about remote files from github
+function GithubView(name, options){
+  this.name = name;
+  options = options || {};
+  this.engine = options.engines[extname(name)];
+  this.path = '/' + options.root + '/master/' + name; // where `root` is username/repo
+}
+GithubView.prototype.render = function(options, fn){
+  var self = this
+    , options = {
+        host: 'rawgithub.com',
+        port: 80,
+        path: this.path,
+        method: 'GET'
+      };
+  http.request(options, function(res) {
+    res.setEncoding('utf8');
+    res.on('data', function (str) {
+      self.engine(str, options, fn);
+    });
+  }).end();
+};
+
+module.exports = GithubView;

--- a/examples/view-constructor/index.js
+++ b/examples/view-constructor/index.js
@@ -1,0 +1,45 @@
+
+/**
+ * Module dependencies.
+ */
+
+var express = require('../../')
+  , http = require('http')
+  , GithubView = require('./github-view')
+  , md = require('github-flavored-markdown').parse;
+
+var app = module.exports = express();
+
+// register .md as an engine in express view system
+app.engine('md', function(str, options, fn){
+  try {
+    var html = md(str);
+    html = html.replace(/\{([^}]+)\}/g, function(_, name){
+      return options[name] || '';
+    })
+    fn(null, html);
+  } catch(err) {
+    fn(err);
+  }
+})
+
+// pointing to a particular github repo to load files from it
+app.set('views', 'visionmedia/express');
+
+// register a new view constructor
+app.set('view constructor', GithubView);
+
+app.get('/', function(req, res){
+  // rendering a view relative to the repo
+  res.render('examples/markdown/views/index.md');
+})
+
+app.get('/Readme.md', function(req, res){
+  // rendering a view from https://github.com/visionmedia/express/blob/master/Readme.md
+  res.render('Readme.md');
+})
+
+if (!module.parent) {
+  app.listen(3000);
+  console.log('Express started on port 3000');
+}

--- a/lib/application.js
+++ b/lib/application.js
@@ -479,7 +479,7 @@ app.render = function(name, options, fn){
 
   // view
   if (!view) {
-    view = new View(name, {
+    view = new (this.get('view constructor') || View)(name, {
       defaultEngine: this.get('view engine'),
       root: this.get('views'),
       engines: engines

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -109,6 +109,28 @@ describe('app', function(){
         })
       })
     })
+
+    describe('when "view constructor" is given', function(){
+      it('should create an instance of it', function(done){
+        var app = express();
+
+        function View(name, options){
+          this.name = name;
+          this.path = 'path is required by application.js as a signal of success even though it is not used there.';
+        }
+        View.prototype.render = function(options, fn){
+          fn(null, 'abtract engine');
+        };
+
+        app.set('view constructor', View);
+
+        app.render('something', function(err, str){
+          if (err) return done(err);
+          str.should.equal('abtract engine');
+          done();
+        })
+      })
+    })
   })
   
   describe('.render(name, options, fn)', function(){

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -119,14 +119,14 @@ describe('app', function(){
           this.path = 'path is required by application.js as a signal of success even though it is not used there.';
         }
         View.prototype.render = function(options, fn){
-          fn(null, 'abtract engine');
+          fn(null, 'abstract engine');
         };
 
         app.set('view constructor', View);
 
         app.render('something', function(err, str){
           if (err) return done(err);
-          str.should.equal('abtract engine');
+          str.should.equal('abstract engine');
           done();
         })
       })


### PR DESCRIPTION
## User Stories
- As a developer, I want to bend the instantiation process for views so I can optimize it for my product.
- As a developer, I want to render views that are loaded over the network so I can control them thru an editorial tool.
- As a developer, I want to render views that are compiled into javascript so I can improve performance.
## Shortcoming

The current implementation:
- enforces the use of a view constructor (`lib/view.js`) that is not exposed, hence cannot be customized, optimized or bended.
- requires the view engine to be bound to the filesystem where each view will have to be backed up by a local file without room for abstraction.
## Details

This PR introduces a simple mechanism to configure express to rely on a custom `View` implementation without having to move the current implementation into a separate package or extra complexity. The proposal is to support this:

```
var app = express();
app.set('view constructor', CustomView);
app.render('something');
```

Where `CustomView` is a Class that mimics the api of `lib/view.js` which is responsible for exposing a method called `render` that will be invoked when calling `app.render`. How the view will be resolved based on the `name` and the `options` passed into `app.render` is irrelevant.
## To-do
- [x] code
- [x] test
- [x] example
