### PR TITLE
req.send() should be a 204, not a 200

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -95,6 +95,8 @@ res.send = function(body){
       this.statusCode = body;
       body = arguments[1];
     }
+  } else if (0 == arguments.length){
+    this.statusCode = 204;
   }
 
   switch (typeof body) {


### PR DESCRIPTION
According to the RFC, a 204 is a 200 without body, so it only makes sense to send it if send() is called without arguments.
