### PR TITLE
Template names with aliases for paths

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -486,7 +486,9 @@ app.render = function(name, options, fn){
     view = new (this.get('view'))(name, {
       defaultEngine: this.get('view engine'),
       root: this.get('views'),
-      engines: engines
+      engines: engines,
+      aliases: this.get('aliases'),
+      aliasSeparator: this.get('alias separator')
     });
 
     if (!view.path) {

--- a/lib/view.js
+++ b/lib/view.js
@@ -25,6 +25,8 @@ module.exports = View;
  *   - `defaultEngine` the default template engine name
  *   - `engines` template engine require() cache
  *   - `root` root path for view lookup
+ *   - `aliases` object contains aliases for paths
+ *   - `aliasSeparator` separator used for aliased path, defaults to '::'
  *
  * @param {String} name
  * @param {Object} options
@@ -35,6 +37,8 @@ function View(name, options) {
   options = options || {};
   this.name = name;
   this.root = options.root;
+  this.aliases = options.aliases;
+  this.aliasSeparator = options.aliasSeparator || '::';
   var engines = options.engines;
   this.defaultEngine = options.defaultEngine;
   var ext = this.ext = extname(name);
@@ -55,6 +59,18 @@ function View(name, options) {
 View.prototype.lookup = function(path){
   var ext = this.ext;
 
+  // resolve aliased path (check only if aliases are defined)
+  if (this.aliases) {
+    var pos = path.indexOf(this.aliasSeparator);
+    // at least one character for alias name and separator is not on the end!
+    if (pos > 0 && pos + this.aliasSeparator.length < path.length) {
+      var aliasName = path.substring(0, pos);
+      var resolvedAliasPath = this.aliases[aliasName];
+      if (!resolvedAliasPath) throw new Error('Alias "' + aliasName + '" for path "' + path + '" does not exist');
+      path = join(resolvedAliasPath, path.substring(pos + this.aliasSeparator.length));
+    } else throw new Error('Invalid aliased path "' + path + '"');
+  }
+  
   // <path>.<engine>
   if (!utils.isAbsolute(path)) path = join(this.root, path);
   if (exists(path)) return path;

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -27,6 +27,35 @@ describe('app', function(){
         done();
       })
     })
+    
+    it('should support aliased path with "view engine"', function(done){
+      var app = express();
+      
+      app.set('aliases', { test_alias: __dirname + '/fixtures' });
+      app.set('view engine', 'jade');
+      app.locals.user = { name: 'tobi' };
+
+      app.render('test_alias::user', function(err, str){
+        if (err) return done(err);
+        str.should.equal('<p>tobi</p>');
+        done();
+      })
+    })
+    
+    it('should support aliased path with custom alias separator with "view engine"', function(done){
+      var app = express();
+      
+      app.set('aliases', { test_alias: __dirname + '/fixtures' });
+      app.set('view engine', 'jade');
+      app.set('alias separator', '___');
+      app.locals.user = { name: 'tobi' };
+
+      app.render('test_alias___user', function(err, str){
+        if (err) return done(err);
+        str.should.equal('<p>tobi</p>');
+        done();
+      })
+    })
 
     it('should expose app.locals', function(done){
       var app = express();
@@ -65,6 +94,38 @@ describe('app', function(){
       })
     })
 
+    describe('when the alias does not exist', function(){
+      it('should provide a helpful error', function(done){
+        var app = express();
+        app.set('views', __dirname + '/fixtures');
+        app.set('view engine', 'jade');
+        app.set('aliases', { test_alias: '' });
+        
+        try {
+          app.render('test_alias_2::blog', function(err){ })
+        } catch (ex) {
+          ex.message.should.equal('Alias "test_alias_2" for path "test_alias_2::blog.jade" does not exist');
+          done();
+        }
+      })
+    })
+    
+    describe('when the alias is not valid', function(){
+      it('should provide a helpful error', function(done){
+        var app = express();
+        app.set('views', __dirname + '/fixtures');
+        app.set('view engine', 'jade');
+        app.set('aliases', { test_alias: __dirname + '/fixtures' });
+        
+        try {
+          app.render('::blog', function(err){ })
+        } catch (ex) {
+          ex.message.should.equal('Invalid aliased path "::blog.jade"');
+          done();
+        }
+      })
+    })
+    
     describe('when an error occurs', function(){
       it('should invoke the callback', function(done){
         var app = express();


### PR DESCRIPTION
I think it would be nice feature if express could handle template names with aliases for paths.

For example 

```
var aliases =  { 
    alias1: __dirname + '/templates/main/'
    alias2: __dirname + '/templates/login/partials''
  };
app.set('aliases', aliases);
...
res.render('alias1::index', {}); // will resolve to __dirname + '/templates/main/index'
res.render('alias2::index', {}); // will resolve to __dirname + '/templates/login/partials/index'
```

Note that :: is separator. It can be changed to something else with app.set('alias separator'). 
Substring before :: is alias name and substring after is normal template name
