### PR TITLE
Throw a meaningful error when there is no default engine

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -38,6 +38,7 @@ function View(name, options) {
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
   var ext = this.ext = extname(name);
+  if (!ext && !this.defaultEngine) throw new Error('No default engine was specified and no extension was provided.');
   if (!ext) name += (ext = this.ext = ('.' != this.defaultEngine[0] ? '.' : '') + this.defaultEngine);
   this.engine = engines[ext] || (engines[ext] = require(ext.slice(1)).__express);
   this.path = this.lookup(name);


### PR DESCRIPTION
See https://github.com/visionmedia/jade/issues/1023 for an example of the current lack of helpful error messages biting people (@lbj96347).

I've run into this myself before as well at some point.
