### PR TITLE
Added `param` parameter to `res.format` that checks for the `req.params.format` variable in order to determine the requested content-type.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -9,6 +9,7 @@ var http = require('http')
   , sign = require('cookie-signature').sign
   , normalizeType = require('./utils').normalizeType
   , normalizeTypes = require('./utils').normalizeTypes
+  , accepts = require('./utils').accepts
   , etag = require('./utils').etag
   , statusCodes = http.STATUS_CODES
   , cookie = require('cookie')
@@ -402,6 +403,12 @@ res.type = function(type){
  * is invoked, otherwise the first match is used. When
  * no match is performed the server responds with
  * 406 "Not Acceptable".
+ * 
+ * When the `param` flag is set, this method will also check
+ * for its contents (`param="json"`). When set to `true`, it
+ * checks for the contents of `req.params.format`. You can
+ * add routes such as `versions.:format?` that override the
+ * "Accept" header.
  *
  * Content-Type is set for you, however if you choose
  * you may alter this within the callback using `res.type()`
@@ -445,11 +452,12 @@ res.type = function(type){
  * instead.
  *
  * @param {Object} obj
+ * @param {Boolean} param
  * @return {ServerResponse} for chaining
  * @api public
  */
 
-res.format = function(obj){
+res.format = function(obj, param){
   var req = this.req
     , next = req.next;
 
@@ -458,6 +466,9 @@ res.format = function(obj){
   var keys = Object.keys(obj);
 
   var key = req.accepts(keys);
+  
+  if (param && (param !== true || req.params.format))
+    key = accepts(keys, [normalizeType(param === true ? req.params.format : param).value].join(','));
 
   this.set('Vary', 'Accept');
 


### PR DESCRIPTION
Works exactly the same when no `param` is set. When set to `true`, tries to override the requested content-type by using `req.params.format`. When set to a string, e.g. either `json` or `application/json`, it tries to override the requested content-type by using that string.
