### PR TITLE
adding methodOverride to examples/route-separation/index.js

### DIFF
--- a/examples/route-separation/index.js
+++ b/examples/route-separation/index.js
@@ -7,6 +7,7 @@ var app = express();
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+var methodOverride = require('method-override');
 var site = require('./site');
 var post = require('./post');
 var user = require('./user');


### PR DESCRIPTION
when trying to run this example, methodOverride is undefined. requiring it.
