### PR TITLE
Router: add parameter handling to middleware

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -3,6 +3,7 @@
  */
 
 var Route = require('./route')
+  , Layer = require('./layer')
   , utils = require('../utils')
   , methods = require('methods')
   , debug = require('debug')('express:router')
@@ -162,62 +163,72 @@ Router.prototype.handle = function(req, res, done) {
       var path = parseUrl(req).pathname;
       if (undefined == path) path = '/';
 
+      if (!layer.match(path)) return next(err);
+
       // route object and not middleware
       var route = layer.route;
 
-      // handle route
+      // if final route, then we support options
       if (route) {
         // we don't run any routs with error first
-        if (err || !route.match(path)) {
+        if (err) {
           return next(err);
         }
 
-        req.params = route.params;
+        req.route = route;
 
         // we can now dispatch to the route
         if (method === 'options' && !route.methods['options']) {
           options.push.apply(options, route._options());
         }
+      }
 
-        return self.process_params(route, req, res, function(err) {
-          if (err) {
-            return next(err);
+      req.params = layer.params;
+
+      // this should be done for the layer
+      return self.process_params(layer, req, res, function(err) {
+        if (err) {
+          return next(err);
+        }
+
+        if (route) {
+          return layer.handle(req, res, next);
+        }
+
+        trim_prefix();
+      });
+
+      return next(err);
+
+      function trim_prefix() {
+        var c = path[layer.path.length];
+        if (c && '/' != c && '.' != c) return next(err);
+
+        // Trim off the part of the url that matches the route
+        // middleware (.use stuff) needs to have the path stripped
+        debug('trim prefix (%s) from url %s', removed, req.url);
+        removed = layer.path;
+        req.url = protohost + req.url.substr(protohost.length + removed.length);
+
+        // Ensure leading slash
+        if (!fqdn && '/' != req.url[0]) {
+          req.url = '/' + req.url;
+          slashAdded = true;
+        }
+
+        debug('%s %s : %s', layer.handle.name || 'anonymous', layer.path, req.originalUrl);
+        var arity = layer.handle.length;
+        if (err) {
+          if (arity === 4) {
+            layer.handle(err, req, res, next);
+          } else {
+            next(err);
           }
-
-          route.dispatch(req, res, next);
-        });
-      }
-
-      // skip this layer if the path doesn't match.
-      if (0 != path.toLowerCase().indexOf(layer.path.toLowerCase())) return next(err);
-
-      var c = path[layer.path.length];
-      if (c && '/' != c && '.' != c) return next(err);
-
-      // Trim off the part of the url that matches the route
-      // middleware (.use stuff) needs to have the path stripped
-      debug('trim prefix (%s) from url %s', removed, req.url);
-      removed = layer.path;
-      req.url = protohost + req.url.substr(protohost.length + removed.length);
-
-      // Ensure leading slash
-      if (!fqdn && '/' != req.url[0]) {
-        req.url = '/' + req.url;
-        slashAdded = true;
-      }
-
-      debug('%s %s : %s', layer.handle.name || 'anonymous', layer.path, req.originalUrl);
-      var arity = layer.handle.length;
-      if (err) {
-        if (arity === 4) {
-          layer.handle(err, req, res, next);
+        } else if (arity < 4) {
+          layer.handle(req, res, next);
         } else {
           next(err);
         }
-      } else if (arity < 4) {
-        layer.handle(req, res, next);
-      } else {
-        next(err);
       }
     } catch (err) {
       next(err);
@@ -237,6 +248,11 @@ Router.prototype.process_params = function(route, req, res, done) {
 
   // captured parameters from the route, keys and values
   var keys = route.keys || [];
+
+  // fast track
+  if (keys.length === 0) {
+    return done();
+  }
 
   var i = 0;
   var paramIndex = 0;
@@ -314,10 +330,16 @@ Router.prototype.use = function(route, fn){
     route = route.slice(0, -1);
   }
 
+  var layer = Layer(route, {
+    sensitive: this.caseSensitive,
+    strict: this.strict,
+    end: false
+  }, fn);
+
   // add the middleware
   debug('use %s %s', route || '/', fn.name || 'anonymous');
-  this.stack.push({ path: route, handle: fn });
 
+  this.stack.push(layer);
   return this;
 };
 
@@ -335,12 +357,17 @@ Router.prototype.use = function(route, fn){
  */
 
 Router.prototype.route = function(path){
-  var route = new Route(path, {
-    sensitive: this.caseSensitive,
-    strict: this.strict
-  });
+  var route = new Route(path);
 
-  this.stack.push({ path: path, route: route });
+  var layer = Layer(path, {
+    sensitive: this.caseSensitive,
+    strict: this.strict,
+    end: true
+  }, route.dispatch.bind(route));
+
+  layer.route = route;
+
+  this.stack.push(layer);
   return route;
 };
 

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -1,0 +1,61 @@
+var utils = require('../utils')
+  , debug = require('debug')('express:router:layer')
+
+function Layer(path, options, fn) {
+  if (!(this instanceof Layer)) {
+    return new Layer(path, options, fn);
+  }
+
+  debug('new %s', path);
+  options = options || {};
+  this.path = path;
+  this.params = {};
+  this.regexp = utils.pathRegexp(path
+    , this.keys = []
+    , options.sensitive
+    , options.strict
+    , options.end);
+  this.handle = fn;
+}
+
+/**
+ * Check if this route matches `path`, if so
+ * populate `.params`.
+ *
+ * @param {String} path
+ * @return {Boolean}
+ * @api private
+ */
+
+Layer.prototype.match = function(path){
+  var keys = this.keys
+    , params = this.params = {}
+    , m = this.regexp.exec(path)
+    , n = 0;
+
+  if (!m) return false;
+
+  for (var i = 1, len = m.length; i < len; ++i) {
+    var key = keys[i - 1];
+
+    try {
+      var val = 'string' == typeof m[i]
+        ? decodeURIComponent(m[i])
+        : m[i];
+    } catch(e) {
+      var err = new Error("Failed to decode param '" + m[i] + "'");
+      err.status = 400;
+      throw err;
+    }
+
+    if (key) {
+      params[key.name] = val;
+    } else {
+      params[n++] = val;
+    }
+  }
+
+  return true;
+};
+
+module.exports = Layer;

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -3,8 +3,7 @@
  * Module dependencies.
  */
 
-var utils = require('../utils')
-  , debug = require('debug')('express:router:route')
+var debug = require('debug')('express:router:route')
   , methods = require('methods')
 
 /**
@@ -14,74 +13,20 @@ var utils = require('../utils')
 module.exports = Route;
 
 /**
- * Initialize `Route` with the given HTTP `method`, `path`,
- * and an array of `callbacks` and `options`.
- *
- * Options:
- *
- *   - `sensitive`    enable case-sensitive routes
- *   - `strict`       enable strict matching for trailing slashes
+ * Initialize `Route` with the given `path`,
  *
  * @param {String} path
- * @param {Object} options.
  * @api private
  */
 
-function Route(path, options) {
+function Route(path) {
   debug('new %s', path);
-  options = options || {};
   this.path = path;
-  this.params = {};
-  this.regexp = utils.pathRegexp(path
-    , this.keys = []
-    , options.sensitive
-    , options.strict);
-
   this.stack = undefined;
 
   // route handlers for various http methods
   this.methods = {};
 }
-
-/**
- * Check if this route matches `path`, if so
- * populate `.params`.
- *
- * @param {String} path
- * @return {Boolean}
- * @api private
- */
-
-Route.prototype.match = function(path){
-  var keys = this.keys
-    , params = this.params = {}
-    , m = this.regexp.exec(path)
-    , n = 0;
-
-  if (!m) return false;
-
-  for (var i = 1, len = m.length; i < len; ++i) {
-    var key = keys[i - 1];
-
-    try {
-      var val = 'string' == typeof m[i]
-        ? decodeURIComponent(m[i])
-        : m[i];
-    } catch(e) {
-      var err = new Error("Failed to decode param '" + m[i] + "'");
-      err.status = 400;
-      throw err;
-    }
-
-    if (key) {
-      params[key.name] = val;
-    } else {
-      params[n++] = val;
-    }
-  }
-
-  return true;
-};
 
 /**
  * @return {Array} supported HTTP methods

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,11 +132,12 @@ function acceptParams(str, index) {
  * @param  {Array} keys
  * @param  {Boolean} sensitive
  * @param  {Boolean} strict
+ * @param  {Boolean} end (whether to append $ to regex)
  * @return {RegExp}
  * @api private
  */
 
-exports.pathRegexp = function(path, keys, sensitive, strict) {
+exports.pathRegexp = function(path, keys, sensitive, strict, end) {
   if (toString.call(path) == '[object RegExp]') return path;
   if (Array.isArray(path)) path = '(' + path.join('|') + ')';
   path = path
@@ -155,7 +156,7 @@ exports.pathRegexp = function(path, keys, sensitive, strict) {
     })
     .replace(/([\/.])/g, '\\$1')
     .replace(/\*/g, '(.*)');
-  return new RegExp('^' + path + '$', sensitive ? '' : 'i');
+  return new RegExp('^' + path + ((end) ? '$' : ''), sensitive ? '' : 'i');
 }
 
 /**

--- a/test/Route.js
+++ b/test/Route.js
@@ -6,15 +6,6 @@ var express = require('../')
 
 describe('Route', function(){
 
-  describe('.match', function(){
-    it('should match', function(){
-      var route = new Route('/foo/bar');
-
-      assert(route.match('/foo/bar'));
-      assert(!route.match('/foo/baz'));
-    })
-  })
-
   describe('.all', function(){
     it('should add handler', function(done){
       var route = new Route('/foo');

--- a/test/Router.js
+++ b/test/Router.js
@@ -94,4 +94,39 @@ describe('Router', function(){
       done();
     })
   })
+
+  describe('.param', function() {
+    it('should call param function when routing VERBS', function(done) {
+      var router = new Router();
+
+      router.param('id', function(req, res, next, id) {
+        assert.equal(id, '123');
+        next();
+      });
+
+      router.get('/foo/:id/bar', function(req, res, next) {
+        assert.equal(req.params.id, '123');
+        next();
+      });
+
+      router.handle({ url: '/foo/123/bar', method: 'get' }, {}, done);
+    });
+
+    it('should call param function when routing middleware', function(done) {
+      var router = new Router();
+
+      router.param('id', function(req, res, next, id) {
+        assert.equal(id, '123');
+        next();
+      });
+
+      router.use('/foo/:id/bar', function(req, res, next) {
+        assert.equal(req.params.id, '123');
+        assert.equal(req.url, '/baz');
+        next();
+      });
+
+      router.handle({ url: '/foo/123/bar/baz', method: 'get' }, {}, done);
+    });
+  });
 })


### PR DESCRIPTION
Middleware (.use) can now specify parameter arguments to trigger
Router.param loading. This is handy if you want to `.use` additional
routers but need to load certain objects before the mounted middleware
runs.

This will resolve #696
