### PR TITLE
Stop Express from crashing when used with SugarJS

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -260,7 +260,7 @@ Router.prototype.route = function(method, path, callbacks){
   });
 
   // add it
-  (this.map[method] = this.map[method] || []).push(route);
+  (this.map[method] = this.map.hasOwnProperty(method) && this.map[method] || []).push(route);
   return this;
 };
 


### PR DESCRIPTION
Express 3.0 currently breaks if you use SugarJS with it's `Object.extend();` feature. 
The problem occurs in `router/index.js` 

`(this.map[method] = this.map[method] || []).push(route);`

Because `merge` is a method supported by express and a function added to the Object prototype by Sugar, `this.map[method]` is mistakenly assigned the merge function from the prototype instead of the empty array.

Fix:
Use hasOwnProperty to check if the method exists, to fix mixups caused by merge function added to the Object prototype by Sugar
