### PR TITLE
Pass object to middleware

### DIFF
--- a/examples/session/redis.js
+++ b/examples/session/redis.js
@@ -1,5 +1,4 @@
 
-
 var express = require('../..');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
@@ -7,7 +6,7 @@ var session = require('express-session');
 
 // pass the express to the connect redis module
 // allowing it to inherit from session.Store
-var RedisStore = require('connect-redis')(session);
+var RedisStore = require('connect-redis')({ session: session });
 
 var app = express();
 


### PR DESCRIPTION
Middleware expects a object i.e connect. So we could opt to change the middleware instead and may make more sense to.
