### PR TITLE
#sendFile callback not invoked when request aborted

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -364,16 +364,19 @@ res.sendFile = function sendFile(path, options, fn) {
     throw new TypeError('path must be absolute or specify root to res.sendFile');
   }
 
-  // socket errors
-  req.socket.on('error', onerror);
+  // @todo find a good way to test if request was aborted
+  if (!req.socket.writable) onabort();
+  req.on('aborted', onabort);
+
+  // abort
+  function onabort () {
+    onerror(new Error('Request aborted'));
+  }
 
   // errors
   function onerror(err) {
     if (done) return;
     done = true;
-
-    // clean up
-    cleanup();
 
     // callback available
     if (fn) return fn(err);
@@ -382,16 +385,11 @@ res.sendFile = function sendFile(path, options, fn) {
     next(err);
   }
 
-  // streaming
-  function onstream(stream) {
+  // end
+  function onend() {
     if (done) return;
-    cleanup();
-    if (fn) stream.on('end', fn);
-  }
-
-  // cleanup
-  function cleanup() {
-    req.socket.removeListener('error', onerror);
+    done = true;
+    if (fn) fn();
   }
 
   // transfer
@@ -399,7 +397,7 @@ res.sendFile = function sendFile(path, options, fn) {
   var file = send(req, pathname, options);
   file.on('error', onerror);
   file.on('directory', next);
-  file.on('stream', onstream);
+  file.on('end', onend);
 
   if (options.headers) {
     // set headers on successful transfer
@@ -416,7 +414,6 @@ res.sendFile = function sendFile(path, options, fn) {
 
   // pipe
   file.pipe(this);
-  this.on('finish', cleanup);
 };
 
 /**

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -5,6 +5,8 @@ var express = require('../')
   , assert = require('assert');
 var path = require('path');
 var should = require('should');
+var net = require('net');
+var http = require('http');
 var fixtures = path.join(__dirname, 'fixtures');
 
 describe('res', function(){
@@ -485,6 +487,55 @@ describe('res', function(){
           .expect('tobi', done);
         })
       })
+    })
+  })
+  describe('with aborted requests', function(){
+
+    function sendAbortedRequest (app) {
+      var server = http.createServer(app);
+      app.server = server;
+      server.listen(function () {
+        var port = this.address().port;
+        var headers = [
+            'GET / HTTP/1.1',
+            'Host: localhost:3000',
+            '',
+            ''
+          ].join('\r\n');
+
+        var socket = new net.Socket();
+        socket.connect(port, 'localhost', function() {
+          socket.write(headers, 'utf-8', function () {
+              socket.end();
+          });
+        });
+      });
+    }
+
+    it('should invoke callback', function(done){
+      var app = express();
+      app.get('/', function (req, res) {
+        res.sendFile(__filename, function (err) {
+          assert(err);
+          app.server.close();
+          done();
+        });
+      });
+      sendAbortedRequest(app);
+    })
+
+    it('should also invoke callback when deferred', function(done){
+      var app = express();
+      app.get('/', function (req, res) {
+        setImmediate(function () {
+          res.sendFile(__filename, function (err) {
+            assert(err);
+            app.server.close();
+            done();
+          });  
+        });
+      });
+      sendAbortedRequest(app);
     })
   })
 })


### PR DESCRIPTION
Hi.

I have been hunting memory and file descriptor leaks in my web service. There are several issues in `#sendFile` and in the `send` dependency when requests are aborted.

The following example leaks open files and I think it also leads to a memory leak that prevents the request and response object from being garbage collected.

``` javascript
var express = require('express');
var app = express();
var http = require('http');

app.get('/', function (req, res) {
    res.sendFile(__filename);
});
http.createServer(app).listen(3000, 'localhost');
```

I used following script to generate some aborted requests and looked with `lsof` for open files after.

``` javascript
var net = require('net');
var headers = [
    'GET / HTTP/1.1',
    'Host: localhost:3000',
    '',
    ''
  ].join('\r\n');

function sendCanceledRequest () {
  var socket = new net.Socket();
  socket.connect(3000, 'localhost', function() {
    socket.write(headers, 'utf-8', function () {
        socket.destroy();
    });
  });  
}

setInterval(sendCanceledRequest, 1000);
```

`#sendFile` handles the `error` event of the underlying socket. As far as i understand that event fires when the `Content-Length` header is sent and the request is closed before that length is reached. But it does not fire for well-formed requests that close too early (Tested on node v0.10.28)

I think the `end` event should also get handled. 

Maybe both events should get handled directly in the `send` dependency. 

Send currently does not handle the request `close` and socket `error` event. And also does not provide a public api to clean up once it's started.

The example in the `#sendFile` doc comment suggests that you can do some async stuff in a route and then call `#sendFile` after. This will lead again to the same problem if the `error` event or the `close` event fires before `#sendFile` is called.

I would create a pull request. But i wanted to ask first how you think this should get handled.
