### PR TITLE
Don't add charset to Content-Type header when using res.jsonp() 

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -231,12 +231,12 @@ res.jsonp = function(obj){
   var callback = this.req.query[app.get('jsonp callback name')];
 
   // content-type
-  this.charset = this.charset || 'utf-8';
   this.set('Content-Type', 'application/json');
 
   // jsonp
   if (callback) {
     if (callback instanceof Array) callback = callback[0];
+    this.charset = this.charset || 'utf-8';
     this.set('Content-Type', 'text/javascript');
     var cb = callback.replace(/[^\[\]\w$.]/g, '');
     body = cb + ' && ' + cb + '(' + body + ');';

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "ejs": "*",
-    "mocha": "*",
+    "mocha": "1.9.0",
     "jade": "0.30.0",
     "hjs": "*",
     "stylus": "*",

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -98,7 +98,7 @@ describe('res', function(){
         request(app)
         .get('/')
         .end(function(err, res){
-          res.headers.should.have.property('content-type', 'application/json; charset=utf-8');
+          res.headers.should.have.property('content-type', 'application/json');
           res.text.should.equal('null');
           done();
         })
@@ -116,7 +116,7 @@ describe('res', function(){
         request(app)
         .get('/')
         .end(function(err, res){
-          res.headers.should.have.property('content-type', 'application/json; charset=utf-8');
+          res.headers.should.have.property('content-type', 'application/json');
           res.text.should.equal('["foo","bar","baz"]');
           done();
         })
@@ -134,7 +134,7 @@ describe('res', function(){
         request(app)
         .get('/')
         .end(function(err, res){
-          res.headers.should.have.property('content-type', 'application/json; charset=utf-8');
+          res.headers.should.have.property('content-type', 'application/json');
           res.text.should.equal('{"name":"tobi"}');
           done();
         })
@@ -208,7 +208,7 @@ describe('res', function(){
       .get('/')
       .end(function(err, res){
         res.statusCode.should.equal(201);
-        res.headers.should.have.property('content-type', 'application/json; charset=utf-8');
+        res.headers.should.have.property('content-type', 'application/json');
         res.text.should.equal('{"id":1}');
         done();
       })
@@ -227,7 +227,7 @@ describe('res', function(){
       .get('/')
       .end(function(err, res){
         res.statusCode.should.equal(201);
-        res.headers.should.have.property('content-type', 'application/json; charset=utf-8');
+        res.headers.should.have.property('content-type', 'application/json');
         res.text.should.equal('{"id":1}');
         done();
       })


### PR DESCRIPTION
The charset was removed from `res.json()` in visionmedia/express#1631 - this PR removes it from `res.jsonp` too.
