### PR TITLE
Add Support for Multiple View Folders

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -60,7 +60,7 @@ View.prototype.lookup = function(path){
     var match;
     for (var i = 0; i < this.root.length; i++) {
       context = { root: this.root[ i ] };
-      match = this.call( context , path );
+      match = this.lookup.call( context , path );
       if (match) return match;
     }
     return null;

--- a/lib/view.js
+++ b/lib/view.js
@@ -55,7 +55,7 @@ function View(name, options) {
 View.prototype.lookup = function(path){
   var ext = this.ext;
   
-  if (this.root instanceof Array) {
+  if (Array.isArray( this.root )) {
     var context;
     var match;
     for (var i = 0; i < this.root.length; i++) {
@@ -63,7 +63,7 @@ View.prototype.lookup = function(path){
       match = this.lookup.call( context , path );
       if (match) return match;
     }
-    return null;
+    return undefined;
   } else {
     // <path>.<engine>
     if (!utils.isAbsolute(path)) path = join(this.root, path);

--- a/lib/view.js
+++ b/lib/view.js
@@ -54,14 +54,25 @@ function View(name, options) {
 
 View.prototype.lookup = function(path){
   var ext = this.ext;
+  
+  if (this.root instanceof Array) {
+    var context;
+    var match;
+    for (var i = 0; i < this.root.length; i++) {
+      context = { root: this.root[ i ] };
+      match = this.call( context , path );
+      if (match) return match;
+    }
+    return null;
+  } else {
+    // <path>.<engine>
+    if (!utils.isAbsolute(path)) path = join(this.root, path);
+    if (exists(path)) return path;
 
-  // <path>.<engine>
-  if (!utils.isAbsolute(path)) path = join(this.root, path);
-  if (exists(path)) return path;
-
-  // <path>/index.<engine>
-  path = join(dirname(path), basename(path, ext), 'index' + ext);
-  if (exists(path)) return path;
+    // <path>/index.<engine>
+    path = join(dirname(path), basename(path, ext), 'index' + ext);
+    if (exists(path)) return path;
+  }
 };
 
 /**

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -28,6 +28,20 @@ describe('app', function(){
       })
     })
 
+    it('should support multiple path resolution for views', function(done){
+      var app = express();
+
+      app.set('view engine', 'jade');
+      app.locals.user = { name: 'tobi' };
+      app.set('views', ['somefolder', __dirname + '/fixtures' ]);
+
+      app.render('user', function(err, str){
+        if (err) return done(err);
+        str.should.equal('<p>tobi</p>');
+        done();
+      })
+    })
+
     it('should expose app.locals', function(done){
       var app = express();
 


### PR DESCRIPTION
This adds support for supplying an array of view folders in place of a single view folder [string], allowing for a "fallback" folder of views to be overridden by a preferred location, if they exist.
