### PR TITLE
Add a test on res.sendFile if path is null

### DIFF
--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -151,6 +151,23 @@ describe('res', function(){
       .get('/')
       .expect(200, 'got it', done);
     })
+
+    it('should throw a TypeError if path is null', function(done){
+      var app = express();
+
+      app.use(function (req, res) {
+        try {
+          res.sendFile(null, function (err) {});
+        } catch(e) {
+          e.name.should.equal('TypeError');
+          done();
+        }
+      });
+
+      request(app)
+      .get('/')
+      .end(function(){});
+    })
   })
 
   describe('.sendfile(path, fn)', function(){

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -153,20 +153,11 @@ describe('res', function(){
     })
 
     it('should throw a TypeError if path is null', function(done){
-      var app = express();
-
-      app.use(function (req, res) {
-        try {
-          res.sendFile(null, function (err) {});
-        } catch(e) {
-          e.name.should.equal('TypeError');
-          done();
-        }
-      });
+      var app = createApp(null);
 
       request(app)
       .get('/')
-      .end(function(){});
+      .expect(500, /path argument/, done);
     })
   })
 


### PR DESCRIPTION
It was a missing line in the coverage, res should be covered to 100% with this one.
I don't know if there a better way to assert this part.
