### PR TITLE
This example does not work with express 4.x.

### DIFF
--- a/examples/multipart/index.js
+++ b/examples/multipart/index.js
@@ -4,11 +4,26 @@
 
 var express = require('../..');
 var bodyParser = require('body-parser');
+var multiparty = require('multiparty');
 var format = require('util').format;
 
 var app = module.exports = express();
 
 app.use(bodyParser());
+app.use(function(req, res, next){
+	console.log(req.method);
+	if(req.method === 'POST' && req.headers['content-type'].indexOf("multipart/form-data") !== -1){
+		var form = new multiparty.Form();
+		form.parse(req, function(err, fields, files){
+			req.files = files;
+			next();
+		});
+		
+	}
+	else next();
+	
+});
+
 
 app.get('/', function(req, res){
   res.send('<form method="post" enctype="multipart/form-data">'
@@ -22,9 +37,9 @@ app.post('/', function(req, res, next){
   // the uploaded file can be found as `req.files.image` and the
   // title field as `req.body.title`
   res.send(format('\nuploaded %s (%d Kb) to %s as %s'
-    , req.files.image.name
-    , req.files.image.size / 1024 | 0
-    , req.files.image.path
+    , req.files.image[0].name
+    , req.files.image[0].size / 1024 | 0
+    , req.files.image[0].path
     , req.body.title));
 });
 


### PR DESCRIPTION
This example does not work with express 4.x.
bodyParser() does not have multipart() anymore.
Multiparty module and middleware are added.
