### PR TITLE
Clean up #sendFile

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -364,16 +364,10 @@ res.sendFile = function sendFile(path, options, fn) {
     throw new TypeError('path must be absolute or specify root to res.sendFile');
   }
 
-  // socket errors
-  req.socket.on('error', onerror);
-
   // errors
   function onerror(err) {
     if (done) return;
     done = true;
-
-    // clean up
-    cleanup();
 
     // callback available
     if (fn) return fn(err);
@@ -382,16 +376,11 @@ res.sendFile = function sendFile(path, options, fn) {
     next(err);
   }
 
-  // streaming
-  function onstream(stream) {
+  // end
+  function onend () {
     if (done) return;
-    cleanup();
-    if (fn) stream.on('end', fn);
-  }
-
-  // cleanup
-  function cleanup() {
-    req.socket.removeListener('error', onerror);
+    done = true;
+    if (fn) fn();
   }
 
   // transfer
@@ -399,7 +388,7 @@ res.sendFile = function sendFile(path, options, fn) {
   var file = send(req, pathname, options);
   file.on('error', onerror);
   file.on('directory', next);
-  file.on('stream', onstream);
+  file.on('end', onend);
 
   if (options.headers) {
     // set headers on successful transfer
@@ -416,7 +405,6 @@ res.sendFile = function sendFile(path, options, fn) {
 
   // pipe
   file.pipe(this);
-  this.on('finish', cleanup);
 };
 
 /**


### PR DESCRIPTION
In case my pull request for send gets merged `#sendFile` can get cleaned up (https://github.com/visionmedia/send/pull/58)

This would also fix an issue that in some cases the callback of `#sendFile` is never invoked.
