### PR TITLE
Replaced deprecated __defineGetter__() functions

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -249,7 +249,7 @@ req.is = function(types){
  * @api public
  */
 
-req.__defineGetter__('protocol', function(){
+Object.defineProperty(req, 'protocol', {get: function(){
   var trust = this.app.get('trust proxy fn');
 
   if (!trust(this.connection.remoteAddress)) {
@@ -262,7 +262,7 @@ req.__defineGetter__('protocol', function(){
   //       single value, but this is to be safe.
   var proto = this.get('X-Forwarded-Proto') || 'http';
   return proto.split(/\s*,\s*/)[0];
-});
+}});
 
 /**
  * Short-hand for:
@@ -273,9 +273,9 @@ req.__defineGetter__('protocol', function(){
  * @api public
  */
 
-req.__defineGetter__('secure', function(){
+Object.defineProperty(req, 'secure', {get: function(){
   return 'https' == this.protocol;
-});
+}});
 
 /**
  * Return the remote address from the trusted proxy.
@@ -287,10 +287,10 @@ req.__defineGetter__('secure', function(){
  * @api public
  */
 
-req.__defineGetter__('ip', function(){
+Object.defineProperty(req, 'ip', {get: function(){
   var trust = this.app.get('trust proxy fn');
   return proxyaddr(this, trust);
-});
+}});
 
 /**
  * When "trust proxy" is set, trusted proxy addresses + client.
@@ -304,11 +304,11 @@ req.__defineGetter__('ip', function(){
  * @api public
  */
 
-req.__defineGetter__('ips', function(){
+Object.defineProperty(req, 'ips', {get: function() {
   var trust = this.app.get('trust proxy fn');
   var addrs = proxyaddr.all(this, trust);
   return addrs.slice(1).reverse();
-});
+}});
 
 /**
  * Return subdomains as an array.
@@ -325,13 +325,13 @@ req.__defineGetter__('ips', function(){
  * @api public
  */
 
-req.__defineGetter__('subdomains', function(){
+Object.defineProperty(req, 'subdomains', {get: function() {
   var offset = this.app.get('subdomain offset');
   return (this.host || '')
     .split('.')
     .reverse()
     .slice(offset);
-});
+}});
 
 /**
  * Short-hand for `url.parse(req.url).pathname`.
@@ -340,9 +340,9 @@ req.__defineGetter__('subdomains', function(){
  * @api public
  */
 
-req.__defineGetter__('path', function(){
+Object.defineProperty(req, 'path', {get: function() {
   return parse(this).pathname;
-});
+}});
 
 /**
  * Parse the "Host" header field hostname.
@@ -355,7 +355,7 @@ req.__defineGetter__('path', function(){
  * @api public
  */
 
-req.__defineGetter__('host', function(){
+Object.defineProperty(req, 'host', {get: function(){
   var trust = this.app.get('trust proxy fn');
   var host = this.get('X-Forwarded-Host');
 
@@ -374,7 +374,7 @@ req.__defineGetter__('host', function(){
   return ~index
     ? host.substring(0, index)
     : host;
-});
+}});
 
 /**
  * Check if the request is fresh, aka
@@ -385,7 +385,7 @@ req.__defineGetter__('host', function(){
  * @api public
  */
 
-req.__defineGetter__('fresh', function(){
+Object.defineProperty(req, 'fresh', {get: function(){
   var method = this.method;
   var s = this.res.statusCode;
 
@@ -398,7 +398,7 @@ req.__defineGetter__('fresh', function(){
   }
 
   return false;
-});
+}});
 
 /**
  * Check if the request is stale, aka
@@ -409,9 +409,9 @@ req.__defineGetter__('fresh', function(){
  * @api public
  */
 
-req.__defineGetter__('stale', function(){
+Object.defineProperty(req, 'stale', {get: function(){
   return !this.fresh;
-});
+}});
 
 /**
  * Check if the request was an _XMLHttpRequest_.
@@ -420,7 +420,7 @@ req.__defineGetter__('stale', function(){
  * @api public
  */
 
-req.__defineGetter__('xhr', function(){
+Object.defineProperty(req, 'xhr', {get: function(){
   var val = this.get('X-Requested-With') || '';
   return 'xmlhttprequest' == val.toLowerCase();
-});
+}});

--- a/lib/request.js
+++ b/lib/request.js
@@ -238,6 +238,23 @@ req.is = function(types){
 };
 
 /**
+ * Helper function for creating a getter on an object.
+ *
+ * @param {Object} object to set getter on
+ * @param {String} name of getter
+ * @param {Function} function to call for getter
+ * @return {undefined}
+ * @api private
+ */
+var defineGetter = function(obj, name, func) {
+  Object.defineProperty(obj, name, {
+    configurable: true,
+    enumerable: true,
+    get: func
+  });
+};
+
+/**
  * Return the protocol string "http" or "https"
  * when requested with TLS. When the "trust proxy"
  * setting trusts the socket address, the
@@ -249,23 +266,19 @@ req.is = function(types){
  * @api public
  */
 
-Object.defineProperty(req, 'protocol', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    var trust = this.app.get('trust proxy fn');
+defineGetter(req, 'protocol', function(){
+  var trust = this.app.get('trust proxy fn');
 
-    if (!trust(this.connection.remoteAddress)) {
-      return this.connection.encrypted
-        ? 'https'
-        : 'http';
-    }
-
-    // Note: X-Forwarded-Proto is normally only ever a
-    //       single value, but this is to be safe.
-    var proto = this.get('X-Forwarded-Proto') || 'http';
-    return proto.split(/\s*,\s*/)[0];
+  if (!trust(this.connection.remoteAddress)) {
+    return this.connection.encrypted
+      ? 'https'
+      : 'http';
   }
+
+  // Note: X-Forwarded-Proto is normally only ever a
+  //       single value, but this is to be safe.
+  var proto = this.get('X-Forwarded-Proto') || 'http';
+  return proto.split(/\s*,\s*/)[0];
 });
 
 /**
@@ -277,12 +290,8 @@ Object.defineProperty(req, 'protocol', {
  * @api public
  */
 
-Object.defineProperty(req, 'secure', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    return 'https' == this.protocol;
-  }
+defineGetter(req, 'secure', function(){
+  return 'https' == this.protocol;
 });
 
 /**
@@ -295,13 +304,9 @@ Object.defineProperty(req, 'secure', {
  * @api public
  */
 
-Object.defineProperty(req, 'ip', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    var trust = this.app.get('trust proxy fn');
-    return proxyaddr(this, trust);
-  }
+defineGetter(req, 'ip', function(){
+  var trust = this.app.get('trust proxy fn');
+  return proxyaddr(this, trust);
 });
 
 /**
@@ -316,14 +321,10 @@ Object.defineProperty(req, 'ip', {
  * @api public
  */
 
-Object.defineProperty(req, 'ips', {
-  configurable: true,
-  enumerable: true,
-  get: function() {
-    var trust = this.app.get('trust proxy fn');
-    var addrs = proxyaddr.all(this, trust);
-    return addrs.slice(1).reverse();
-  }
+defineGetter(req, 'ips', function() {
+  var trust = this.app.get('trust proxy fn');
+  var addrs = proxyaddr.all(this, trust);
+  return addrs.slice(1).reverse();
 });
 
 /**
@@ -341,16 +342,12 @@ Object.defineProperty(req, 'ips', {
  * @api public
  */
 
-Object.defineProperty(req, 'subdomains', {
-  configurable: true,
-  enumerable: true,
-  get: function() {
+defineGetter(req, 'subdomains', function() {
   var offset = this.app.get('subdomain offset');
   return (this.host || '')
     .split('.')
     .reverse()
     .slice(offset);
-  }
 });
 
 /**
@@ -360,12 +357,8 @@ Object.defineProperty(req, 'subdomains', {
  * @api public
  */
 
-Object.defineProperty(req, 'path', {
-  configurable: true,
-  enumerable: true,
-  get: function() {
-    return parse(this).pathname;
-  }
+defineGetter(req, 'path', function() {
+  return parse(this).pathname;
 });
 
 /**
@@ -379,29 +372,25 @@ Object.defineProperty(req, 'path', {
  * @api public
  */
 
-Object.defineProperty(req, 'host', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    var trust = this.app.get('trust proxy fn');
-    var host = this.get('X-Forwarded-Host');
+defineGetter(req, 'host', function(){
+  var trust = this.app.get('trust proxy fn');
+  var host = this.get('X-Forwarded-Host');
 
-    if (!host || !trust(this.connection.remoteAddress)) {
-      host = this.get('Host');
-    }
-
-    if (!host) return;
-
-    // IPv6 literal support
-    var offset = host[0] === '['
-      ? host.indexOf(']') + 1
-      : 0;
-    var index = host.indexOf(':', offset);
-
-    return ~index
-      ? host.substring(0, index)
-      : host;
+  if (!host || !trust(this.connection.remoteAddress)) {
+    host = this.get('Host');
   }
+
+  if (!host) return;
+
+  // IPv6 literal support
+  var offset = host[0] === '['
+    ? host.indexOf(']') + 1
+    : 0;
+  var index = host.indexOf(':', offset);
+
+  return ~index
+    ? host.substring(0, index)
+    : host;
 });
 
 /**
@@ -413,23 +402,19 @@ Object.defineProperty(req, 'host', {
  * @api public
  */
 
-Object.defineProperty(req, 'fresh', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    var method = this.method;
-    var s = this.res.statusCode;
+defineGetter(req, 'fresh', function(){
+  var method = this.method;
+  var s = this.res.statusCode;
 
-    // GET or HEAD for weak freshness validation only
-    if ('GET' != method && 'HEAD' != method) return false;
+  // GET or HEAD for weak freshness validation only
+  if ('GET' != method && 'HEAD' != method) return false;
 
-    // 2xx or 304 as per rfc2616 14.26
-    if ((s >= 200 && s < 300) || 304 == s) {
-      return fresh(this.headers, this.res._headers);
-    }
-
-    return false;
+  // 2xx or 304 as per rfc2616 14.26
+  if ((s >= 200 && s < 300) || 304 == s) {
+    return fresh(this.headers, this.res._headers);
   }
+
+  return false;
 });
 
 /**
@@ -441,12 +426,8 @@ Object.defineProperty(req, 'fresh', {
  * @api public
  */
 
-Object.defineProperty(req, 'stale', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    return !this.fresh;
-  }
+defineGetter(req, 'stale', function(){
+  return !this.fresh;
 });
 
 /**
@@ -456,11 +437,7 @@ Object.defineProperty(req, 'stale', {
  * @api public
  */
 
-Object.defineProperty(req, 'xhr', {
-  configurable: true,
-  enumerable: true,
-  get: function(){
-    var val = this.get('X-Requested-With') || '';
-    return 'xmlhttprequest' == val.toLowerCase();
-  }
+defineGetter(req, 'xhr', function(){
+  var val = this.get('X-Requested-With') || '';
+  return 'xmlhttprequest' == val.toLowerCase();
 });

--- a/lib/request.js
+++ b/lib/request.js
@@ -249,20 +249,24 @@ req.is = function(types){
  * @api public
  */
 
-Object.defineProperty(req, 'protocol', {get: function(){
-  var trust = this.app.get('trust proxy fn');
+Object.defineProperty(req, 'protocol', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    var trust = this.app.get('trust proxy fn');
 
-  if (!trust(this.connection.remoteAddress)) {
-    return this.connection.encrypted
-      ? 'https'
-      : 'http';
+    if (!trust(this.connection.remoteAddress)) {
+      return this.connection.encrypted
+        ? 'https'
+        : 'http';
+    }
+
+    // Note: X-Forwarded-Proto is normally only ever a
+    //       single value, but this is to be safe.
+    var proto = this.get('X-Forwarded-Proto') || 'http';
+    return proto.split(/\s*,\s*/)[0];
   }
-
-  // Note: X-Forwarded-Proto is normally only ever a
-  //       single value, but this is to be safe.
-  var proto = this.get('X-Forwarded-Proto') || 'http';
-  return proto.split(/\s*,\s*/)[0];
-}});
+});
 
 /**
  * Short-hand for:
@@ -273,9 +277,13 @@ Object.defineProperty(req, 'protocol', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'secure', {get: function(){
-  return 'https' == this.protocol;
-}});
+Object.defineProperty(req, 'secure', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    return 'https' == this.protocol;
+  }
+});
 
 /**
  * Return the remote address from the trusted proxy.
@@ -287,10 +295,14 @@ Object.defineProperty(req, 'secure', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'ip', {get: function(){
-  var trust = this.app.get('trust proxy fn');
-  return proxyaddr(this, trust);
-}});
+Object.defineProperty(req, 'ip', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    var trust = this.app.get('trust proxy fn');
+    return proxyaddr(this, trust);
+  }
+});
 
 /**
  * When "trust proxy" is set, trusted proxy addresses + client.
@@ -304,11 +316,15 @@ Object.defineProperty(req, 'ip', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'ips', {get: function() {
-  var trust = this.app.get('trust proxy fn');
-  var addrs = proxyaddr.all(this, trust);
-  return addrs.slice(1).reverse();
-}});
+Object.defineProperty(req, 'ips', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    var trust = this.app.get('trust proxy fn');
+    var addrs = proxyaddr.all(this, trust);
+    return addrs.slice(1).reverse();
+  }
+});
 
 /**
  * Return subdomains as an array.
@@ -325,13 +341,17 @@ Object.defineProperty(req, 'ips', {get: function() {
  * @api public
  */
 
-Object.defineProperty(req, 'subdomains', {get: function() {
+Object.defineProperty(req, 'subdomains', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
   var offset = this.app.get('subdomain offset');
   return (this.host || '')
     .split('.')
     .reverse()
     .slice(offset);
-}});
+  }
+});
 
 /**
  * Short-hand for `url.parse(req.url).pathname`.
@@ -340,9 +360,13 @@ Object.defineProperty(req, 'subdomains', {get: function() {
  * @api public
  */
 
-Object.defineProperty(req, 'path', {get: function() {
-  return parse(this).pathname;
-}});
+Object.defineProperty(req, 'path', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return parse(this).pathname;
+  }
+});
 
 /**
  * Parse the "Host" header field hostname.
@@ -355,26 +379,30 @@ Object.defineProperty(req, 'path', {get: function() {
  * @api public
  */
 
-Object.defineProperty(req, 'host', {get: function(){
-  var trust = this.app.get('trust proxy fn');
-  var host = this.get('X-Forwarded-Host');
+Object.defineProperty(req, 'host', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    var trust = this.app.get('trust proxy fn');
+    var host = this.get('X-Forwarded-Host');
 
-  if (!host || !trust(this.connection.remoteAddress)) {
-    host = this.get('Host');
+    if (!host || !trust(this.connection.remoteAddress)) {
+      host = this.get('Host');
+    }
+
+    if (!host) return;
+
+    // IPv6 literal support
+    var offset = host[0] === '['
+      ? host.indexOf(']') + 1
+      : 0;
+    var index = host.indexOf(':', offset);
+
+    return ~index
+      ? host.substring(0, index)
+      : host;
   }
-
-  if (!host) return;
-
-  // IPv6 literal support
-  var offset = host[0] === '['
-    ? host.indexOf(']') + 1
-    : 0;
-  var index = host.indexOf(':', offset);
-
-  return ~index
-    ? host.substring(0, index)
-    : host;
-}});
+});
 
 /**
  * Check if the request is fresh, aka
@@ -385,20 +413,24 @@ Object.defineProperty(req, 'host', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'fresh', {get: function(){
-  var method = this.method;
-  var s = this.res.statusCode;
+Object.defineProperty(req, 'fresh', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    var method = this.method;
+    var s = this.res.statusCode;
 
-  // GET or HEAD for weak freshness validation only
-  if ('GET' != method && 'HEAD' != method) return false;
+    // GET or HEAD for weak freshness validation only
+    if ('GET' != method && 'HEAD' != method) return false;
 
-  // 2xx or 304 as per rfc2616 14.26
-  if ((s >= 200 && s < 300) || 304 == s) {
-    return fresh(this.headers, this.res._headers);
+    // 2xx or 304 as per rfc2616 14.26
+    if ((s >= 200 && s < 300) || 304 == s) {
+      return fresh(this.headers, this.res._headers);
+    }
+
+    return false;
   }
-
-  return false;
-}});
+});
 
 /**
  * Check if the request is stale, aka
@@ -409,9 +441,13 @@ Object.defineProperty(req, 'fresh', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'stale', {get: function(){
-  return !this.fresh;
-}});
+Object.defineProperty(req, 'stale', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    return !this.fresh;
+  }
+});
 
 /**
  * Check if the request was an _XMLHttpRequest_.
@@ -420,7 +456,11 @@ Object.defineProperty(req, 'stale', {get: function(){
  * @api public
  */
 
-Object.defineProperty(req, 'xhr', {get: function(){
-  var val = this.get('X-Requested-With') || '';
-  return 'xmlhttprequest' == val.toLowerCase();
-}});
+Object.defineProperty(req, 'xhr', {
+  configurable: true,
+  enumerable: true,
+  get: function(){
+    var val = this.get('X-Requested-With') || '';
+    return 'xmlhttprequest' == val.toLowerCase();
+  }
+});


### PR DESCRIPTION
Replaced deprecated **defineGetter**() functions with ES5 compliant Object.defineProperty() functions.
