### PR TITLE
Fixed rawgit URL in example

### DIFF
--- a/examples/view-constructor/github-view.js
+++ b/examples/view-constructor/github-view.js
@@ -34,7 +34,7 @@ function GithubView(name, options){
 GithubView.prototype.render = function(options, fn){
   var self = this;
   var opts = {
-    host: 'rawgithub.com',
+    host: 'rawgit.com',
     port: 80,
     path: this.path,
     method: 'GET'


### PR DESCRIPTION
It was using the old "rawgithub.com" URL and the example was just returning a 301 error page.
