### PR TITLE
removed unnecessary require statement

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -4,8 +4,7 @@
  * Module dependencies.
  */
 
-var exec = require('child_process').exec
-  , program = require('commander')
+var program = require('commander')
   , mkdirp = require('mkdirp')
   , pkg = require('../package.json')
   , version = pkg.version


### PR DESCRIPTION
I was reviewing the bin/express script and noticed that it doesn't seem to use exec anywhere even though its being required in. The test are still passing after the change, although I'm not sure if this script is covered by any test.
