### PR TITLE
update the tests to show a difference between `send(null)` and `send(und...

### DIFF
--- a/test/res.send.js
+++ b/test/res.send.js
@@ -14,6 +14,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
+      .expect('Content-Length', '0')
       .expect('', done);
     })
   })
@@ -28,7 +29,10 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('', done);
+      .expect('', function(req, res){
+        res.header.should.not.have.property('content-length');
+        done();
+      });
     })
   })
 


### PR DESCRIPTION
Not sure why these are treated differently, but at least let's put a hint that they are.
