### PR TITLE
Release 4.9

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
     - Applies to `res.sendFile`, `res.sendfile`, and `res.download`
     - `err` will be populated with request aborted error
   * Support IP address host in `req.subdomains`
+  * Use `etag` to generate `ETag` headers
   * deps: accepts@~1.1.0
     - update `mime-types`
   * deps: cookie-signature@1.0.5

--- a/History.md
+++ b/History.md
@@ -1,6 +1,9 @@
 unreleased
 ==========
 
+  * Invoke callback for sendfile when client aborts
+    - Applies to `res.sendFile`, `res.sendfile`, and `res.download`
+    - `err` will be populated with request aborted error
   * Support IP address host in `req.subdomains`
   * deps: accepts@~1.1.0
     - update `mime-types`

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add `res.sendStatus`
   * Invoke callback for sendfile when client aborts
     - Applies to `res.sendFile`, `res.sendfile`, and `res.download`
     - `err` will be populated with request aborted error

--- a/lib/response.js
+++ b/lib/response.js
@@ -304,6 +304,30 @@ res.jsonp = function jsonp(obj) {
 };
 
 /**
+ * Send given HTTP status code.
+ *
+ * Sets the response status to `statusCode` and the body of the
+ * response to the standard description from node's http.STATUS_CODES
+ * or the statusCode number if no description.
+ *
+ * Examples:
+ *
+ *     res.sendStatus(200);
+ *
+ * @param {number} statusCode
+ * @api public
+ */
+
+res.sendStatus = function sendStatus(statusCode) {
+  var body = http.STATUS_CODES[statusCode] || String(statusCode);
+
+  this.statusCode = statusCode;
+  this.type('txt');
+
+  return this.send(body);
+};
+
+/**
  * Transfer the file at the given `path`.
  *
  * Automatically sets the _Content-Type_ response header field.

--- a/lib/response.js
+++ b/lib/response.js
@@ -6,6 +6,7 @@ var deprecate = require('depd')('express');
 var escapeHtml = require('escape-html');
 var http = require('http');
 var isAbsolute = require('./utils').isAbsolute;
+var onFinished = require('on-finished');
 var path = require('path');
 var mixin = require('utils-merge');
 var sign = require('cookie-signature').sign;
@@ -344,8 +345,8 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendFile = function sendFile(path, options, fn) {
-  var done;
   var req = this.req;
+  var res = this;
   var next = req.next;
 
   if (!path) {
@@ -364,59 +365,20 @@ res.sendFile = function sendFile(path, options, fn) {
     throw new TypeError('path must be absolute or specify root to res.sendFile');
   }
 
-  // socket errors
-  req.socket.on('error', onerror);
-
-  // errors
-  function onerror(err) {
-    if (done) return;
-    done = true;
-
-    // clean up
-    cleanup();
-
-    // callback available
-    if (fn) return fn(err);
-
-    // delegate
-    next(err);
-  }
-
-  // streaming
-  function onstream(stream) {
-    if (done) return;
-    cleanup();
-    if (fn) stream.on('end', fn);
-  }
-
-  // cleanup
-  function cleanup() {
-    req.socket.removeListener('error', onerror);
-  }
-
-  // transfer
+  // create file stream
   var pathname = encodeURI(path);
   var file = send(req, pathname, options);
-  file.on('error', onerror);
-  file.on('directory', next);
-  file.on('stream', onstream);
 
-  if (options.headers) {
-    // set headers on successful transfer
-    file.on('headers', function headers(res) {
-      var obj = options.headers;
-      var keys = Object.keys(obj);
+  // transfer
+  sendfile(res, file, options, function (err) {
+    if (fn) return fn(err);
+    if (err && err.code === 'EISDIR') return next();
 
-      for (var i = 0; i < keys.length; i++) {
-        var k = keys[i];
-        res.setHeader(k, obj[k]);
-      }
-    });
-  }
-
-  // pipe
-  file.pipe(this);
-  this.on('finish', cleanup);
+    // next() all but aborted errors
+    if (err && err.code !== 'ECONNABORT') {
+      next(err);
+    }
+  });
 };
 
 /**
@@ -461,71 +423,31 @@ res.sendFile = function sendFile(path, options, fn) {
  */
 
 res.sendfile = function(path, options, fn){
-  options = options || {};
-  var self = this;
-  var req = self.req;
-  var next = this.req.next;
-  var done;
-
+  var req = this.req;
+  var res = this;
+  var next = req.next;
 
   // support function as second arg
-  if ('function' == typeof options) {
+  if (typeof options === 'function') {
     fn = options;
     options = {};
   }
 
-  // socket errors
-  req.socket.on('error', error);
+  options = options || {};
 
-  // errors
-  function error(err) {
-    if (done) return;
-    done = true;
-
-    // clean up
-    cleanup();
-
-    // callback available
-    if (fn) return fn(err);
-
-    // delegate
-    next(err);
-  }
-
-  // streaming
-  function stream(stream) {
-    if (done) return;
-    cleanup();
-    if (fn) stream.on('end', fn);
-  }
-
-  // cleanup
-  function cleanup() {
-    req.socket.removeListener('error', error);
-  }
+  // create file stream
+  var file = send(req, path, options);
 
   // transfer
-  var file = send(req, path, options);
-  file.on('error', error);
-  file.on('directory', next);
-  file.on('stream', stream);
+  sendfile(res, file, options, function (err) {
+    if (fn) return fn(err);
+    if (err && err.code === 'EISDIR') return next();
 
-  if (options.headers) {
-    // set headers on successful transfer
-    file.on('headers', function headers(res) {
-      var obj = options.headers;
-      var keys = Object.keys(obj);
-
-      for (var i = 0; i < keys.length; i++) {
-        var k = keys[i];
-        res.setHeader(k, obj[k]);
-      }
-    });
-  }
-
-  // pipe
-  file.pipe(this);
-  this.on('finish', cleanup);
+    // next() all but aborted errors
+    if (err && err.code !== 'ECONNABORT') {
+      next(err);
+    }
+  });
 };
 
 res.sendfile = deprecate.function(res.sendfile,
@@ -953,3 +875,69 @@ res.render = function(view, options, fn){
   // render
   app.render(view, options, fn);
 };
+
+// pipe the send file stream
+function sendfile(res, file, options, callback) {
+  var done = false;
+
+  // directory
+  function ondirectory() {
+    if (done) return;
+    done = true;
+
+    var err = new Error('EISDIR, read');
+    err.code = 'EISDIR';
+    callback(err);
+  }
+
+  // errors
+  function onerror(err) {
+    if (done) return;
+    done = true;
+    callback(err);
+  }
+
+  // ended
+  function onend() {
+    if (done) return;
+    done = true;
+    callback();
+  }
+
+  // finished
+  function onfinish(err) {
+    if (err) return onerror(err);
+    if (done) return;
+
+    setImmediate(function () {
+      if (done) return;
+      done = true;
+
+      // response finished before end of file
+      var err = new Error('Request aborted');
+      err.code = 'ECONNABORT';
+      callback(err);
+    });
+  }
+
+  file.on('end', onend);
+  file.on('error', onerror);
+  file.on('directory', ondirectory);
+  onFinished(res, onfinish);
+
+  if (options.headers) {
+    // set headers on successful transfer
+    file.on('headers', function headers(res) {
+      var obj = options.headers;
+      var keys = Object.keys(obj);
+
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i];
+        res.setHeader(k, obj[k]);
+      }
+    });
+  }
+
+  // pipe
+  file.pipe(res);
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,9 +3,8 @@
  */
 
 var mime = require('send').mime;
-var crc32 = require('buffer-crc32');
-var crypto = require('crypto');
 var basename = require('path').basename;
+var etag = require('etag');
 var proxyaddr = require('proxy-addr');
 var qs = require('qs');
 var querystring = require('querystring');
@@ -20,17 +19,12 @@ var typer = require('media-typer');
  * @api private
  */
 
-exports.etag = function etag(body, encoding){
-  if (body.length === 0) {
-    // fast-path empty body
-    return '"1B2M2Y8AsgTpgAmY7PhCfg=="'
-  }
+exports.etag = function (body, encoding) {
+  var buf = !Buffer.isBuffer(body)
+    ? new Buffer(body, encoding)
+    : body
 
-  var hash = crypto
-    .createHash('md5')
-    .update(body, encoding)
-    .digest('base64')
-  return '"' + hash + '"'
+  return etag(buf, {weak: false})
 };
 
 /**
@@ -43,16 +37,11 @@ exports.etag = function etag(body, encoding){
  */
 
 exports.wetag = function wetag(body, encoding){
-  if (body.length === 0) {
-    // fast-path empty body
-    return 'W/"0-0"'
-  }
+  var buf = !Buffer.isBuffer(body)
+    ? new Buffer(body, encoding)
+    : body
 
-  var buf = Buffer.isBuffer(body)
-    ? body
-    : new Buffer(body, encoding)
-  var len = buf.length
-  return 'W/"' + len.toString(16) + '-' + crc32.unsigned(buf) + '"'
+  return etag(buf, {weak: true})
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "debug": "~2.0.0",
     "depd": "0.4.4",
     "escape-html": "1.0.1",
+    "etag": "~1.3.0",
     "finalhandler": "0.2.0",
     "fresh": "0.2.4",
     "media-typer": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fresh": "0.2.4",
     "media-typer": "0.3.0",
     "methods": "1.1.0",
+    "on-finished": "~2.1.0",
     "parseurl": "~1.3.0",
     "path-to-regexp": "0.1.3",
     "proxy-addr": "1.0.1",

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -118,13 +118,13 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        var str = Array(1024 * 2).join('-');
+        var str = Array(1000).join('-');
         res.send(str);
       });
 
       request(app)
       .get('/')
-      .expect('ETag', 'W/"7ff-2796319984"')
+      .expect('ETag', 'W/"3e7-8084ccd1"')
       .end(done);
     })
 
