### PR TITLE
Adds a json prefix setting.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -182,7 +182,13 @@ res.json = function(obj){
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
+  var prefix = app.get('json prefix');
   var body = JSON.stringify(obj, replacer, spaces);
+
+  // prefix
+  if (prefix) {
+    body = prefix + body;
+  }
 
   // content-type
   this.charset = this.charset || 'utf-8';

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -181,4 +181,21 @@ describe('res', function(){
       done();
     })
   })
+
+  it('should contain the prefix when set', function(done){
+    var app = express();
+
+    app.set('json prefix', ')]}\',\n');
+
+    app.get('/', function(req, res){
+      res.json({ hello: 'world' });
+    });
+
+    request(app)
+    .get('/')
+    .end(function(err, res){
+      res.text.should.equal(')]}\',\n{"hello":"world"}');
+      done();
+    })
+  });
 })


### PR DESCRIPTION
Adds a new optional setting called `json prefix` for prefixing a value to the body of json responses in order to prevent [json hijacking](http://haacked.com/archive/2009/06/25/json-hijacking.aspx).

Could technically be external middleware, but seems simple enough to live inside `.json()` like the rest of the json settings.
