### PR TITLE
Adds support for multiple view directories

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -34,7 +34,7 @@ module.exports = View;
 function View(name, options) {
   options = options || {};
   this.name = name;
-  this.root = options.root;
+  this.roots = Array.isArray(options.root) ? options.root : [options.root];
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
   var ext = this.ext = extname(name);
@@ -47,21 +47,26 @@ function View(name, options) {
 /**
  * Lookup view by the given `path`
  *
- * @param {String} path
+ * @param {String} filename
  * @return {String}
  * @api private
  */
 
-View.prototype.lookup = function(path){
+View.prototype.lookup = function(filename){
   var ext = this.ext;
 
-  // <path>.<engine>
-  if (!utils.isAbsolute(path)) path = join(this.root, path);
-  if (exists(path)) return path;
+  for (var key in this.roots) {
+    var root = this.roots[key];
+    var path = filename;
 
-  // <path>/index.<engine>
-  path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
+    // <path>.<engine>
+    if (!utils.isAbsolute(path)) path = join(root, path);
+    if (exists(path)) return path;
+
+    // <path>/index.<engine>
+    path = join(dirname(path), basename(path, ext), 'index' + ext);
+    if (exists(path)) return path;
+  }
 };
 
 /**

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -28,6 +28,23 @@ describe('app', function(){
       })
     })
 
+    it('should support multiple "views"', function(done){
+      var app = express();
+
+      app.set('views', [__dirname + '/fixtures', __dirname + '/fixtures/blog']);
+      app.set('view engine', 'jade');
+
+      app.render('post', function(err, str){
+        if (err) return done(err);
+        str.should.equal('<h1>blog post</h1>');
+        done();
+      })
+
+      app.use(function(req, res){
+        res.render('post');
+      });
+    })
+
     it('should expose app.locals', function(done){
       var app = express();
 

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -6,7 +6,7 @@ describe('res', function(){
   describe('.render(name)', function(){
     it('should support absolute paths', function(done){
       var app = express();
-  
+
       app.locals.user = { name: 'tobi' };
 
       app.use(function(req, res){
@@ -17,10 +17,10 @@ describe('res', function(){
       .get('/')
       .expect('<p>tobi</p>', done);
     })
-    
+
     it('should support absolute paths with "view engine"', function(done){
       var app = express();
-  
+
       app.locals.user = { name: 'tobi' };
       app.set('view engine', 'jade');
 
@@ -33,9 +33,24 @@ describe('res', function(){
       .expect('<p>tobi</p>', done);
     })
 
+    it('should support multiple "views"', function(done){
+      var app = express();
+
+      app.set('views', [__dirname + '/fixtures', __dirname + '/fixtures/blog']);
+      app.set('view engine', 'jade');
+
+      app.use(function(req, res){
+        res.render('post');
+      });
+
+      request(app)
+      .get('/')
+      .expect('<h1>blog post</h1>', done);
+    })
+
     it('should expose app.locals', function(done){
       var app = express();
-  
+
       app.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
@@ -47,32 +62,32 @@ describe('res', function(){
       .get('/')
       .expect('<p>tobi</p>', done);
     })
-  
+
     it('should support index.<engine>', function(done){
       var app = express();
-  
+
       app.set('views', __dirname + '/fixtures');
       app.set('view engine', 'jade');
 
       app.use(function(req, res){
         res.render('blog/post');
       });
-      
+
       request(app)
       .get('/')
       .expect('<h1>blog post</h1>', done);
     })
-  
+
     describe('when an error occurs', function(){
       it('should next(err)', function(done){
         var app = express();
-  
+
         app.set('views', __dirname + '/fixtures');
 
         app.use(function(req, res){
           res.render('user.jade');
         });
-        
+
         app.use(function(err, req, res, next){
           res.end(err.message);
         });
@@ -82,11 +97,11 @@ describe('res', function(){
         .expect(/user is not defined/, done);
       })
     })
-  
+
     describe('when "view engine" is given', function(){
       it('should render the template', function(done){
         var app = express();
-  
+
         app.set('view engine', 'jade');
         app.set('views', __dirname + '/fixtures');
 
@@ -104,9 +119,9 @@ describe('res', function(){
   describe('.render(name, option)', function(){
     it('should render the template', function(done){
       var app = express();
-  
+
       app.set('views', __dirname + '/fixtures');
-  
+
       var user = { name: 'tobi' };
 
       app.use(function(req, res){
@@ -117,10 +132,10 @@ describe('res', function(){
       .get('/')
       .expect('<p>tobi</p>', done);
     })
-  
+
     it('should expose app.locals', function(done){
       var app = express();
-    
+
       app.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
@@ -132,10 +147,10 @@ describe('res', function(){
       .get('/')
       .expect('<p>tobi</p>', done);
     })
-    
+
     it('should expose res.locals', function(done){
       var app = express();
-    
+
       app.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
@@ -147,10 +162,10 @@ describe('res', function(){
       .get('/')
       .expect('<p>tobi</p>', done);
     })
-    
+
     it('should give precedence to res.locals over app.locals', function(done){
       var app = express();
-    
+
       app.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
@@ -166,10 +181,10 @@ describe('res', function(){
 
     it('should give precedence to res.render() locals over res.locals', function(done){
       var app = express();
-    
+
       app.set('views', __dirname + '/fixtures');
       var jane = { name: 'jane' };
-    
+
       app.use(function(req, res){
         res.locals.user = { name: 'tobi' };
         res.render('user.jade', { user: jane });
@@ -179,14 +194,14 @@ describe('res', function(){
       .get('/')
       .expect('<p>jane</p>', done);
     })
-    
+
     it('should give precedence to res.render() locals over app.locals', function(done){
       var app = express();
-    
+
       app.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
       var jane = { name: 'jane' };
-    
+
       app.use(function(req, res){
         res.render('user.jade', { user: jane });
       });

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -33,6 +33,21 @@ describe('res', function(){
       .expect('<p>tobi</p>', done);
     })
 
+    it('should support multiple "views"', function(done){
+      var app = express();
+
+      app.set('views', [__dirname + '/fixtures', __dirname + '/fixtures/blog']);
+      app.set('view engine', 'jade');
+
+      app.use(function(req, res){
+        res.render('post');
+      });
+
+      request(app)
+      .get('/')
+      .expect('<h1>blog post</h1>', done);
+    })
+
     it('should expose app.locals', function(done){
       var app = express();
   


### PR DESCRIPTION
Adds support for multiple view directories. Backwards compatible and allows you to go `app.set("views", ["views", "views2"]);`. This is especially handy for modular applications that have multiple view directories.
