### PR TITLE
`doctype 5` is deprecated

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -74,7 +74,7 @@ var users = [
  */
 
 var jadeLayout = [
-    'doctype 5'
+    'doctype html'
   , 'html'
   , '  head'
   , '    title= title'


### PR DESCRIPTION
`doctype 5` is deprecated, it should use `doctype html`.

And follow the steps to build a express project with jade, after `node app`, It jumps an error telling change to `doctype html`
