### PR TITLE
Avoid express overwriting you package.json file if it already exists

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -364,8 +364,12 @@ function createApplicationAt(path) {
         }
     }
 
-    write(path + '/package.json', JSON.stringify(pkg, null, 2));
-    write(path + '/app.js', app);
+    if(!fs.exists(path + '/package.json')){
+      write(path + '/package.json', JSON.stringify(pkg, null, 2));
+    }
+    if(!fs.exists(path + '/app.js')){
+      write(path + '/app.js', app);
+    }
   });
 }
 
@@ -394,6 +398,7 @@ function write(path, str) {
   fs.writeFile(path, str);
   console.log('   \x1b[36mcreate\x1b[0m : ' + path);
 }
+
 
 /**
  * Mkdir -p.


### PR DESCRIPTION
If you start a new project by running `npm init` and then thinks you want a express boilerplate and writes `express` and init in the current directory, your new package.json will be overwritten by express, because it does not look for the file first.

I thought about making a function similar to write(), so it would be exists(), but the exists command is already so short, and then you would have to pass the write command as a callback, that would make it more messy.

Was i right?
