### PR TITLE
Updated Util.isAbsolute(path) to return true for Azure absolute paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,6 +54,7 @@ exports.locals = function(obj){
 exports.isAbsolute = function(path){
   if ('/' == path[0]) return true;
   if (':' == path[1] && '\\' == path[2]) return true;
+  if ('\\\\' == path.substring(0, 2)) return true; // Microsoft Azure absolute path
 };
 
 /**


### PR DESCRIPTION
- Azure absolute paths look like \\ip_address\volume\guid\guid\site\wwwroot...file.js.
  Changed Util.isAbsolute to return true for paths that start with two backslashes.
