### PR TITLE
trim_prefix hoisting within the try/catch causing --use-strict flag to fail

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -198,39 +198,41 @@ proto.handle = function(req, res, done) {
         trim_prefix();
       });
 
-      function trim_prefix() {
-        var c = path[layer.path.length];
-        if (c && '/' != c && '.' != c) return next(err);
-
-        // Trim off the part of the url that matches the route
-        // middleware (.use stuff) needs to have the path stripped
-        debug('trim prefix (%s) from url %s', removed, req.url);
-        removed = layer.path;
-        req.url = protohost + req.url.substr(protohost.length + removed.length);
-
-        // Ensure leading slash
-        if (!fqdn && '/' != req.url[0]) {
-          req.url = '/' + req.url;
-          slashAdded = true;
-        }
-
-        debug('%s %s : %s', layer.handle.name || 'anonymous', layer.path, req.originalUrl);
-        var arity = layer.handle.length;
-        if (err) {
-          if (arity === 4) {
-            layer.handle(err, req, res, next);
-          } else {
-            next(err);
-          }
-        } else if (arity < 4) {
-          layer.handle(req, res, next);
-        } else {
-          next(err);
-        }
-      }
     } catch (err) {
       next(err);
     }
+
+    function trim_prefix() {
+      var c = path[layer.path.length];
+      if (c && '/' != c && '.' != c) return next(err);
+
+      // Trim off the part of the url that matches the route
+      // middleware (.use stuff) needs to have the path stripped
+      debug('trim prefix (%s) from url %s', removed, req.url);
+      removed = layer.path;
+      req.url = protohost + req.url.substr(protohost.length + removed.length);
+
+      // Ensure leading slash
+      if (!fqdn && '/' != req.url[0]) {
+        req.url = '/' + req.url;
+        slashAdded = true;
+      }
+
+      debug('%s %s : %s', layer.handle.name || 'anonymous', layer.path, req.originalUrl);
+      var arity = layer.handle.length;
+      if (err) {
+        if (arity === 4) {
+          layer.handle(err, req, res, next);
+        } else {
+          next(err);
+        }
+      } else if (arity < 4) {
+        layer.handle(req, res, next);
+      } else {
+        next(err);
+      }
+    }
+
   })();
 };
 


### PR DESCRIPTION
since function declaration is hoisted for the scope in any case, there's no reason to ditch `use strict` hint on having that `trim_prefix` nested declaration.
