### PR TITLE
add fix for non-ascii filenames in content-disposition headers

### DIFF
--- a/examples/downloads/app.js
+++ b/examples/downloads/app.js
@@ -10,6 +10,7 @@ app.get('/', function(req, res){
     + '<li>Download <a href="/files/amazing.txt">amazing.txt</a>.</li>'
     + '<li>Download <a href="/files/utf-8 한中日.txt">utf-8 한中日.txt</a>.</li>'
     + '<li>Download <a href="/files/missing.txt">missing.txt</a>.</li>'
+    + '<li>Download <a href="/files/首届CCTV阿拉伯语大赛上海分赛区初赛圆满落幕.txt">首届CCTV阿拉伯语大赛上海分赛区初赛圆满落幕.txt</a>.</li>'
     + '</ul>');
 });
 

--- a/examples/downloads/files/首届CCTV阿拉伯语大赛上海分赛区初赛圆满落幕.txt
+++ b/examples/downloads/files/首届CCTV阿拉伯语大赛上海分赛区初赛圆满落幕.txt
@@ -1,0 +1,2 @@
+Only for test.
+The file name is faked.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,7 +164,7 @@ exports.contentDisposition = function(filename){
     filename = basename(filename);
     // if filename contains non-ascii characters, add a utf-8 version ala RFC 5987
     ret = /[^\040-\176]/.test(filename)
-      ? 'attachment; filename=' + encodeURI(filename) + '; filename*=UTF-8\'\'' + encodeURI(filename)
+      ? 'attachment; filename="' + encodeURI(filename) + '"; filename*=UTF-8\'\'' + encodeURI(filename)
       : 'attachment; filename="' + filename + '"';
   }
 

--- a/test/res.attachment.js
+++ b/test/res.attachment.js
@@ -57,7 +57,7 @@ describe('res', function(){
       request(app)
       .get('/')
       .expect('Content-Disposition', 'attachment;' +
-          ' filename=%E6%97%A5%E6%9C%AC%E8%AA%9E.txt;' +
+          ' filename="%E6%97%A5%E6%9C%AC%E8%AA%9E.txt";' +
           ' filename*=UTF-8\'\'%E6%97%A5%E6%9C%AC%E8%AA%9E.txt',
         done);
     })


### PR DESCRIPTION
For visionmedia/express#2058, although it is correct on almost all the browers, but it may face some problem for non-ascii filenames on safari.
I just add `""` on the encoded filename, then it is OK on Safari.
###### Before:

![qq20140620134130](https://cloud.githubusercontent.com/assets/424475/3336835/8c6a5110-f83d-11e3-88a9-eb5170988917.jpg)
###### After:

![qq20140620134126](https://cloud.githubusercontent.com/assets/424475/3336838/92598ef6-f83d-11e3-8c81-973330fe64cf.jpg)

Reference:
http://blog.robotshell.org/2012/deal-with-http-header-encoding-for-file-download/
