### PR TITLE
Script to automate setting+tagging version name

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Common variables used by all shell scripts
+
+PROJECT_NAME=$(grep name package.json| awk -F '"' '{print $4}')
+VERSION_NAME=$(grep version package.json| awk -F '"' '{print $4}')
+VERSION_TAG="v$VERSION_NAME"

--- a/bin/version_tag
+++ b/bin/version_tag
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# This script automates the process of setting the version name both in the
+# package.json file and the code repository. Just edit the package.json file
+# without committing/pushing anything and then run this script that will take
+# care of the other needed operations.
+
+. bin/common
+
+TAG_EXISTS=$(git tag|grep -E "^$VERSION_TAG$")
+if [ -n "$TAG_EXISTS" ]; then
+    echo """
+Version $VERSION_NAME (as stated in \`package.json\` file) already tagged
+in the Git repository.
+"""
+    exit
+fi
+
+echo """
+Do you want to create a tag in the Git repository for version $VERSION_NAME
+as stated in \`package.json\` file? (Y/n)
+
+Note: The version name must follow Semantic Versioning Specification
+http://semver.org/ (for example 3.3.4, 4.1.0-beta.1, 4.1.0-pre.2.0)
+""" 1>&2
+read DO_TAG
+if [ ! $DO_TAG = 'Y' ] && [ ! $DO_TAG = '' ]; then
+    exit
+fi
+
+git add package.json
+git commit -m"Releasing version $VERSION_NAME" package.json || true
+git tag -a "$VERSION_TAG" -m"$VERSION_TAG"
+git push origin master
+git push --tags origin master


### PR DESCRIPTION
Hello,

At the moment, while Express version 3.3.2 and version 3.3.3 are out in the npm registry, those versions are not tagged in the Git repository. Tags may be "annoying to maintain" (please note the official quote ;-) ) when they are not part of an automated process.

So here I propose you a script to ease version name bump and tag.

Please note that this script enforces the SemVerTag sub-spec (because this is the convention I use for the projects I work on and from where this script is coming):
version names are like "3.3.4" (semver compliant) and that tag names are like "v3.3.4".

Also note that recently the SemVerTag sub-spec has been removed from the SemVer spec but only to have the SemVer reach the widest possible consensus https://github.com/mojombo/semver.org/issues/42 but SemVerTag is still relevant and useful cf. http://stackoverflow.com/questions/2006265/is-there-an-standard-naming-convention-for-git-tags

If following SemVerTag is not what you want, I can modify the script so that version names and version tags are of the same form. Please let me know.

Best, (and thank you for Express!)
