### PR TITLE
Inherit parent local settings

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -62,6 +62,7 @@ app.defaultConfiguration = function(){
     this.response.__proto__ = parent.response;
     this.engines.__proto__ = parent.engines;
     this.settings.__proto__ = parent.settings;
+    this.locals.__proto__ = parent.locals;
   });
 
   // setup locals

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -24,4 +24,43 @@ describe('app', function(){
       obj.should.have.property('title', 'House of Manny');
     })
   })
+
+  describe('.locals', function(){
+    it('should lookup on parent when mounted', function(done){
+      var app = express();
+      var blog = express();
+
+      app.locals.foo = 'bar';
+
+      app.use(blog);
+
+      blog.use(function(req, res){
+        req.app.locals.foo.should.equal('bar');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(200, done);
+    });
+
+    it('should override parent when mounted', function(done){
+      var app = express();
+      var blog = express();
+
+      app.locals.foo = 'bar';
+      blog.locals.foo = 'baz';
+
+      app.use(blog);
+
+      blog.use(function(req, res){
+        req.app.locals.foo.should.equal('baz');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(200, done);
+    });
+  })
 })


### PR DESCRIPTION
This is quite useful when you set script or style locations in the parent app, and in the child app you use it during render, like this:

``` jade
each style in styles
  link(rel='stylesheet', href=style)
```

If there is already a best practice for achieving this functionality, please tell me!
