### PR TITLE
Error message now describes where the view was not able to be found.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -490,7 +490,7 @@ app.render = function(name, options, fn){
     });
 
     if (!view.path) {
-      var err = new Error('Failed to lookup view "' + name + '"');
+      var err = new Error('Failed to lookup view "' + name + '" in views directory "' + view.root + '"');
       err.view = view;
       return fn(err);
     }

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -59,7 +59,7 @@ describe('app', function(){
         var app = express();
         app.set('views', __dirname + '/fixtures');
         app.render('rawr.jade', function(err){
-          err.message.should.equal('Failed to lookup view "rawr.jade"');
+          err.message.should.equal('Failed to lookup view "rawr.jade" in views directory "' + __dirname + '/fixtures"');
           done();
         });
       })


### PR DESCRIPTION
This is an issue that sometimes arises when a view cannot be found and there is insufficient information to ascertain why. This patch adds the views directory that was tried to the error message returned when a view could not be found.
