### PR TITLE
Fixes indentation for css engines when using express to scaffold an application

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -323,10 +323,10 @@ function createApplicationAt(path) {
     // CSS Engine support
     switch (program.css) {
       case 'less':
-        app = app.replace('{css}', eol + '  app.use(require(\'less-middleware\')({ src: __dirname + \'/public\' }));');
+        app = app.replace('{css}', eol + 'app.use(require(\'less-middleware\')({ src: __dirname + \'/public\' }));');
         break;
       case 'stylus':
-        app = app.replace('{css}', eol + '  app.use(require(\'stylus\').middleware(__dirname + \'/public\'));');
+        app = app.replace('{css}', eol + 'app.use(require(\'stylus\').middleware(__dirname + \'/public\'));');
         break;
       default:
         app = app.replace('{css}', '');


### PR DESCRIPTION
Generating an express application with `express -c less` generates an app.js file like this

```
...
app.use(app.router);
  app.use(require('less-middleware')({ src: __dirname + '/public' }));
app.use(express.static(path.join(__dirname, 'public')));
...
```

After applying this fix the indentation for the css middleware is fixed and the app.js flile will look like this:

```
...
app.use(app.router);
app.use(require('less-middleware')({ src: __dirname + '/public' }));
app.use(express.static(path.join(__dirname, 'public')));
...
```
