### PR TITLE
req.secure: check first comma-delimited protocol

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -348,7 +348,7 @@ req.__defineGetter__('protocol', function(){
   return this.connection.encrypted
     ? 'https'
     : trustProxy
-      ? (this.get('X-Forwarded-Proto') || 'http')
+      ? ((this.get('X-Forwarded-Proto') || '').split(',')[0] || 'http')
       : 'http';
 });
 


### PR DESCRIPTION
Currently, my request headers look like this:

``` js
  'x-forwarded-for': '24.205.165.76,127.0.0.1',
  'x-forwarded-proto': 'https,http',
  'x-forwarded-port': '32220' 
```

But this doesn't work with `req.secure` as it currently assumes there's only one proxy. 

Also, there are no tests for `req.secure`, so I don't know how to add a test.
