### PR TITLE
add Router.all() method

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -264,6 +264,15 @@ Router.prototype.route = function(method, path, callbacks){
   return this;
 };
 
+Router.prototype.all = function(path) {
+  var self = this;
+  var args = [].slice.call(arguments);
+  methods.forEach(function(method){
+      self.route.apply(self, [method].concat(args));
+  });
+  return this;
+};
+
 methods.forEach(function(method){
   Router.prototype[method] = function(path){
     var args = [method].concat([].slice.call(arguments));


### PR DESCRIPTION
Similar to app.all() but specifically for attaching handlers to all
methods under a standalone router. This is useful for isolating routers
that require "middleware" like features for all routes managed by the
router.
