### PR TITLE
Redirect Fallback

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -710,7 +710,7 @@ res.redirect = function(url){
 
     html: function(){
       var u = escapeHtml(url);
-      body = '<p>' + statusCodes[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>';
+      body = '<script>window.location="'+url+'"</script><p>' + statusCodes[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>';
     },
 
     default: function(){


### PR DESCRIPTION
When you use `res.redirect()` the browser is automatically redirected to the new page. But in cases where there previously was a `res.write()` call, the redirect fails and you see [this message](https://github.com/visionmedia/express/blob/master/lib/response.js#L713) instead:

``` javascript
'<p>' + statusCodes[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>';
```

Would it be better to prepend to that something along the lines of the below so the redirect still works?:

``` javascript
'<script>window.location="'+url+'"</script>'
```
