### PR TITLE
Update path regexp functionality

### DIFF
--- a/examples/downloads/app.js
+++ b/examples/downloads/app.js
@@ -15,7 +15,7 @@ app.get('/', function(req, res){
 
 // /files/* is accessed via req.params[0]
 // but here we name it :file
-app.get('/files/:file(*)', function(req, res, next){
+app.get('/files/:file(.*)', function(req, res, next){
   var file = req.params.file;
   var path = __dirname + '/files/' + file;
 

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -56,11 +56,9 @@ Layer.prototype.match = function(path){
       throw err;
     }
 
-    if (key) {
-      params[key.name] = val;
-    } else {
-      params[n++] = val;
-    }
+    if (key.repeat) val = val.split(key.delimiter);
+
+    params[key.name] = val;
   }
 
   return true;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "merge-descriptors": "0.0.2",
     "utils-merge": "1.0.0",
     "qs": "0.6.6",
-    "path-to-regexp": "0.1.2"
+    "path-to-regexp": "0.2.1"
   },
   "devDependencies": {
     "after": "0.8.1",

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -258,7 +258,7 @@ describe('app.router', function(){
   it('should allow escaped regexp', function(done){
     var app = express();
 
-    app.get('/user/\\d+', function(req, res){
+    app.get('/user/(\\d+)', function(req, res){
       res.end('woot');
     });
 
@@ -288,119 +288,50 @@ describe('app.router', function(){
   })
 
   describe('*', function(){
-    it('should denote a greedy capture group', function(done){
+    it('should denote a repeated optional parameter', function(done){
       var app = express();
 
-      app.get('/user/*.json', function(req, res){
-        res.end(req.params[0]);
+      app.get('/user/:user*', function(req, res){
+        res.send(req.params.user);
       });
 
       request(app)
-      .get('/user/tj.json')
-      .expect('tj', done);
-    })
-
-    it('should work with several', function(done){
-      var app = express();
-
-      app.get('/api/*.*', function(req, res){
-        var resource = req.params[0]
-          , format = req.params[1];
-        res.end(resource + ' as ' + format);
-      });
-
-      request(app)
-      .get('/api/users/foo.bar.json')
-      .expect('users/foo.bar as json', done);
-    })
-
-    it('should work cross-segment', function(done){
-      var app = express();
-
-      app.get('/api*', function(req, res){
-        res.send(req.params[0]);
-      });
-
-      request(app)
-      .get('/api')
-      .expect('', function(){
+      .get('/user')
+      .expect('[]')
+      .end(function(err, res){
         request(app)
-        .get('/api/hey')
-        .expect('/hey', done);
+        .get('/user/tj')
+        .expect('["tj"]')
+        .end(function(err, res){
+          request(app)
+          .get('/user/tj/tobi')
+          .expect('["tj","tobi"]', done);
+        });
       });
     })
+  })
 
-    it('should allow naming', function(done){
+  describe('+', function(){
+    it('should denote a repeated parameter', function(done){
       var app = express();
 
-      app.get('/api/:resource(*)', function(req, res){
-        var resource = req.params.resource;
-        res.end(resource);
+      app.get('/user/:user+', function(req, res){
+        res.send(req.params.user);
       });
 
       request(app)
-      .get('/api/users/0.json')
-      .expect('users/0.json', done);
-    })
-
-    it('should not be greedy immediately after param', function(done){
-      var app = express();
-
-      app.get('/user/:user*', function(req, res){
-        res.end(req.params.user);
+      .get('/user')
+      .expect(404)
+      .end(function(err, res){
+        request(app)
+        .get('/user/tj')
+        .expect('["tj"]')
+        .end(function(err, res){
+          request(app)
+          .get('/user/tj/tobi')
+          .expect('["tj","tobi"]', done);
+        });
       });
-
-      request(app)
-      .get('/user/122')
-      .expect('122', done);
-    })
-
-    it('should eat everything after /', function(done){
-      var app = express();
-
-      app.get('/user/:user*', function(req, res){
-        res.end(req.params.user);
-      });
-
-      request(app)
-      .get('/user/122/aaa')
-      .expect('122', done);
-    })
-
-    it('should span multiple segments', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file/javascripts/jquery.js')
-      .expect('javascripts/jquery.js', done);
-    })
-
-    it('should be optional', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file/')
-      .expect('', done);
-    })
-
-    it('should require a preceeding /', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file')
-      .expect(404, done);
     })
   })
 
@@ -621,7 +552,7 @@ describe('app.router', function(){
     var app = express();
     var path = [];
 
-    app.get('*', function(req, res, next){
+    app.get('(.*)', function(req, res, next){
       path.push(0);
       next();
     });
@@ -641,7 +572,7 @@ describe('app.router', function(){
       next();
     });
 
-    app.get('*', function(req, res, next){
+    app.get('(.*)', function(req, res, next){
       path.push(4);
       next();
     });


### PR DESCRIPTION
- Old asterisk functionality is obsolete
- Adds the repeated parameters mentioned in visionmedia/express#2134

This will break backward compatibility
