### PR TITLE
Replace buffer-crc32 to improve performance

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
  */
 
 var mime = require('send').mime;
-var crc32 = require('buffer-crc32');
+var crc32c = require('fast-crc32c');
 var basename = require('path').basename;
 var deprecate = require('util').deprecate;
 var proxyaddr = require('proxy-addr');
@@ -46,7 +46,7 @@ exports.deprecate = function(fn, msg){
  */
 
 exports.etag = function(body){
-  return '"' + crc32.signed(body) + '"';
+  return '"' + crc32c.calculate(body) + '"';
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "range-parser": "1.0.0",
     "type-is": "1.2.0",
     "cookie": "0.1.2",
-    "buffer-crc32": "0.2.1",
+    "fast-crc32c": "0.1.3",
     "fresh": "0.2.2",
     "methods": "1.0.0",
     "send": "0.3.0",

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -109,7 +109,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('ETag', '"-1498647312"')
+      .expect('ETag', '"4124899540"')
       .end(done);
     })
 
@@ -198,7 +198,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('ETag', '"-1498647312"')
+      .expect('ETag', '"4124899540"')
       .end(done);
     })
 
@@ -313,7 +313,7 @@ describe('res', function(){
 
     request(app)
     .get('/')
-    .set('If-None-Match', '"-1498647312"')
+    .set('If-None-Match', '"4124899540"')
     .expect(304, done);
   })
 
@@ -373,7 +373,7 @@ describe('res', function(){
         request(app)
         .get('/')
         .end(function(err, res){
-          res.headers.should.have.property('etag', '"-1498647312"');
+          res.headers.should.have.property('etag', '"4124899540"');
           done();
         });
       });

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,16 +8,16 @@ describe('utils.etag(body)', function(){
   var strUTF8 = '<!DOCTYPE html>\n<html>\n<head>\n</head>\n<body><p>自動販売</p></body></html>';
 
   it('should support strings', function(){
-    utils.etag(str).should.eql('"-2034458343"');
+    utils.etag(str).should.eql('"1450003261"');
   })
 
   it('should support utf8 strings', function(){
-    utils.etag(strUTF8).should.eql('"1395090196"');
+    utils.etag(strUTF8).should.eql('"384820390"');
   })
 
   it('should support buffer', function(){
-    utils.etag(new Buffer(strUTF8)).should.eql('"1395090196"');
-    utils.etag(new Buffer(str)).should.eql('"-2034458343"');
+    utils.etag(new Buffer(strUTF8)).should.eql('"384820390"');
+    utils.etag(new Buffer(str)).should.eql('"1450003261"');
   })
 
 })


### PR DESCRIPTION
As buffer-crc32 is used to calculate etag for each response, it's performance is
critical for express.  buffer-crc32 is a Javascript CRC-32 implementation, which
could result in performance penalty due to the language it self.

I propose to use fast-crc32c to replace current CRC-32 implementation, as it may
use hardware acceleration when possible, and will gracefully fall back to js
implementation of CRC-32C whichs result is consistent with hardware accelerated
version.

Here is the benchmark result for different implementations

| res size | fast-crc32c hw | fast-crc32c js | buffer-crc32 | change |
| --: | --: | --: | --: | --- |
| 128B | 7883.30 req/s | 8153.78 req/s | 8100.85 req/s | -2.7% / 0.7% |
| 512B | 8099.78 req/s | 8112.71 req/s | 8022.18 req/s | 1.0% / 1.1% |
| 1024B | 7942.10 req/s | 8127.20 req/s | 7801.90 req/s | 1.8% / 4.2% |
| 2048B | 8030.10 req/s | 7837.05 req/s | 7613.33 req/s | 5.5% / 2.9% |
| 4096B | 7554.95 req/s | 7283.39 req/s | 6911.11 req/s | 9.3% / 5.4% |
| 16384 | 7205.52 req/s | 5623.53 req/s | 4860.64 req/s | 48.2% / 15.7% |
| 65536 | 5203.17 req/s | 1925.98 req/s | 2126.77 req/s | 144.7% / -9.4% |

and charted as
![screen shot 2014-05-22 at 10 45 54 am](https://cloud.githubusercontent.com/assets/687367/3049402/1eee873c-e15e-11e3-9864-6efbdf5e55dc.png)

[Scripts used for benchmark](https://gist.github.com/ashi009/294f125ade6f7a9e11cb)