@@ -132,7 +132,7 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        var str = Array(1024 * 2).join('-');
+        var str = Array(1000).join('-');
         res.send(str);
       });
 
@@ -207,13 +207,13 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        var str = Array(1024 * 2).join('-');
+        var str = Array(1000).join('-');
         res.send(new Buffer(str));
       });
 
       request(app)
       .get('/')
-      .expect('ETag', 'W/"7ff-2796319984"')
+      .expect('ETag', 'W/"3e7-8084ccd1"')
       .end(done);
     })
 
@@ -321,15 +321,17 @@ describe('res', function(){
 
   it('should respond with 304 Not Modified when fresh', function(done){
     var app = express();
+    var etag = '"asdf"';
 
     app.use(function(req, res){
-      var str = Array(1024 * 2).join('-');
+      var str = Array(1000).join('-');
+      res.set('ETag', etag);
       res.send(str);
     });
 
     request(app)
     .get('/')
-    .set('If-None-Match', 'W/"7ff-2796319984"')
+    .set('If-None-Match', etag)
     .expect(304, done);
   })
 
@@ -375,7 +377,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"c-1525560792"', done)
+        .expect('etag', 'W/"c-5aee35d8"', done)
       })
 
       it('should send ETag for empty string response', function(done){
@@ -396,7 +398,7 @@ describe('res', function(){
         var app = express();
 
         app.use(function(req, res){
-          var str = Array(1024 * 2).join('-');
+          var str = Array(1000).join('-');
           res.send(str);
         });
 
@@ -404,7 +406,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"7ff-2796319984"', done)
+        .expect('etag', 'W/"3e7-8084ccd1"', done)
       });
 
       it('should not override ETag when manually set', function(done){
@@ -445,7 +447,7 @@ describe('res', function(){
         var app = express();
 
         app.use(function(req, res){
-          var str = Array(1024 * 2).join('-');
+          var str = Array(1000).join('-');
           res.send(str);
         });
 
@@ -503,7 +505,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('etag', 'W/"d-1486392595"', done)
+        .expect('etag', 'W/"d-58988d13"', done)
       })
     })
 

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -1,0 +1,32 @@
+
+var assert = require('assert')
+var express = require('..')
+var request = require('supertest')
+
+describe('res', function () {
+  describe('.sendStatus(statusCode)', function () {
+    it('should send the status code and message as body', function (done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.sendStatus(201);
+      });
+
+      request(app)
+      .get('/')
+      .expect(201, 'Created', done);
+    })
+
+    it('should work with unknown code', function (done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.sendStatus(599);
+      });
+
+      request(app)
+      .get('/')
+      .expect(599, '599', done);
+    })
+  })
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -28,18 +28,18 @@ describe('utils.etag(body, encoding)', function(){
 describe('utils.wetag(body, encoding)', function(){
   it('should support strings', function(){
     utils.wetag('express!')
-    .should.eql('W/"8-3098196679"')
+    .should.eql('W/"8-b8aabac7"')
   })
 
   it('should support utf8 strings', function(){
     utils.wetag('express❤', 'utf8')
-    .should.eql('W/"a-1751845617"')
+    .should.eql('W/"a-686b0af1"')
   })
 
   it('should support buffer', function(){
     var buf = new Buffer('express!')
     utils.wetag(buf)
-    .should.eql('W/"8-3098196679"');
+    .should.eql('W/"8-b8aabac7"');
   })
 
   it('should support empty string', function(){


### PR DESCRIPTION
This is a tracking issue for release 4.9.

**Please keep feature requests in their own issues**

If you want to make a comment on a particular change, please make the comment in the "Files changed" tab so comments are not lost during a rebase (they may occur on patches to the previous release).

List of changes for release:
- [x] Add `res.sendStatus` #2297
- [x] Fix behavior of `req.subdomains` for IP hostnames #2308
- [x] Provide client aborted error from `res.sendFile` #2305
- [x] Support `X-Forwarded-Host` in `req.subdomains`

**Testing this release**

If you want to try out this release, you can install it with the following command:

``` bash
$ npm install visionmedia/express#4.9
```

Owners/collaborators: please do not merge this PR :)
