### PR TITLE
jump support added to next() middleware calling technique

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -153,7 +153,27 @@ Router.prototype._dispatch = function(req, res, next){
 
     // invoke route callbacks
     function callbacks(err) {
-      var fn = route.callbacks[i++];
+      var number,
+        currentIndex=i,
+        fn = route.callbacks[i++];
+      if(err && isNaN(err)===false){
+        if(Number(err)==0) return nextRoute();
+        if(Number(err) < 0){
+            number=(route.callbacks.length-Math.abs(err));
+            if(route.callbacks.length > number && 
+              number > currentIndex){
+                i=number;
+                return route.callbacks[i](req, res, callbacks);  
+            }
+        }else{
+          number=currentIndex+Number(err);
+          if(route.callbacks.length > number && 
+            number > currentIndex){
+              i=number;
+              return route.callbacks[i](req, res, callbacks);
+          }
+        }
+      }
       try {
         if ('route' == err) {
           nextRoute();


### PR DESCRIPTION
next(1) will skip next 1st handler and jump to 2nd handler in middleware

and next(-1) will invoke last handler in middleware
