### PR TITLE
Change double quotes to single quotes on line 503

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -500,7 +500,7 @@ res.format = function(obj){
 
   var key = req.accepts(keys);
 
-  this.vary("Accept");
+  this.vary('Accept');
 
   if (key) {
     this.set('Content-Type', normalizeType(key).value);


### PR DESCRIPTION
Change from double quotes to single quotes for consistency throughout files.

Line 503:
BEFORE
  this.vary("Accept");

AFTER
  this.vary('Accept');
