### PR TITLE
change req.params to an object instead of an array

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -49,8 +49,9 @@ function Route(method, path, callbacks, options) {
 
 Route.prototype.match = function(path){
   var keys = this.keys
-    , params = this.params = []
-    , m = this.regexp.exec(path);
+    , params = this.params = {}
+    , m = this.regexp.exec(path)
+    , n = 0;
 
   if (!m) return false;
 
@@ -64,7 +65,7 @@ Route.prototype.match = function(path){
     if (key) {
       params[key.name] = val;
     } else {
-      params.push(val);
+      params[n++] = val;
     }
   }
 

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -126,8 +126,8 @@ describe('app.router', function(){
       var app = express();
 
       app.get(/^\/user\/([0-9]+)\/(view|edit)?$/, function(req, res){
-        var id = req.params.shift()
-          , op = req.params.shift();
+        var id = req.params[0]
+          , op = req.params[1];
         res.end(op + 'ing user ' + id);
       });
 
@@ -302,8 +302,8 @@ describe('app.router', function(){
       var app = express();
 
       app.get('/api/*.*', function(req, res){
-        var resource = req.params.shift()
-          , format = req.params.shift();
+        var resource = req.params[0]
+          , format = req.params[1];
         res.end(resource + ' as ' + format);
       });
 


### PR DESCRIPTION
this seems to trip people up a lot even though it behaves the same an object. technically a breaking change, though the impact would probably be extremely minimal - it might be best to wait until a 4.0 or we'll get lots of flack from trolls
