### PR TITLE
Object.getOwnPropertyDescriptor called on inherited property causes unhalted TypeError

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -44,10 +44,12 @@ function createApplication() {
  */
 
 for (var key in connect.middleware) {
-  Object.defineProperty(
-      exports
-    , key
-    , Object.getOwnPropertyDescriptor(connect.middleware, key));
+  if (connect.middleware.hasOwnProperty(key)) {
+    Object.defineProperty(
+        exports
+      , key
+      , Object.getOwnPropertyDescriptor(connect.middleware, key));
+  }
 }
 
 /**


### PR DESCRIPTION
`connect.middleware` object seems to have 'isString' function in its prototype chain which makes Object.getOwnPropertyDescriptor() to fail. I experienced that after running express 3.4.6 with connect 2.11.2. 

```
c:\Users\xxx\express\lib\express.js:48
  Object.defineProperty(
         ^
TypeError: Property description must be an object: undefined
    at Function.defineProperty (native)
    at Object.<anonymous> (c:\Users\xxx\express\lib\express.js:48:10)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (c:\Users\xxx\express\index.js:4:5)
    at Module._compile (module.js:456:26)
```

Besides from the above-mentioned circumstance I think it would be reasonable in general to filter object properties before calling something like `Object.get ===> Own <=== PropertyDescriptor()` on them. 
