### PR TITLE
Replace the "buffer-crc32" with "jhash"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
  */
 
 var mime = require('send').mime;
-var crc32 = require('buffer-crc32');
+var jhash = require('jhash');
 var crypto = require('crypto');
 var basename = require('path').basename;
 var proxyaddr = require('proxy-addr');
@@ -35,22 +35,17 @@ exports.etag = function etag(body, encoding){
  * Return weak ETag for `body`.
  *
  * @param {String|Buffer} body
- * @param {String} [encoding]
  * @return {String}
  * @api private
  */
 
-exports.wetag = function wetag(body, encoding){
-  if (body.length === 0) {
+exports.wetag = function wetag(body){
+  var len = body.length
+  if (len === 0) {
     // fast-path empty body
     return 'W/"0-0"'
   }
-
-  var buf = Buffer.isBuffer(body)
-    ? body
-    : new Buffer(body, encoding)
-  var len = buf.length
-  return 'W/"' + len.toString(16) + '-' + crc32.unsigned(buf) + '"'
+  return 'W/"' + len.toString(16) + '-' + jhash.hash(body) + '"'
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "~1.0.7",
-    "buffer-crc32": "0.2.3",
+    "jhash": "~0.1.4",
     "debug": "1.0.2",
     "depd": "0.3.0",
     "escape-html": "1.0.1",

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -109,7 +109,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('ETag', 'W/"7ff-2796319984"')
+      .expect('ETag', 'W/"7ff-1ju)Ki"')
       .end(done);
     })
 
@@ -198,7 +198,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('ETag', 'W/"7ff-2796319984"')
+      .expect('ETag', 'W/"7ff-1ju)Ki"')
       .end(done);
     })
 
@@ -314,7 +314,7 @@ describe('res', function(){
 
     request(app)
     .get('/')
-    .set('If-None-Match', 'W/"7ff-2796319984"')
+    .set('If-None-Match', 'W/"7ff-1ju)Ki"')
     .expect(304, done);
   })
 
@@ -360,7 +360,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"c-1525560792"', done)
+        .expect('etag', 'W/"c-bd3c-"', done)
       })
 
       it('should send ETag for empty string response', function(done){
@@ -389,7 +389,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"7ff-2796319984"', done)
+        .expect('etag', 'W/"7ff-1ju)Ki"', done)
       });
 
       it('should not override ETag when manually set', function(done){
@@ -488,7 +488,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"d-1486392595"', done)
+        .expect('etag', 'W/"d-mq8Up"', done)
       })
     })
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -28,18 +28,18 @@ describe('utils.etag(body, encoding)', function(){
 describe('utils.wetag(body, encoding)', function(){
   it('should support strings', function(){
     utils.wetag('express!')
-    .should.eql('W/"8-3098196679"')
+    .should.eql('W/"8-M!*1"')
   })
 
   it('should support utf8 strings', function(){
     utils.wetag('express❤', 'utf8')
-    .should.eql('W/"a-1751845617"')
+    .should.eql('W/"8-M.(o"')
   })
 
   it('should support buffer', function(){
     var buf = new Buffer('express!')
     utils.wetag(buf)
-    .should.eql('W/"8-3098196679"');
+    .should.eql('W/"8-M!*1"');
   })
 
   it('should support empty string', function(){


### PR DESCRIPTION
jhash will create shorter sum result and the performance is better.
It don't have to waste cpu to encoding a string into a buffer before calculating the hash.

Here's a simple benchmark's source code:
https://github.com/ysmood/nobone/blob/5e36ea738a57c69dce839eb2e595a4be2a73737d/benchmark/crc_vs_jhash.coffee

Here's the project home:
https://github.com/ysmood/jhash

As we can see, jhash is about 1.5x faster than crc32.
Their results of collision test are nearly the same.

```
Performance Test
crc buffer   x 5,903 ops/sec ±0.52% (100 runs sampled)
crc str      x 54,045 ops/sec ±6.67% (83 runs sampled)
jhash buffer x 9,756 ops/sec ±0.67% (101 runs sampled)
jhash str    x 72,056 ops/sec ±0.36% (94 runs sampled)
Collision Test
***** jhash *****
 5 samples: 3481292839,1601668515,957061576,1031084327,1000054056
      time: 10.001s
collisions: 0.0018788163457017504% (4/212900)
***** crc32 *****
 5 samples: 3494480258,2736329845,2815219153,3510180228,2016919691
      time: 10.003s
collisions: 0.0027945971122544933% (6/214700)
```
