### PR TITLE
res.jsonp() fails when response object is undefined

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -223,7 +223,8 @@ res.jsonp = function(obj){
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(obj, replacer, spaces)
+  var body = ('undefined' == typeof obj) ? '' :
+    JSON.stringify(obj, replacer, spaces)
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
   var callback = this.req.query[app.get('jsonp callback name')];

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -233,4 +233,22 @@ describe('res', function(){
       })
     })
   })
+
+  describe('.jsonp()', function(){
+    it('should respond empty', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonp();
+      });
+
+      request(app)
+      .get('/?callback=something')
+      .end(function(err, res){
+        res.headers.should.have.property('content-type', 'text/javascript; charset=utf-8');
+        res.text.should.equal('something && something();');
+        done();
+      })
+    })
+  })
 })


### PR DESCRIPTION
This patch allows res.jsonp() to respond an empty object.

https://github.com/visionmedia/express/issues/1644
