### PR TITLE
Send "hidden" option to send library

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -333,6 +333,7 @@ res.sendfile = function(path, options, fn){
   // transfer
   var file = send(req, path);
   if (options.root) file.root(options.root);
+  if (typeof options.hidden === 'boolean') file.hidden(options.hidden);
   file.maxage(options.maxAge || 0);
   file.on('error', error);
   file.on('directory', next);


### PR DESCRIPTION
Simply exposes some of the API that's [already built into](https://github.com/visionmedia/send#hiddenbool) `send`.
