### PR TITLE
Signed cookies can now accept numbers as values, like unsigned cookies

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -580,6 +580,7 @@ res.cookie = function(name, val, options){
   var secret = this.req.secret;
   var signed = options.signed;
   if (signed && !secret) throw new Error('connect.cookieParser("secret") required for signed cookies');
+  if ('number' == typeof val) val = val.toString();
   if ('object' == typeof val) val = 'j:' + JSON.stringify(val);
   if (signed) val = 's:' + sign(val, secret);
   if ('maxAge' in options) {


### PR DESCRIPTION
Fixed this issue:

```
var count = 1;
res.cookie('count', count); // works
res.cookie('count', count, { signed: true }); // throws
```

Details: https://github.com/visionmedia/express/issues/1588
