### PR TITLE
Add application setting to disable ETag (again)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -46,6 +46,7 @@ app.init = function(){
 app.defaultConfiguration = function(){
   // default settings
   this.enable('x-powered-by');
+  this.enable('etag');
   this.set('env', process.env.NODE_ENV || 'development');
   this.set('subdomain offset', 2);
   debug('booting in %s mode', this.get('env'));

--- a/lib/response.js
+++ b/lib/response.js
@@ -82,6 +82,9 @@ res.send = function(body){
   var head = 'HEAD' == req.method;
   var len;
 
+  // settings
+  var app = this.app;
+
   // allow status / body
   if (2 == arguments.length) {
     // res.send(body, status) backwards compat
@@ -128,7 +131,7 @@ res.send = function(body){
 
   // ETag support
   // TODO: W/ support
-  if (len > 1024 && 'GET' == req.method) {
+  if (app.settings['etag'] && len > 1024 && 'GET' == req.method) {
     if (!this.get('ETag')) {
       this.set('ETag', etag(body));
     }

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -318,4 +318,62 @@ describe('res', function(){
     .get('/?callback=foo')
     .expect('{"foo":"bar"}', done);
   })
+
+  describe('"etag" setting', function(){
+    describe('when enabled', function(){
+      it('should send ETag ', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          var str = Array(1024 * 2).join('-');
+          res.send(str);
+        });
+
+        request(app)
+        .get('/')
+        .end(function(err, res){
+          res.headers.should.have.property('etag', '"-1498647312"');
+          done();
+        });
+      });
+    });
+
+    describe('when disabled', function(){
+      it('should send no ETag', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          var str = Array(1024 * 2).join('-');
+          res.send(str);
+        });
+
+        app.disable('etag');
+
+        request(app)
+        .get('/')
+        .end(function(err, res){
+          res.headers.should.not.have.property('etag');
+          done();
+        });
+      });
+
+      it('should send ETag when manually set', function(done){
+        var app = express();
+
+        app.disable('etag');
+
+        app.use(function(req, res){
+          res.set('etag', 1);
+          res.send(200);
+        });
+
+        request(app)
+        .get('/')
+        .end(function(err, res){
+          res.headers.should.have.property('etag');
+          done();
+        });
+      });
+    });
+  })
 })


### PR DESCRIPTION
It's updated to upstream duplicate of the old Pull Request #1421.

Old Pull Request description:

> Add application setting app.disable('etag'); to disable ETag. Manual ETag addition via res.set('etag', 'somestring);' still works.
> 
> Please, check this feature.
> 
> Btw, it's my first experience in Express and JS BDD, so, please, if there are any issues or mistakes (for ex., I am not sure about proper spec placement), let me know, maybe I'll can fix 'em.
> 
> Thanks!

@visionmedia, sorry for such a long delay, I totally forgot about this pull request and that I need to sync it with upstream. I hope everything is good now.
