### PR TITLE
Update CORS example.

### DIFF
--- a/examples/cors/index.js
+++ b/examples/cors/index.js
@@ -25,7 +25,7 @@ api.all('*', function(req, res, next){
   if (!req.get('Origin')) return next();
   // use "*" here to accept any origin
   res.set('Access-Control-Allow-Origin', 'http://localhost:3000');
-  res.set('Access-Control-Allow-Methods', 'GET, POST');
+  res.set('Access-Control-Allow-Methods', 'PUT');
   res.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type');
   // res.set('Access-Control-Allow-Max-Age', 3600);
   if ('OPTIONS' == req.method) return res.send(200);
@@ -33,12 +33,12 @@ api.all('*', function(req, res, next){
 });
 
 /**
- * POST a user.
+ * PUT an existing user.
  */
 
-api.post('/user', function(req, res){
+api.put('/user/:id', function(req, res){
   console.log(req.body);
-  res.send(201);
+  res.send(204);
 });
 
 app.listen(3000);

--- a/examples/cors/public/index.html
+++ b/examples/cors/public/index.html
@@ -3,7 +3,7 @@
   <body>
     <script>
       var req = new XMLHttpRequest;
-      req.open('POST', 'http://localhost:3001/user', false);
+      req.open('PUT', 'http://localhost:3001/user/1', false);
       req.setRequestHeader('Content-Type', 'application/json');
       req.send('{"name":"tobi","species":"ferret"}');
       console.log(req.responseText);


### PR DESCRIPTION
According to the CORS spec, the POST method is a [simple method](http://www.w3.org/TR/cors/#simple-method) and does not need to be listed as part of the Access-Control-Allow-Methods response header. See number 9 on http://www.w3.org/TR/cors/#resource-preflight-requests 

> If a method is a simple method it does not need to be listed, but this is not prohibited.

This means the line:

``` javascript
res.set('Access-Control-Allow-Methods', 'GET, POST');
```

is completely irrelevant for the example.

This PR updates the example with an HTTP method that actually raises an error in case it's not listed as part of the CORS response headers.
