### PR TITLE
Use path.join instead of string concat

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -11,6 +11,7 @@ var query = require('./middleware/query');
 var debug = require('debug')('express:application');
 var View = require('./view');
 var http = require('http');
+var path = require('path');
 var compileETag = require('./utils').compileETag;
 var compileTrust = require('./utils').compileTrust;
 var deprecate = require('./utils').deprecate;
@@ -74,7 +75,7 @@ app.defaultConfiguration = function(){
 
   // default configuration
   this.set('view', View);
-  this.set('views', process.cwd() + '/views');
+  this.set('views', path.resolve('views'));
   this.set('jsonp callback name', 'callback');
 
   if (env === 'production') {


### PR DESCRIPTION
I just got bitten by this trying to run an express app on Windows. `path.join` allows us to be platform agnostic, so let's use it.
