### PR TITLE
Fix app.use('/blog', mw1, mw2, blogApp)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -150,51 +150,51 @@ app.handle = function(req, res, done) {
  */
 
 app.use = function use(path, fn) {
-  var mount_app;
-  var mount_path;
-  
   var args = [].slice.call(arguments);
-  mount_app = args[args.length - 1];
+  var mount_apps = [];
+  var mount_path;
+  var offset = 0;
   
   if (typeof args[0] === 'string') {
     mount_path = args[0];
+    offset = 1;
   } else {
     mount_path = '/';
   }
-
+  
   // setup router
   this.lazyrouter();
   var router = this._router;
   
-  // express app
-  if (mount_app && mount_app.handle && mount_app.set) {
-    debug('.use app under %s', mount_path);
-    mount_app.mountpath = mount_path;
-    mount_app.parent = this;
-
-    var handler = function mounted_app(req, res, next) {
-      var orig = req.app;
-      mount_app.handle(req, res, function(err) {
-        req.__proto__ = orig.request;
-        res.__proto__ = orig.response;
-        next(err);
-      });
-    };
-
-    // replace the final argument
-    args[args.length - 1] = handler;
-    
-    // restore .app property on req and res
-    router.use.apply(router, args);
-
-    // mounted an app
-    mount_app.emit('mount', this);
-
-    return this;
+  for (var i = offset; i < args.length; i++) {
+    if (typeof args[i].handle === 'function' && args[i].set) {
+        debug('.use app under %s', mount_path);
+        var mount_app = args[i];
+        mount_app.mountpath = mount_path;
+        mount_app.parent = this;
+        
+        mount_apps.push(mount_app);
+        
+        var handler = function mounted_app(req, res, next) {
+          var orig = req.app;
+          mount_app.handle(req, res, function(err) {
+            req.__proto__ = orig.request;
+            res.__proto__ = orig.response;
+            next(err);
+          });
+        };
+        
+        args[i] = handler;
+    }
   }
-
+  
   // pass-through use
-  router.use.apply(router, arguments);
+  router.use.apply(router, args);
+  
+  // mount apps
+  for (var i = 0; i < mount_apps.length; i++) {
+    mount_apps[i].emit('mount', this);
+  }
 
   return this;
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -152,36 +152,40 @@ app.handle = function(req, res, done) {
 app.use = function use(path, fn) {
   var mount_app;
   var mount_path;
-
-  // check for .use(path, app) or .use(app) signature
-  if (arguments.length <= 2) {
-    mount_path = typeof path === 'string'
-      ? path
-      : '/';
-    mount_app = typeof path === 'function'
-      ? path
-      : fn;
+  
+  var args = [].slice.call(arguments);
+  mount_app = args[args.length - 1];
+  
+  if (typeof args[0] === 'string') {
+    mount_path = args[0];
+  } else {
+    mount_path = '/';
   }
 
   // setup router
   this.lazyrouter();
   var router = this._router;
-
+  
   // express app
   if (mount_app && mount_app.handle && mount_app.set) {
     debug('.use app under %s', mount_path);
     mount_app.mountpath = mount_path;
     mount_app.parent = this;
 
-    // restore .app property on req and res
-    router.use(mount_path, function mounted_app(req, res, next) {
+    var handler = function mounted_app(req, res, next) {
       var orig = req.app;
       mount_app.handle(req, res, function(err) {
         req.__proto__ = orig.request;
         res.__proto__ = orig.response;
         next(err);
       });
-    });
+    };
+
+    // replace the final argument
+    args[args.length - 1] = handler;
+    
+    // restore .app property on req and res
+    router.use.apply(router, args);
 
     // mounted an app
     mount_app.emit('mount', this);

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -84,6 +84,33 @@ describe('app', function(){
       .get('/post/once-upon-a-time')
       .expect('success', done);
     })
+    
+    it('should support middleware', function(done){
+      var blog = express()
+        , app = express();
+
+      function fn1(req, res, next) {
+        res.setHeader('x-fn-1', 'hit');
+        next();
+      }
+      
+      function fn2(req, res, next) {
+        res.setHeader('x-fn-2', 'hit');
+        next();
+      }
+
+      blog.get('/', function(req, res){
+        res.end('success');
+      });
+
+      app.use('/post/:article', fn1, fn2, blog);
+
+      request(app)
+      .get('/post/once-upon-a-time')
+      .expect('x-fn-1', 'hit')
+      .expect('x-fn-2', 'hit')
+      .expect('success', done);
+    })
   })
 
   describe('.use(middleware)', function(){

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -102,7 +102,19 @@ describe('app', function(){
       blog.get('/', function(req, res){
         res.end('success');
       });
+      
+      // var other = express();
+      // 
+      // other.use(function(req, res, next) {
+      //   next();
+      // });
+      // 
+      // other.get('/', function(req, res, next) {
+      //   next();
+      // });
 
+      // app.use('/post/:article', fn1, other, fn2, blog);
+      
       app.use('/post/:article', fn1, fn2, blog);
 
       request(app)


### PR DESCRIPTION
This fixes the use case of mounting another app with preceding middleware, as introduced by #2224
