### PR TITLE
fix error 'doctype 5 is deprecated' in index

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -74,7 +74,7 @@ var users = [
  */
 
 var jadeLayout = [
-    'doctype 5'
+    'doctype html'
   , 'html'
   , '  head'
   , '    title= title'


### PR DESCRIPTION
'layout.jade' obsolete after start new express project. Fix using 'doctype html' instead of 'doctype 5'
