### PR TITLE
fixes #1826: res.redirect('toString') fails with 500

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -605,8 +605,7 @@ res.cookie = function(name, val, options){
 /**
  * Set the location header to `url`.
  *
- * The given `url` can also be the name of a mapped url, for
- * example by default express supports "back" which redirects
+ * The given `url` can also be "back", which redirects
  * to the _Referrer_ or _Referer_ headers or "/".
  *
  * Examples:
@@ -637,11 +636,8 @@ res.location = function(url){
     , req = this.req
     , path;
 
-  // setup redirect map
-  var map = { back: req.get('Referrer') || '/' };
-
-  // perform redirect
-  url = map[url] || url;
+  // "back" is an alias for the referrer
+  if(url === 'back') url = req.get('Referrer') || '/';
 
   // relative
   if (!~url.indexOf('://') && 0 != url.indexOf('//')) {


### PR DESCRIPTION
Fixes #1826. Removed the unused map and corrected the doc comment. No tests because who cares about correctness anyway?
