### PR TITLE
redirect can take a hash of queries

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -674,24 +674,43 @@ res.location = function(url){
  *    res.redirect('http://example.com', 301);
  *    res.redirect('../login'); // /blog/post/1 -> /blog/login
  *
- * @param {String} url
  * @param {Number} code
+ * @param {String} url
+ * @param {Object} queries
  * @api public
  */
 
-res.redirect = function(url){
+res.redirect = function(code, url, queries){
   var head = 'HEAD' == this.req.method
     , status = 302
     , body;
 
-  // allow status / url
-  if (2 == arguments.length) {
+  // allow status / url argument swapping
+  if ('object' == typeof url) {
+    queries = url;
+    url = code;
+  } else {
     if ('number' == typeof url) {
       status = url;
-      url = arguments[1];
+      url = code
     } else {
-      status = arguments[1];
+      if ('string' == typeof code) {
+        url = code;
+      } else {
+        status = code;
+      }
     }
+  }
+
+  // Parse though queries and append to url
+  if (typeof queries == "object" && Object.keys(queries).length > 0) {
+    url = url + "?"
+    for (q in queries) {
+      str = queries[q];
+      url = url + q + "=" + str + "&";
+      console.log(url)
+    }
+    url = url.slice(0, -1);
   }
 
   // Set location header


### PR DESCRIPTION
I found that it would often be helpful to pass information to another page via a query string, so I added the ability to include an object of `{ q : val, q2 : val2 }` as either the second or third variable (in the case of having codes or not). The parsing of redirect string and code values (order not mattering) should be preserved.
