### PR TITLE
removed some spaces from bin/express

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -334,7 +334,7 @@ function createApplicationAt(path) {
 
     // Session support
     app = app.replace('{sess}', program.sessions
-      ? eol + '  app.use(express.cookieParser(\'your secret here\'));' + eol + '  app.use(express.session());'
+      ? eol + 'app.use(express.cookieParser(\'your secret here\'));' + eol + 'app.use(express.session());'
       : '');
 
     // Template support


### PR DESCRIPTION
this is how it used to look:

``` js
app.use(express.methodOverride());
  app.use(express.cookieParser('your secret here'));
  app.use(express.session());
app.use(app.router);
```

this is how it looks now:

``` js
app.use(express.methodOverride());
app.use(express.cookieParser('your secret here'));
app.use(express.session());
app.use(app.router);
```
