### PR TITLE
Fixed issue with callback querystring failure

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -234,6 +234,7 @@ res.jsonp = function(obj){
 
   // jsonp
   if (callback) {
+    if (callback instanceof Array) callback = callback[0];
     this.set('Content-Type', 'text/javascript');
     var cb = callback.replace(/[^\[\]\w$.]/g, '');
     body = cb + ' && ' + cb + '(' + body + ');';


### PR DESCRIPTION
express/lib/response.js:238 failure when querystring contains > 1 callback function reference.

It is not uncommon for callback to appear in the querystring twice (albeit on accident) if jQuery's jsonp signature (e.g. jsonpCallback) is used incorrectly in conjunction with a manual querystring setting. The app should not fail just because of a querystring issue. This fixes that situation.

My test querystring which crashed the Node instance was "?callback=go&callback=go".
