### PR TITLE
Add support for inherited param handlers

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -33,7 +33,8 @@ var proto = module.exports = function(options) {
   router.params = {};
   router._params = [];
   router.caseSensitive = options.caseSensitive;
-  router.mergeParams = options.mergeParams;
+  router.mergeParams = options.mergeParams || options.inheritParamHandlers;
+  router.inheritParamHandlers = options.inheritParamHandlers;
   router.strict = options.strict;
   router.stack = [];
 
@@ -133,10 +134,11 @@ proto.handle = function(req, res, done) {
   // middleware and routes
   var stack = self.stack;
 
-  // manage inter-router variables
+  // manage inter-router variables and their handlers
   var parentParams = req.params;
+  var parentParamHandlers = req._paramHandlers;
   var parentUrl = req.baseUrl || '';
-  done = restore(done, req, 'baseUrl', 'next', 'params');
+  done = restore(done, req, 'baseUrl', 'next', 'params', '_paramHandlers');
 
   // setup next layer
   req.next = next;
@@ -215,6 +217,9 @@ proto.handle = function(req, res, done) {
       req.params = self.mergeParams
         ? mergeParams(layer.params, parentParams)
         : layer.params;
+      req._paramHandlers = self.inheritParamHandlers
+        ? mergeParamHandlers(self.params, parentParamHandlers)
+        : self.params;
       var layerPath = layer.path;
 
       // this should be done for the layer
@@ -295,7 +300,7 @@ proto.match_layer = function match_layer(layer, req, res, done) {
  */
 
 proto.process_params = function(layer, called, req, res, done) {
-  var params = this.params;
+  var params = req._paramHandlers;
 
   // captured parameters from the layer, keys and values
   var keys = layer.keys;
@@ -511,6 +516,30 @@ function mergeParams(params, parent) {
   }
 
   return mixin(parent, params);
+}
+
+// merge our param handlers with our parent handlers
+function mergeParamHandlers(paramHandlers, parent) {
+  if (typeof parent !== 'object' || !parent) {
+    return paramHandlers;
+  }
+
+  var obj = mixin({}, parent);
+  var newHandlers = Object.keys(paramHandlers);
+
+  for (var i = 0; i < newHandlers.length; ++i) {
+    var name = newHandlers[i];
+
+    // order our handlers before our parent's handlers
+    if (obj.hasOwnProperty(name)) {
+      obj[name] = paramHandlers[name].concat(obj[name]);
+    }
+    else {
+      obj[name] = paramHandlers[name];
+    }
+  }
+
+  return obj;
 }
 
 // restore obj props after function


### PR DESCRIPTION
This is a first cut at inherited param handlers. Likely this comes with corner cases, as I'm not an express internals expert, but it appears to work in straightforward cases. An additional parameter for `Router` is introduced to control this behavior:

``` javascript
var router = express.Router({ inheritParamHandlers: true });

app.param('user', function (req, res, next, id) {
  User.findOne(id, function (err, user) {
    if (err) return next(err);
    req.params.user = user;
    next();
  });
});

router.param('photo', function (req, res, next, id) {
  Photo.findOne(id, function (err, photo) {
    if (err) return next(err);
    req.params.photo = photo;
    next();
  });
});

router.post('/update-tags/:photo', function (req, res) {
  // Error: contrived example
  req.params.user.update(req.params.photo, req.body, function (err) {
    if (err) return res.status(500).json({ status: 'error', error: err.message });
    return res.status(200).json({ status: 'updated' });
  });
});

app.use('/users/:user', router);
```

I've made it separate from `mergeParams`, as this may cause unexpected behavior for users if enabled via that option. However, it does enable `mergeParams` implicitly if used. A case could be made to consolidate the two into a single option which always does both as `mergeParams` was only publicly documented recently so perhaps the exposure is small.

The parameter handlers are kept in the `Router` but now follow the request throughout the `_router.handle()` path. This _should_ allow different behavior if a router is attached to different apps or paths.

This would address issue #2151.
