### PR TITLE
Removed Buffer call with 'binary' encoding option in auth example.

### DIFF
--- a/examples/auth/pass.js
+++ b/examples/auth/pass.js
@@ -32,7 +32,7 @@ var iterations = 12000;
 exports.hash = function (pwd, salt, fn) {
   if (3 == arguments.length) {
     crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
-      fn(err, (new Buffer(hash, 'binary')).toString('base64'));
+      fn(err, hash.toString('base64'));
     });
   } else {
     fn = salt;
@@ -41,7 +41,7 @@ exports.hash = function (pwd, salt, fn) {
       salt = salt.toString('base64');
       crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
         if (err) return fn(err);
-        fn(null, salt, (new Buffer(hash, 'binary')).toString('base64'));
+        fn(null, salt, hash.toString('base64'));
       });
     });
   }


### PR DESCRIPTION
According to the Node.js documentation for Buffer objects regarding the
'binary' encoding option:

"This encoding method is deprecated and should be avoided in favor of
Buffer objects where possible. This encoding will be removed in future
versions of Node."

Simply calling toString() with a 'base64' argument on the hash seems to
accomplish the same thing; this makes the code compatible with current
documentation as well as being a bit easier to follow.
