### PR TITLE
package.json: remove qs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "methods": "0.0.1",
     "send": "0.1.0",
     "cookie-signature": "1.0.1",
-    "debug": "*",
-    "qs": "0.6.1"
+    "debug": "*"
   },
   "devDependencies": {
     "ejs": "*",


### PR DESCRIPTION
doesn't seem to be used anywhere in Express. it is, however, used in Connect and should be updated there. right now, it uses an older version.
