### PR TITLE
Fixed a bug when sending status code with a number.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -100,15 +100,13 @@ res.send = function(body){
     }
   }
 
+  // when sending statusCode with a number.
+  if ('number' == typeof body && 2 == arguments.length)
+    body = body.toString();
+
   switch (typeof body) {
     // response status
     case 'number':
-      // when sending statusCode with a number.
-      if (arguments.length == 2) {
-        body = body.toString();
-        break;
-      }
-
       this.get('Content-Type') || this.type('txt');
       this.statusCode = body;
       body = http.STATUS_CODES[body];

--- a/lib/response.js
+++ b/lib/response.js
@@ -103,6 +103,12 @@ res.send = function(body){
   switch (typeof body) {
     // response status
     case 'number':
+      // when sending statusCode with a number.
+      if (arguments.length == 2) {
+        body = body.toString();
+        break;
+      }
+
       this.get('Content-Type') || this.type('txt');
       this.statusCode = body;
       body = http.STATUS_CODES[body];

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -81,6 +81,21 @@ describe('res', function(){
     })
   })
 
+  describe('.send(code, number)', function(){
+    it('should send number as string', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(200, 0.123);
+      });
+
+      request(app)
+      .get('/')
+      .expect('0.123')
+      .expect(200, done);
+    })
+  })
+
   describe('.send(String)', function(){
     it('should send as html', function(done){
       var app = express();


### PR DESCRIPTION
For the edge condition example see the added test case.

``` javascript
app.get('/', function (req, res) {
   res.send(200, 0.123);
})
```
