### PR TITLE
Add res.sendStatus method

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -304,6 +304,26 @@ res.jsonp = function jsonp(obj) {
 };
 
 /**
+ * Send given HTTP status code.
+ *
+ * Sets the response status to `statusCode` and the body of the
+ * response to the standard description from node's http.STATUS_CODES.
+ * 
+ * Examples:
+ *
+ *     res.sendStatus(200);
+ *
+ * @param {number} statusCode
+ * @api public
+ */
+
+res.sendStatus = function sendStatus(statusCode) {
+  this.status(statusCode);
+  this.set('Content-Type', 'text/plain');
+  this.send(http.STATUS_CODES[statusCode]);
+};
+
+/**
  * Transfer the file at the given `path`.
  *
  * Automatically sets the _Content-Type_ response header field.

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -1,0 +1,33 @@
+
+var express = require('../')
+  , request = require('supertest')
+  , assert = require('assert')
+  , http = require("http");
+
+describe('res', function(){
+  describe('.sendStatus(statusCode)', function(){
+    it('should send the correct status', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.sendStatus(201);
+      });
+
+      request(app)
+      .get('/')
+      .expect(201, done);
+    })
+    
+    it('should send a body from http\'s STATUS_CODE', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.sendStatus(404);
+      });
+
+      request(app)
+      .get('/')
+      .expect(404, http.STATUS_CODES[404], done);
+    })
+  })
+})


### PR DESCRIPTION
A helpful method for apps that send many simple status code responses, e.g., REST APIs. The body of the response is set using node's http.STATUS_CODES to avoid problems with clients that choke on empty body responses.
