### PR TITLE
improve req.xhr test by verifying status code

### DIFF
--- a/test/req.xhr.js
+++ b/test/req.xhr.js
@@ -15,8 +15,9 @@ describe('req', function(){
       request(app)
       .get('/')
       .set('X-Requested-With', 'xmlhttprequest')
-      .end(function(res){
-        done();
+      .expect(200)
+      .end(function(err, res){
+        done(err);
       })
     })
 
@@ -31,8 +32,9 @@ describe('req', function(){
       request(app)
       .get('/')
       .set('X-Requested-With', 'XMLHttpRequest')
-      .end(function(res){
-        done();
+      .expect(200)
+      .end(function(err, res){
+        done(err);
       })
     })
 
@@ -47,8 +49,9 @@ describe('req', function(){
       request(app)
       .get('/')
       .set('X-Requested-With', 'blahblah')
-      .end(function(res){
-        done();
+      .expect(200)
+      .end(function(err, res){
+        done(err);
       })
     })
 
@@ -62,8 +65,9 @@ describe('req', function(){
 
       request(app)
       .get('/')
-      .end(function(res){
-        done();
+      .expect(200)
+      .end(function(err, res){
+        done(err);
       })
     })
   })


### PR DESCRIPTION
I found this problem from one question on stackoverflow: http://stackoverflow.com/questions/22816121/supertest-test-express-middleware/23074621#23074621

The `req.xhr` tests will never fail because it doesn't use `.expect()` assertion to return error to `.end()` callback. so it should pass error object to `done()` with `.expect()` assertion.
