### PR TITLE
Added UTF-8 charset default to res.json method.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -185,6 +185,7 @@ res.json = function(obj){
   var body = JSON.stringify(obj, replacer, spaces);
 
   // content-type
+  this.charset = this.charset || 'utf-8';
   this.get('Content-Type') || this.set('Content-Type', 'application/json');
 
   return this.send(body);


### PR DESCRIPTION
`res.json` malfunctioned when JSON contained UTF-8 characters. For example

```
res.json({ 'ąčęėįšųūž': 'ąčęėįšųūž' })
```

would be treated in Chrome like

```
{
  "Ä…ÄÄ™Ä—Ä¯Å¡Å³Å«Å¾": "Ä…ÄÄ™Ä—Ä¯Å¡Å³Å«Å¾"
}
```

It can be fixed by setting charset BEFORE setting content type so that `Content-Type` header would be set to `application/json; charset=utf-8` instead of `application/json`. This is pretty much the same what `res.send` does with a string - `Content-Type` header also gets the UTF-8 charset: `text/html; charset=utf-8`.
