### PR TITLE
Automatic OPTIONS response breaks with multiple routers

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -104,7 +104,7 @@ Router.prototype._dispatch = function(req, res, next){
     req.route = route = self.matchRequest(req, i);
 
     // implied OPTIONS
-    if (!route && 'OPTIONS' == req.method) return self._options(req, res);
+    if (!route && 'OPTIONS' == req.method) return self._options(req, res, next);
 
     // no route
     if (!route) return next(err);
@@ -181,9 +181,10 @@ Router.prototype._dispatch = function(req, res, next){
  * @api private
  */
 
-Router.prototype._options = function(req, res){
+Router.prototype._options = function(req, res, next){
   var path = parse(req).pathname
     , body = this._optionsFor(path).join(',');
+  if (!body) return next();
   res.set('Allow', body).send(body);
 };
 

--- a/test/app.options.js
+++ b/test/app.options.js
@@ -15,6 +15,30 @@ describe('OPTIONS', function(){
     .expect('GET,PUT')
     .expect('Allow', 'GET,PUT', done);
   })
+
+  it('should not respond if the path is not defined', function(done){
+    var app = express();
+
+    app.get('/users', function(req, res){});
+
+    request(app)
+    .options('/other')
+    .expect(404, done);
+  })
+
+  it('should forward requests down the middleware chain', function(done){
+    var app = express();
+    var router = new express.Router();
+
+    router.get('/users', function(req, res){});
+    app.use(router.middleware);
+    app.get('/other', function(req, res){});
+
+    request(app)
+    .options('/other')
+    .expect('GET')
+    .expect('Allow', 'GET', done);
+  })
 })
 
 describe('app.options()', function(){


### PR DESCRIPTION
We ran into a situation where a middleware from a node module was creating its own express router instance and inserting it as middleware. This was causing the automatic options to break since the flow never fell back to our main router. I don't know what your views on supporting applications that use multiple routers are.

It would be very easy to fix by passing `next` to `_options`, and then calling it if the response from `_optionsFor` is empty. This would also have the added benefit of returning 404 errors for `OPTIONS` requests to routes that don't exist, which I believe is standard practice.

However, the downside of this is that if you have multiple verbs for a single route spread over two routers, it won't return all the available verbs. So it may not be a complete fix, depending on how you view it. If you like the fix, I can submit a pull request (though it is only 4 lines).
