### PR TITLE
Refactor merging of options in app.render

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -455,7 +455,8 @@ app.del = app.delete;
 
 app.render = function(name, options, fn){
   var self = this
-    , opts = {}
+    // use app.locals as the base for opts
+    , opts = Object.create(this.locals);
     , cache = this.cache
     , engines = this.engines
     , view;
@@ -464,9 +465,6 @@ app.render = function(name, options, fn){
   if ('function' == typeof options) {
     fn = options, options = {};
   }
-
-  // merge app.locals
-  utils.merge(opts, this.locals);
 
   // merge options._locals
   if (options._locals) utils.merge(opts, options._locals);


### PR DESCRIPTION
Since opts is a newly created object, why not have it extend the this.locals instead of merging it?
