### PR TITLE
Allow app#set to accept a hash of settings

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -301,6 +301,10 @@ app.param = function(name, fn){
 
 app.set = function(setting, val){
   if (1 == arguments.length) {
+    if (typeof setting === 'object') {
+      mixin(this.settings, setting);
+      return this;
+    }
     return this.settings[setting];
   } else {
     this.settings[setting] = val;

--- a/test/config.js
+++ b/test/config.js
@@ -13,6 +13,13 @@ describe('config', function(){
       var app = express();
       app.set('foo', undefined).should.equal(app);
     })
+
+    it('should merge a hash of settings', function() {
+      var app = express();
+      app.set({foo: 'bar', baz: 'quux'});
+      app.get('foo').should.equal('bar');
+      app.get('baz').should.equal('quux');
+    })
   })
 
   describe('.get()', function(){


### PR DESCRIPTION
This would, among other things, allow simpler integration with configuration modules like [rc](https://github.com/dominictarr/rc).
