### PR TITLE
Handle missing Host: header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -473,6 +472,7 @@ req.__defineGetter__('host', function(){
   var trustProxy = this.app.get('trust proxy');
   var host = trustProxy && this.get('X-Forwarded-Host');
   host = host || this.get('Host');
+  if (!host) return '';
   return host.split(':')[0];
 });
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -473,9 +473,9 @@ req.__defineGetter__('path', function(){
 req.__defineGetter__('host', function(){
   var trustProxy = this.app.get('trust proxy');
   var host = trustProxy && this.get('X-Forwarded-Host');
-  if (host === false || typeof host === 'undefined')  // If X-Forwarded-Host is present but empty, return it.
+  if (host === false || host === undefined)  // If X-Forwarded-Host is present but empty, return it.
     host = this.get('Host');
-  if (typeof host === 'undefined')
+  if (host === undefined)
     return null;
   return host.split(':')[0];
 });

--- a/lib/request.js
+++ b/lib/request.js
@@ -444,7 +444,9 @@ req.__defineGetter__('auth', function(){
 
 req.__defineGetter__('subdomains', function(){
   var offset = this.app.get('subdomain offset');
-  return this.get('Host')
+  var host = this.get('Host');
+  if (!host) return [];
+  return host
     .split('.')
     .reverse()
     .slice(offset);
@@ -471,8 +473,10 @@ req.__defineGetter__('path', function(){
 req.__defineGetter__('host', function(){
   var trustProxy = this.app.get('trust proxy');
   var host = trustProxy && this.get('X-Forwarded-Host');
-  host = host || this.get('Host');
-  if (!host) return '';
+  if (host === false || typeof host === 'undefined')  // If X-Forwarded-Host is present but empty, return it.
+    host = this.get('Host');
+  if (typeof host === 'undefined')
+    return null;
   return host.split(':')[0];
 });
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "should": "*",
     "connect-redis": "*",
     "github-flavored-markdown": "*",
-    "supertest": "0.0.1"
+    "supertest": "0.6.0"
   },
   "keywords": [
     "express",

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -72,8 +72,6 @@ describe('req', function(){
       it('should return the domain only', function(done){
         var app = express();
 
-        app.enable('trust proxy');
-
         app.use(function(req, res, next){
           res.send(req.host);
         });
@@ -86,8 +84,6 @@ describe('req', function(){
       it('should return the domain only even when there is no port', function(done){
         var app = express();
 
-        app.enable('trust proxy');
-
         app.use(function(req, res, next){
           res.send(req.host);
         });
@@ -99,8 +95,6 @@ describe('req', function(){
       })
       it('should return undefined when there is no Host header', function(done){
         var app = express();
-
-        app.enable('trust proxy');
 
         app.use(function(req, res, next){
           res.send(req.host);

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -7,12 +7,12 @@ describe('req', function(){
   describe('.host', function(){
     describe('when X-Forwarded-Host is present', function(){
       describe('when "trust proxy" is enabled', function(){
-        it('should return the forwarded header', function (done) {
+        it('should return the forwarded header', function (done){
           var app = express();
 
           app.enable('trust proxy');
 
-          app.use(function (req, res, next) {
+          app.use(function (req, res, next){
             res.send(req.host);
           });
 
@@ -22,12 +22,13 @@ describe('req', function(){
           .set('X-Forwarded-Host', 'example.com:80')
           .expect('example.com', done);
         })
-        it('should return the forwarded header even if empty', function (done) {
+
+        it('should return the forwarded header even if empty', function (done){
           var app = express();
 
           app.enable('trust proxy');
 
-          app.use(function (req, res, next) {
+          app.use(function (req, res, next){
             res.send(req.host);
           });
 
@@ -37,12 +38,13 @@ describe('req', function(){
           .set('X-Forwarded-Host', '')
           .expect('', done);
         })
-        it('should return null when there are no headers', function (done) {
+
+        it('should return null when there are no headers', function (done){
           var app = express();
 
           app.enable('trust proxy');
 
-          app.use(function (req, res, next) {
+          app.use(function (req, res, next){
             res.send(JSON.stringify(req.host));
           });
 
@@ -54,10 +56,10 @@ describe('req', function(){
       })
 
       describe('when "trust proxy" is disabled', function(){
-        it('should return null when there is no Host header', function (done) {
+        it('should return null when there is no Host header', function (done){
           var app = express();
 
-          app.use(function (req, res, next) {
+          app.use(function (req, res, next){
             res.send(JSON.stringify(req.host));
           });
 
@@ -67,10 +69,11 @@ describe('req', function(){
           .unset('Host')
           .expect('null', done);
         })
-        it('should return empty string when there is an empty Host header', function (done) {
+
+        it('should return empty string when there is an empty Host header', function (done){
           var app = express();
 
-          app.use(function (req, res, next) {
+          app.use(function (req, res, next){
             res.send(req.host);
           });
 
@@ -80,6 +83,7 @@ describe('req', function(){
           .set('Host', '')
           .expect('', done);
         })
+
         it('should return the actual host address', function(done){
           var app = express();
 
@@ -96,7 +100,7 @@ describe('req', function(){
       })
     })
 
-    describe('when X-Forwarded-Host is not present', function () {
+    describe('when X-Forwarded-Host is not present', function (){
       it('should return the domain only', function(done){
         var app = express();
 
@@ -109,6 +113,7 @@ describe('req', function(){
         .set('Host', 'example.com:8080')
         .expect('example.com', done);
       })
+
       it('should return the domain only even when there is no port', function(done){
         var app = express();
 
@@ -121,7 +126,8 @@ describe('req', function(){
         .set('Host', 'example.com')
         .expect('example.com', done);
       })
-      it('should return null when there is no Host header', function (done) {
+
+      it('should return null when there is no Host header', function (done){
         var app = express();
 
         app.use(function(req, res, next){
@@ -133,10 +139,11 @@ describe('req', function(){
         .unset('Host')
         .expect('null', done);
       })
-      it('should return empty string when there is an empty Host header', function (done) {
+
+      it('should return empty string when there is an empty Host header', function (done){
         var app = express();
 
-        app.use(function (req, res, next) {
+        app.use(function (req, res, next){
           res.send(req.host);
         });
 

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -3,8 +3,6 @@ var express = require('../')
   , request = require('./support/http');
 
 
-//TODO: Prevent superttest@0.5.0 from adding Host: headers on its own
-
 describe('req', function(){
   describe('.host', function(){
     describe('when X-Forwarded-Host is present', function(){
@@ -35,12 +33,13 @@ describe('req', function(){
 
           request(app)
           .get('/')
-          .expect(undefined, done);
+          .unset('Host')
+          .expect('', done);
         })
       })
 
       describe('when "trust proxy" is disabled', function(){
-        it('should return undefined when there is no Host header', function (done) {
+        it('should return empty string when there is no Host header', function (done) {
           var app = express();
 
           app.use(function (req, res, next) {
@@ -50,7 +49,8 @@ describe('req', function(){
           request(app)
           .get('/')
           .set('X-Forwarded-Host', 'example.com:80')
-          .expect(undefined, done);
+          .unset('Host')
+          .expect('', done);
         })
         it('should return the actual host address', function(done){
           var app = express();
@@ -93,7 +93,7 @@ describe('req', function(){
         .set('Host', 'example.com')
         .expect('example.com', done);
       })
-      it('should return undefined when there is no Host header', function(done){
+      it('should return empty string when there is no Host header', function (done) {
         var app = express();
 
         app.use(function(req, res, next){
@@ -102,7 +102,8 @@ describe('req', function(){
 
         request(app)
         .get('/')
-        .expect(undefined, done);
+        .unset('Host')
+        .expect('', done);
       })
     })
   })

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -2,6 +2,9 @@
 var express = require('../')
   , request = require('./support/http');
 
+
+//TODO: Prevent superttest@0.5.0 from adding Host: headers on its own
+
 describe('req', function(){
   describe('.host', function(){
     describe('when X-Forwarded-Host is present', function(){
@@ -21,9 +24,34 @@ describe('req', function(){
           .set('X-Forwarded-Host', 'example.com:80')
           .expect('example.com', done);
         })
+        it('should return undefined when there are no headers', function (done) {
+          var app = express();
+
+          app.enable('trust proxy');
+
+          app.use(function (req, res, next) {
+            res.send(req.host);
+          });
+
+          request(app)
+          .get('/')
+          .expect(undefined, done);
+        })
       })
 
       describe('when "trust proxy" is disabled', function(){
+        it('should return undefined when there is no Host header', function (done) {
+          var app = express();
+
+          app.use(function (req, res, next) {
+            res.send(req.host);
+          });
+
+          request(app)
+          .get('/')
+          .set('X-Forwarded-Host', 'example.com:80')
+          .expect(undefined, done);
+        })
         it('should return the actual host address', function(done){
           var app = express();
 

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -7,12 +7,12 @@ describe('req', function(){
   describe('.host', function(){
     describe('when X-Forwarded-Host is present', function(){
       describe('when "trust proxy" is enabled', function(){
-        it('should return the forwarded header', function(done){
+        it('should return the forwarded header', function (done) {
           var app = express();
 
           app.enable('trust proxy');
 
-          app.use(function(req, res, next){
+          app.use(function (req, res, next) {
             res.send(req.host);
           });
 
@@ -22,7 +22,7 @@ describe('req', function(){
           .set('X-Forwarded-Host', 'example.com:80')
           .expect('example.com', done);
         })
-        it('should return undefined when there are no headers', function (done) {
+        it('should return the forwarded header even if empty', function (done) {
           var app = express();
 
           app.enable('trust proxy');
@@ -33,13 +33,41 @@ describe('req', function(){
 
           request(app)
           .get('/')
-          .unset('Host')
+          .set('Host', 'proxy.example.com:80')
+          .set('X-Forwarded-Host', '')
           .expect('', done);
+        })
+        it('should return null when there are no headers', function (done) {
+          var app = express();
+
+          app.enable('trust proxy');
+
+          app.use(function (req, res, next) {
+            res.send(JSON.stringify(req.host));
+          });
+
+          request(app)
+          .get('/')
+          .unset('Host')
+          .expect('null', done);
         })
       })
 
       describe('when "trust proxy" is disabled', function(){
-        it('should return empty string when there is no Host header', function (done) {
+        it('should return null when there is no Host header', function (done) {
+          var app = express();
+
+          app.use(function (req, res, next) {
+            res.send(JSON.stringify(req.host));
+          });
+
+          request(app)
+          .get('/')
+          .set('X-Forwarded-Host', 'example.com:80')
+          .unset('Host')
+          .expect('null', done);
+        })
+        it('should return empty string when there is an empty Host header', function (done) {
           var app = express();
 
           app.use(function (req, res, next) {
@@ -49,7 +77,7 @@ describe('req', function(){
           request(app)
           .get('/')
           .set('X-Forwarded-Host', 'example.com:80')
-          .unset('Host')
+          .set('Host', '')
           .expect('', done);
         })
         it('should return the actual host address', function(done){
@@ -93,16 +121,28 @@ describe('req', function(){
         .set('Host', 'example.com')
         .expect('example.com', done);
       })
-      it('should return empty string when there is no Host header', function (done) {
+      it('should return null when there is no Host header', function (done) {
         var app = express();
 
         app.use(function(req, res, next){
-          res.send(req.host);
+          res.send(JSON.stringify(req.host));
         });
 
         request(app)
         .get('/')
         .unset('Host')
+        .expect('null', done);
+      })
+      it('should return empty string when there is an empty Host header', function (done) {
+        var app = express();
+
+        app.use(function (req, res, next) {
+          res.send(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', '')
         .expect('', done);
       })
     })

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -1,0 +1,87 @@
+
+var express = require('../')
+  , request = require('./support/http');
+
+describe('req', function(){
+  describe('.host', function(){
+    describe('when X-Forwarded-Host is present', function(){
+      describe('when "trust proxy" is enabled', function(){
+        it('should return the forwarded header', function(done){
+          var app = express();
+
+          app.enable('trust proxy');
+
+          app.use(function(req, res, next){
+            res.send(req.host);
+          });
+
+          request(app)
+          .get('/')
+          .set('Host', 'proxy.example.com:80')
+          .set('X-Forwarded-Host', 'example.com:80')
+          .expect('example.com', done);
+        })
+      })
+
+      describe('when "trust proxy" is disabled', function(){
+        it('should return the actual host address', function(done){
+          var app = express();
+
+          app.use(function(req, res, next){
+            res.send(req.host);
+          });
+
+          request(app)
+          .get('/')
+          .set('Host', 'proxy.example.com:80')
+          .set('X-Forwarded-Host', 'example.com:80')
+          .expect('proxy.example.com', done);
+        })
+      })
+    })
+
+    describe('when X-Forwarded-Host is not present', function () {
+      it('should return the domain only', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res, next){
+          res.send(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'example.com:8080')
+        .expect('example.com', done);
+      })
+      it('should return the domain only even when there is no port', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res, next){
+          res.send(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'example.com')
+        .expect('example.com', done);
+      })
+      it('should return undefined when there is no Host header', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res, next){
+          res.send(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .expect(undefined, done);
+      })
+    })
+  })
+})

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -19,11 +19,11 @@ describe('req', function(){
       })
     })
 
-    describe('otherwise', function () {
-      it('should return an empty array', function (done) {
+    describe('otherwise', function (){
+      it('should return an empty array', function (done){
         var app = express();
 
-        app.use(function (req, res) {
+        app.use(function (req, res){
           res.send(req.subdomains);
         });
 
@@ -34,11 +34,11 @@ describe('req', function(){
       })
     })
 
-    describe('when there is no Host header', function () {
-      it('should return an empty array', function (done) {
+    describe('when there is no Host header', function (){
+      it('should return an empty array', function (done){
         var app = express();
 
-        app.use(function (req, res, next) {
+        app.use(function (req, res, next){
           res.send(req.subdomains);
         });
 
@@ -48,11 +48,12 @@ describe('req', function(){
         .expect([], done);
       })
     })
-    describe('when there is an empty Host header', function () {
-      it('should return an empty array', function (done) {
+
+    describe('when there is an empty Host header', function (){
+      it('should return an empty array', function (done){
         var app = express();
 
-        app.use(function (req, res, next) {
+        app.use(function (req, res, next){
           res.send(req.subdomains);
         });
 
@@ -79,12 +80,12 @@ describe('req', function(){
           .expect('["com","example","sub","ferrets","tobi"]', done);
         })
 
-        describe('when there is no Host header', function () {
-          it('should return an empty array', function (done) {
+        describe('when there is no Host header', function (){
+          it('should return an empty array', function (done){
             var app = express();
             app.set('subdomain offset', 0);
 
-            app.use(function (req, res, next) {
+            app.use(function (req, res, next){
               res.send(req.subdomains);
             });
 
@@ -94,12 +95,13 @@ describe('req', function(){
             .expect([], done);
           })
         })
-        describe('when there is an empty Host header', function () {
-          it('should return an empty array', function (done) {
+
+        describe('when there is an empty Host header', function (){
+          it('should return an empty array', function (done){
             var app = express();
             app.set('subdomain offset', 0);
 
-            app.use(function (req, res, next) {
+            app.use(function (req, res, next){
               res.send(req.subdomains);
             });
 

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -19,11 +19,11 @@ describe('req', function(){
       })
     })
 
-    describe('otherwise', function(){
-      it('should return an empty array', function(done){
+    describe('otherwise', function () {
+      it('should return an empty array', function (done) {
         var app = express();
 
-        app.use(function(req, res){
+        app.use(function (req, res) {
           res.send(req.subdomains);
         });
 
@@ -31,6 +31,21 @@ describe('req', function(){
         .get('/')
         .set('Host', 'example.com')
         .expect('[]', done);
+      })
+    })
+
+    describe('when there is no Host header', function () {
+      it('should return an empty array', function (done) {
+        var app = express();
+
+        app.use(function (req, res, next) {
+          res.send(req.subdomains);
+        });
+
+        request(app)
+        .get('/')
+        .unset('Host')
+        .expect([], done);
       })
     })
 
@@ -48,6 +63,22 @@ describe('req', function(){
           .get('/')
           .set('Host', 'tobi.ferrets.sub.example.com')
           .expect('["com","example","sub","ferrets","tobi"]', done);
+        })
+
+        describe('when there is no Host header', function () {
+          it('should return an empty array', function (done) {
+            var app = express();
+            app.set('subdomain offset', 0);
+
+            app.use(function (req, res, next) {
+              res.send(req.subdomains);
+            });
+
+            request(app)
+            .get('/')
+            .unset('Host')
+            .expect([], done);
+          })
         })
       })
 

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -48,6 +48,20 @@ describe('req', function(){
         .expect([], done);
       })
     })
+    describe('when there is an empty Host header', function () {
+      it('should return an empty array', function (done) {
+        var app = express();
+
+        app.use(function (req, res, next) {
+          res.send(req.subdomains);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', '')
+        .expect([], done);
+      })
+    })
 
     describe('when subdomain offset is set', function(){
       describe('when subdomain offset is zero', function(){
@@ -77,6 +91,21 @@ describe('req', function(){
             request(app)
             .get('/')
             .unset('Host')
+            .expect([], done);
+          })
+        })
+        describe('when there is an empty Host header', function () {
+          it('should return an empty array', function (done) {
+            var app = express();
+            app.set('subdomain offset', 0);
+
+            app.use(function (req, res, next) {
+              res.send(req.subdomains);
+            });
+
+            request(app)
+            .get('/')
+            .set('Host', '')
             .expect([], done);
           })
         })

--- a/test/support/http.js
+++ b/test/support/http.js
@@ -1,2 +1,6 @@
 
 module.exports = require('supertest');
+module.exports.Test.prototype.unset = function (field) {
+  this.request().removeHeader(field);
+  return this;
+};


### PR DESCRIPTION
Right now, a request without a `Host:` header (nor `X-Forwarded-Host`) will throw an error every time I access `req.host`.

I fixed that to return an empty string.

This also affects `req.subdomains`.  
`"".split(".")` returns `[ "" ]`.  
However, since `subdomains` slices the initial portion of the host anyway, this will still correctly return `[]`.  (unless `subdomain offset` is `0`)
