### PR TITLE
Integrate XRegExp named capture groups

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,7 +293,9 @@ exports.escape = function(html) {
 exports.pathRegexp = function(path, keys, sensitive, strict) {
   if (toString.call(path) == '[object RegExp]') {
     if(path.xregexp)
-      Array.prototype.push.apply(keys, path.xregexp.captureNames);
+      Array.prototype.push.apply(keys.map(function(key) {
+        return {name: key};
+      }), path.xregexp.captureNames);
     return path;
   }
   if (Array.isArray(path)) path = '(' + path.join('|') + ')';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -292,7 +291,11 @@ exports.escape = function(html) {
  */
 
 exports.pathRegexp = function(path, keys, sensitive, strict) {
-  if (toString.call(path) == '[object RegExp]') return path;
+  if (toString.call(path) == '[object RegExp]') {
+    if(path.xregexp)
+      Array.prototype.push.apply(keys, path.xregexp.captureNames);
+    return path;
+  }
   if (Array.isArray(path)) path = '(' + path.join('|') + ')';
   path = path
     .concat(strict ? '' : '/?')


### PR DESCRIPTION
When path is an [XRegExp](http://xregexp.com/), populate route.keys with its capture group names
