### PR TITLE
Fixing issue with wrong filename in content-disposition when using res.download

### DIFF
--- a/examples/downloads/app.js
+++ b/examples/downloads/app.js
@@ -10,7 +10,21 @@ app.get('/', function(req, res){
   res.send('<ul>'
     + '<li>Download <a href="/files/amazing.txt">amazing.txt</a>.</li>'
     + '<li>Download <a href="/files/missing.txt">missing.txt</a>.</li>'
+    + '<li>Download <a href="/files/1">test_žćčđš.txt</a>.</li>'
+    + '<li>Download <a href="/files/2">amazing.txt as 你好.txt</a>.</li>'
     + '</ul>');
+});
+
+app.get('/files/1', function(req, res, next){
+  var path = __dirname + '/files/test_žćčđš.txt';
+
+  res.download(path);
+});
+
+app.get('/files/2', function(req, res, next){
+  var path = __dirname + '/files/amazing.txt';
+
+  res.download(path, '你好.txt');
 });
 
 // /files/* is accessed via req.params[0]
@@ -21,6 +35,9 @@ app.get('/files/:file(*)', function(req, res, next){
 
   res.download(path);
 });
+
+
+
 
 // error handling middleware. Because it's
 // below our routes, you will be able to

--- a/examples/downloads/files/test_žćčđš.txt
+++ b/examples/downloads/files/test_žćčđš.txt
@@ -1,0 +1,1 @@
+very strange filename

--- a/lib/response.js
+++ b/lib/response.js
@@ -330,7 +330,7 @@ res.sendfile = function(path, options, fn){
   }
 
   // transfer
-  var file = send(req, path);
+  var file = send(req, path, {encoding: 'utf8'});
   if (options.root) file.root(options.root);
   file.maxage(options.maxAge || 0);
   file.on('error', error);

--- a/test/acceptance/downloads.js
+++ b/test/acceptance/downloads.js
@@ -31,3 +31,28 @@ describe('downloads', function(){
     })
   })
 })
+
+  describe('GET /files/1', function(){
+    it('should have a download header', function(done){
+      request(app)
+      .get('/files/1')
+      .end(function(err, res){
+        res.status.should.equal(200);
+        res.headers.should.have.property('content-disposition', 'attachment; filename="test_žćčđš.txt"')
+        done()
+      })
+    })
+  })
+
+
+  describe('GET /files/2', function(){
+    it('should have a download header', function(done){
+      request(app)
+      .get('/files/2')
+      .end(function(err, res){
+        res.status.should.equal(200);
+        res.headers.should.have.property('content-disposition', 'attachment; filename="你好.txt"')
+        done()
+      })
+    })
+  })  

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -41,6 +41,26 @@ describe('res', function(){
     })
   })
 
+
+  describe('.download(path, filename)', function(){
+    it('should provide an alternate filename привет', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.download('test/fixtures/user.html', 'привет');
+      });
+
+      request(app)
+      .get('/')
+      .end(function(err, res){
+        res.should.have.header('Content-Type', 'text/html; charset=UTF-8');
+        res.should.have.header('Content-Disposition', 'attachment; filename="привет"');
+        done();
+      });
+    })
+  })
+
+
   describe('.download(path, fn)', function(){
     it('should invoke the callback', function(done){
       var app = express()


### PR DESCRIPTION
WARNING: fixes filename but file is not readable

res.download(file, 'test_žćčđš.txt') would set wrong filename in content-disposition.

This bug occurs only when streaming some file. 
