### PR TITLE
Removing dependency which is no longer supported

### DIFF
--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -5,7 +5,7 @@
 
 var express = require('../..')
   , fs = require('fs')
-  , md = require('github-flavored-markdown').parse;
+  , md = require('marked').parse;
 
 var app = module.exports = express();
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stylus": "*",
     "should": "*",
     "connect-redis": "*",
-    "github-flavored-markdown": "*",
+    "marked": "*",
     "supertest": "0.6.0"
   },
   "keywords": [


### PR DESCRIPTION
Removing github-flavored-markdown as a dependency as it is no longer supported by Isaac.  Switch to use marked instead, as it is both supported and includes the MIT license.
