### PR TITLE
ETag support in HEAD requests

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -130,7 +130,7 @@ res.send = function(body){
 
   // ETag support
   // TODO: W/ support
-  if (app.settings.etag && len && 'GET' == req.method) {
+  if (app.settings.etag && len && ('GET' == req.method || 'HEAD' == req.method)) {
     if (!this.get('ETag')) {
       this.set('ETag', etag(body));
     }

--- a/test/app.head.js
+++ b/test/app.head.js
@@ -16,6 +16,51 @@ describe('HEAD', function(){
     .head('/tobi')
     .expect(200, done);
   })
+
+  it('should output the same headers is GET or HEAD requests', function(done){
+    var app = express(),
+        headersGET,
+        headersHEAD,
+        compareHeaders;
+
+    compareHeaders = function(){
+      var keysHEAD, keysGET;
+      if(!headersHEAD || !headersGET){
+        return;
+      }
+      keysHEAD = Object.keys(headersHEAD);
+      keysGET = Object.keys(headersGET);
+
+      assert.equal(keysHEAD.length, keysGET.length);
+
+      keysGET.forEach(function(key){
+        assert.equal(headersGET[key], headersHEAD[key]);
+      });
+
+      done();
+    };
+    
+    app.get('/tobi', function(req, res){
+      // send() detects HEAD
+      res.send('tobi');
+    });
+
+    request(app)
+      .head('/tobi')
+      .expect(200)
+      .end(function(err, response){
+        headersHEAD = response.headers;
+        compareHeaders();
+      });
+
+    request(app)
+      .get('/tobi')
+      .expect(200)
+      .end(function(err, response){
+        headersGET = response.headers;
+        compareHeaders();
+      });
+  })
 })
 
 describe('app.head()', function(){


### PR DESCRIPTION
I'm assuming that ETags should also be sent in the HEAD requests. And it would also be quite helpful in the job I have in hands at the moment :) 

According to the RFC (http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4) "The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response". It even mentions "Content-Length, Content-MD5, ETag or Last-Modified" headers in HEAD requests.
