### PR TITLE
Maintain json|jsonp(status,object) as the default order when both args are numbers

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -172,7 +172,7 @@ res.json = function(obj){
   // allow status / body
   if (2 == arguments.length) {
     // res.json(body, status) backwards compat
-    if ('number' == typeof arguments[1]) {
+    if ('number' == typeof arguments[1] && 'number' != typeof obj) {
       this.statusCode = arguments[1];
     } else {
       this.statusCode = obj;
@@ -212,7 +212,7 @@ res.jsonp = function(obj){
   // allow status / body
   if (2 == arguments.length) {
     // res.json(body, status) backwards compat
-    if ('number' == typeof arguments[1]) {
+    if ('number' == typeof arguments[1] && 'number' != typeof obj) {
       this.statusCode = arguments[1];
     } else {
       this.statusCode = obj;

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -156,6 +156,23 @@ describe('res', function(){
       })
     })
   })
+  
+  it('should default to .jsonp(status, object) when when both properties are integerss', function(done){
+    var app = express();
+
+    app.use(function(req, res){
+      res.jsonp(201, 0);
+    });
+
+    request(app)
+    .get('/')
+    .end(function(err, res){
+      res.statusCode.should.equal(201);
+      res.headers.should.have.property('content-type', 'application/json');
+      res.text.should.equal('0');
+      done();
+    })
+  })
 
   it('should not override previous Content-Types', function(done){
     var app = express();

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -259,6 +259,23 @@ describe('res', function(){
     })
   })
 
+  it('should default to .jsonp(status, object) when when both properties are integerss', function(done){
+    var app = express();
+
+    app.use(function(req, res){
+      res.jsonp(201, 0);
+    });
+
+    request(app)
+    .get('/')
+    .end(function(err, res){
+      res.statusCode.should.equal(201);
+      res.headers.should.have.property('content-type', 'application/json');
+      res.text.should.equal('0');
+      done();
+    })
+  })
+
   it('should not override previous Content-Types', function(done){
     var app = express();
 


### PR DESCRIPTION
I added tests and changed the logic.

How would I get this added to the next 3.x release?
