### PR TITLE
Revert the example change that breaks a test

### DIFF
--- a/examples/web-service/index.js
+++ b/examples/web-service/index.js
@@ -49,7 +49,7 @@ var apiKeys = ['foo', 'bar', 'baz'];
 // these two objects will serve as our faux database
 
 var repos = [
-    { name: 'express', url: 'http://github.com/strongloop/express' }
+    { name: 'express', url: 'http://github.com/visionmedia/express' }
   , { name: 'stylus', url: 'http://github.com/learnboost/stylus' }
   , { name: 'cluster', url: 'http://github.com/learnboost/cluster' }
 ];


### PR DESCRIPTION
One of the tests check for hard-coded repo name url. It's now broken due to repo change.
