### PR TITLE
handle malformed paths better

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,8 @@
  */
 
 var mime = require('connect').mime
-  , crc32 = require('buffer-crc32');
+  , crc32 = require('buffer-crc32')
+  , querystring = require('querystring');
 
 /**
  * toString ref.
@@ -315,9 +316,7 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
 
 
 /**
- * Decodes a URI component. Returns
- * the original string if the component
- * is malformed.
+ * Safely decodes a URI component.
  *
  * @param  {String} str
  * @return {String}
@@ -328,6 +327,6 @@ exports.decode = function(str) {
   try {
     return decodeURIComponent(str);
   } catch (e) {
-    return str;
+    return querystring.unescape(str);
   }
 }

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -27,28 +27,66 @@ describe('app.router', function(){
     });
   })
 
-  it('should decode params', function(done){
-    var app = express();
+  describe('decode querystring', function(){
+    it('should decode correct params', function(done){
+      var app = express();
 
-    app.get('/:name', function(req, res, next){
-      res.send(req.params.name);
-    });
+      app.get('/:name', function(req, res, next){
+        res.send(req.params.name);
+      });
 
-    request(app)
-    .get('/foo%2Fbar')
-    .expect('foo/bar', done);
-  })
+      request(app)
+      .get('/foo%2Fbar')
+      .expect('foo/bar', done);
+    })
 
-  it('should accept params in malformed paths', function(done) {
-    var app = express();
+    it('should accept params in malformed paths', function(done) {
+      var app = express();
 
-    app.get('/:name', function(req, res, next){
-      res.send(req.params.name);
-    });
+      app.get('/:name', function(req, res, next){
+        res.send(req.params.name);
+      });
 
-    request(app)
-    .get('/%foobar')
-    .expect('%foobar', done);
+      request(app)
+      .get('/%foobar')
+      .expect('%foobar', done);
+    })
+
+    it('should continue decoding in case of errors', function(done) {
+      var app = express();
+
+      app.get('/:name', function(req, res, next){
+        res.send(req.params.name);
+      });
+
+      request(app)
+      .get('/%foo%2Fbar')
+      .expect('%foo/bar', done);
+    })
+
+    it('should not decode spaces', function(done) {
+      var app = express();
+
+      app.get('/:name', function(req, res, next){
+        res.send(req.params.name);
+      });
+
+      request(app)
+      .get('/%foo+bar')
+      .expect('%foo+bar', done);
+    })
+
+    it('should work with unicode', function(done) {
+      var app = express();
+
+      app.get('/:name', function(req, res, next){
+        res.send(req.params.name);
+      });
+
+      request(app)
+      .get('/%ce%b1')
+      .expect('\u03b1', done);
+    })
   })
 
   it('should be .use()able', function(done){


### PR DESCRIPTION
PR for weird cases described in #1352.

I preserved try..catch in place for performance reasons since node.js core seem to be doing [the same thing](https://github.com/joyent/node/blob/master/lib/querystring.js#L192), see [discussion](https://github.com/joyent/node/pull/2248).
