### PR TITLE
Support Requests directly from trusted proxy

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -345,14 +345,19 @@ req.is = function(type){
  * If you're running behind a reverse proxy that
  * supplies https for you this may be enabled.
  *
+ * If the "trust proxy" setting trusts the socket address
+ * but no "X-Forwarded-Proto" header was set then default
+ * to the connection between the proxy and node.
+ *
  * @return {String}
  * @api public
  */
 
 req.__defineGetter__('protocol', function(){
   var trust = this.app.get('trust proxy fn');
+  var proto = this.get('X-Forwarded-Proto');
 
-  if (!trust(this.connection.remoteAddress)) {
+  if (!proto || !trust(this.connection.remoteAddress)) {
     return this.connection.encrypted
       ? 'https'
       : 'http';
@@ -360,7 +365,6 @@ req.__defineGetter__('protocol', function(){
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  var proto = this.get('X-Forwarded-Proto') || 'http';
   return proto.split(/\s*,\s*/)[0];
 });
 

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -32,6 +32,21 @@ describe('req', function(){
         .expect('https', done);
       })
 
+      it('should default to the socket addr if X-Forwarded-Proto not present', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          req.connection.encrypted = true;
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .expect('https', done);
+      })
+
       it('should ignore X-Forwarded-Proto if socket addr not trusted', function(done){
         var app = express();
 


### PR DESCRIPTION
When returning the protocol used handle the case where the trusted proxy has made a request to a express directly.  When this occurs use the encrypted state on the underlying connection.

This happens with Amazon's ELBs with auto-scaling groups.  The ELB will ping and healthcheck endpoint on the node server to verify its health.  In this case there is no X-Forwarded-Proto header since the request originates directly from the ELB.
