### PR TITLE
Allow overwrite of express middleware properties

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -87,6 +87,7 @@ exports.static = require('serve-static');
   Object.defineProperty(exports, name, {
     get: function () {
       throw new Error('Most middleware (like ' + name + ') is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.');
-    }
+    },
+    configurable: true
   });
 });


### PR DESCRIPTION
A small fix to allow individuals to backport Express middleware back onto Express for older modules that haven't been (and may never be) made compatible with Express 4.x.
