### PR TITLE
Modular routing

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -378,25 +378,8 @@ proto.route = function(path){
   return route;
 };
 
-/**
- * Special-cased "all" method, applying the given route `path`,
- * middleware, and callback to _every_ HTTP method.
- *
- * @param {String} path
- * @param {Function} ...
- * @return {app} for chaining
- * @api public
- */
-
-proto.all = function(path, fn) {
-  var route = this.route(path);
-  methods.forEach(function(method){
-    route[method](fn);
-  });
-};
-
 // create Router#VERB functions
-methods.forEach(function(method){
+methods.concat('all').forEach(function(method){
   proto[method] = function(path, fn){
     var self = this;
     self.route(path)[method](fn);

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -170,7 +170,7 @@ proto.handle = function(req, res, done) {
 
       // if final route, then we support options
       if (route) {
-        // we don't run any routs with error first
+        // we don't run any routes with error first
         if (err) {
           return next(err);
         }
@@ -319,7 +319,6 @@ proto.process_params = function(route, req, res, done) {
  */
 
 proto.use = function(route, fn){
-
   // default route to '/'
   if ('string' != typeof route) {
     fn = route;
@@ -337,7 +336,7 @@ proto.use = function(route, fn){
     route = route.slice(0, -1);
   }
 
-  var layer = Layer(route, {
+  var layer = new Layer(route, {
     sensitive: this.caseSensitive,
     strict: this.strict,
     end: false
@@ -366,7 +365,7 @@ proto.use = function(route, fn){
 proto.route = function(path){
   var route = new Route(path);
 
-  var layer = Layer(path, {
+  var layer = new Layer(path, {
     sensitive: this.caseSensitive,
     strict: this.strict,
     end: true
@@ -381,9 +380,8 @@ proto.route = function(path){
 // create Router#VERB functions
 methods.concat('all').forEach(function(method){
   proto[method] = function(path, fn){
-    var self = this;
-    self.route(path)[method](fn);
-    return self;
+    this.route(path)[method](fn);
+    return this;
   };
 });
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -183,7 +183,11 @@ proto.handle = function(req, res, done) {
         }
       }
 
-      req.params = layer.params;
+      req.params = req.params || {};
+
+      for (var key in layer.params) {
+        req.params[key] = layer.params[key];
+      }
 
       // this should be done for the layer
       return self.process_params(layer, req, res, function(err) {
@@ -244,10 +248,10 @@ proto.process_params = function(route, req, res, done) {
   var params = this.params;
 
   // captured parameters from the route, keys and values
-  var keys = route.keys || [];
+  var keys = route.keys;
 
   // fast track
-  if (keys.length === 0) {
+  if (!keys || keys.length === 0) {
     return done();
   }
 

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -9,8 +9,6 @@ function Layer(path, options, fn) {
 
   debug('new %s', path);
   options = options || {};
-  this.path = path;
-  this.params = {};
   this.regexp = pathRegexp(path, this.keys = [], options);
   this.handle = fn;
 }
@@ -33,6 +31,8 @@ Layer.prototype.match = function(path){
   var val;
 
   if (!m) return false;
+
+  this.path = m[0];
 
   for (var i = 1, len = m.length; i < len; ++i) {
     key = keys[i - 1];

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -129,7 +129,7 @@ Route.prototype.dispatch = function(req, res, done){
 Route.prototype.all = function(fn){
   if (typeof fn !== 'function') {
     var type = {}.toString.call(fn);
-    var msg = 'Route.use() requires callback functions but got a ' + type;
+    var msg = 'Route.all() requires callback functions but got a ' + type;
     throw new Error(msg);
   }
 
@@ -150,7 +150,7 @@ methods.forEach(function(method){
   Route.prototype[method] = function(fn){
     if (typeof fn !== 'function') {
       var type = {}.toString.call(fn);
-      var msg = 'Route.use() requires callback functions but got a ' + type;
+      var msg = 'Route.' + method + '() requires callback functions but got a ' + type;
       throw new Error(msg);
     }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "escape-html": "1.0.1",
     "qs": "0.6.6",
     "serve-static": "1.0.1",
-    "path-to-regexp": "0.1.0",
+    "path-to-regexp": "0.1.2",
     "debug": ">= 0.7.3 < 1"
   },
   "devDependencies": {

--- a/test/Router.js
+++ b/test/Router.js
@@ -5,7 +5,6 @@ var express = require('../')
   , assert = require('assert');
 
 describe('Router', function(){
-
   it('should return a function with router methods', function() {
     var router = Router();
     assert(typeof router == 'function');
@@ -18,16 +17,16 @@ describe('Router', function(){
     assert(typeof router.use == 'function');
   });
 
-  it('should support .use of other routers', function(done) {
-    var router = Router();
-    var another = Router();
+  it('should support .use of other routers', function(done){
+    var router = new Router();
+    var another = new Router();
 
-    another.get('/bar', function(req, res) {
-      res.done();
+    another.get('/bar', function(req, res){
+      res.end();
     });
     router.use('/foo', another);
 
-    router.handle({ url: '/foo/bar', method: 'GET' }, { done: done });
+    router.handle({ url: '/foo/bar', method: 'GET' }, { end: done });
   });
 
   it('should support dynamic routes', function(done){

--- a/test/Router.js
+++ b/test/Router.js
@@ -30,6 +30,20 @@ describe('Router', function(){
     router.handle({ url: '/foo/bar', method: 'GET' }, { done: done });
   });
 
+  it('should support dynamic routes', function(done){
+    var router = new Router();
+    var another = new Router();
+
+    another.get('/:bar', function(req, res){
+      req.params.foo.should.equal('test');
+      req.params.bar.should.equal('route');
+      res.end();
+    });
+    router.use('/:foo', another);
+
+    router.handle({ url: '/test/route', method: 'GET' }, { end: done });
+  });
+
   describe('.handle', function(){
     it('should dispatch', function(done){
       var router = new Router();

--- a/test/app.route.js
+++ b/test/app.route.js
@@ -36,4 +36,17 @@ describe('app.route', function(){
     .post('/foo')
     .expect('post', done);
   });
+
+  it('should support dynamic routes', function(done){
+    var app = express();
+
+    app.route('/:foo')
+    .get(function(req, res) {
+      res.send(req.params.foo);
+    });
+
+    request(app)
+    .get('/test')
+    .expect('test', done);
+  });
 });

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -63,5 +63,20 @@ describe('app', function(){
       app.use('/blog', blog);
       blog.parent.should.equal(app);
     })
+
+    it('should support dynamic routes', function(done){
+      var blog = express()
+        , app = express();
+
+      blog.get('/', function(req, res){
+        res.end(req.params.article);
+      });
+
+      app.use('/post/:article', blog);
+
+      request(app)
+      .get('/post/once-upon-a-time')
+      .expect('once-upon-a-time', done);
+    })
   })
 })


### PR DESCRIPTION
Enable dynamic `.use` mounting for more modular applications. For example:

``` js
var mount = app.route('/').get(function (req) {
  console.log(req.params.route); // Works!
});

app.use('/:route', mount);
```
