### PR TITLE
Add support for multiple view directories

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -34,7 +34,7 @@ module.exports = View;
 function View(name, options) {
   options = options || {};
   this.name = name;
-  this.root = options.root;
+  this.roots = Array.isArray(options.root) ? options.root : [options.root];
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
   var ext = this.ext = extname(name);
@@ -47,21 +47,26 @@ function View(name, options) {
 /**
  * Lookup view by the given `path`
  *
- * @param {String} path
+ * @param {String} filename
  * @return {String}
  * @api private
  */
 
-View.prototype.lookup = function(path){
+View.prototype.lookup = function(filename){
   var ext = this.ext;
 
-  // <path>.<engine>
-  if (!utils.isAbsolute(path)) path = join(this.root, path);
-  if (exists(path)) return path;
+  for (var key in this.roots) {
+    var root = this.roots[key];
+    var path = filename;
 
-  // <path>/index.<engine>
-  path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
+    // <path>.<engine>
+    if (!utils.isAbsolute(path)) path = join(root, path);
+    if (exists(path)) return path;
+
+    // <path>/index.<engine>
+    path = join(dirname(path), basename(path, ext), 'index' + ext);
+    if (exists(path)) return path;
+  }
 };
 
 /**

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -28,6 +28,23 @@ describe('app', function(){
       })
     })
 
+    it('should support multiple "views"', function(done){
+      var app = express();
+
+      app.set('views', [__dirname + '/fixtures', __dirname + '/fixtures/blog']);
+      app.set('view engine', 'jade');
+
+      app.render('post', function(err, str){
+        if (err) return done(err);
+        str.should.equal('<h1>blog post</h1>');
+        done();
+      })
+
+      app.use(function(req, res){
+        res.render('post');
+      });
+    })
+
     it('should expose app.locals', function(done){
       var app = express();
 

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -18,6 +18,21 @@ describe('res', function(){
       .expect('<p>tobi</p>', done);
     })
     
+    it('should support multiple "views"', function(done){
+      var app = express();
+
+      app.set('views', [__dirname + '/fixtures', __dirname + '/fixtures/blog']);
+      app.set('view engine', 'jade');
+
+      app.use(function(req, res){
+        res.render('post');
+      });
+
+      request(app)
+      .get('/')
+      .expect('<h1>blog post</h1>', done);
+    })
+
     it('should support absolute paths with "view engine"', function(done){
       var app = express();
   


### PR DESCRIPTION
Adds support for multiple view directories. Backwards compatible and to add multiple directories you just go `app.set("views", ["views", "views2"]);`. This is especially handy for modular applications that have multiple view directories.

Sorry about the previous closed pull request, never made one before and I screwed things up.
