### PR TITLE
Don't convert header names to lowercase in res.set()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -515,8 +515,7 @@ res.header = function(field, val){
   if (2 == arguments.length) {
     if (Array.isArray(val)) val = val.map(String);
     else val = String(val);
-    field = field.toLowerCase();
-    if ('content-type' == field && !/;\s*charset\s*=/.test(val)) {
+    if ('content-type' == field.toLowerCase() && !/;\s*charset\s*=/.test(val)) {
       var charset = mime.charsets.lookup(val.split(';')[0]);
       if (charset) val += '; charset=' + charset.toLowerCase();
     }


### PR DESCRIPTION
While technically not a problem as far as HTTP is concerned, some dumb clients do case-sensitive header lookups, and this broke them.
