### PR TITLE
Remove unnecessary referencing to `this`

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -154,7 +154,6 @@ app.handle = function(req, res, done) {
 app.use = function use(fn) {
   var offset = 0;
   var path = '/';
-  var self = this;
 
   // default path to '/'
   if (typeof fn !== 'function') {
@@ -180,7 +179,7 @@ app.use = function use(fn) {
 
     debug('.use app under %s', path);
     fn.mountpath = path;
-    fn.parent = self;
+    fn.parent = this;
 
     // restore .app property on req and res
     router.use(path, function mounted_app(req, res, next) {
@@ -193,8 +192,8 @@ app.use = function use(fn) {
     });
 
     // mounted an app
-    fn.emit('mount', self);
-  });
+    fn.emit('mount', this);
+  }, this);
 
   return this;
 };
@@ -268,17 +267,16 @@ app.engine = function(ext, fn){
  */
 
 app.param = function(name, fn){
-  var self = this;
-  self.lazyrouter();
+  this.lazyrouter();
 
   if (Array.isArray(name)) {
     name.forEach(function(key) {
-      self.param(key, fn);
-    });
+      this.param(key, fn);
+    }, this);
     return this;
   }
 
-  self._router.param(name, fn);
+  this._router.param(name, fn);
   return this;
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -463,8 +463,7 @@ res.sendFile = function sendFile(path, options, fn) {
 
 res.sendfile = function(path, options, fn){
   options = options || {};
-  var self = this;
-  var req = self.req;
+  var req = this.req;
   var next = this.req.next;
   var done;
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -402,7 +402,6 @@ proto.process_params = function(layer, called, req, res, done) {
 proto.use = function use(fn) {
   var offset = 0;
   var path = '/';
-  var self = this;
 
   // default path to '/'
   if (typeof fn !== 'function') {
@@ -427,15 +426,15 @@ proto.use = function use(fn) {
     debug('use %s %s', path, fn.name || '<anonymous>');
 
     var layer = new Layer(path, {
-      sensitive: self.caseSensitive,
+      sensitive: this.caseSensitive,
       strict: false,
       end: false
     }, fn);
 
     layer.route = undefined;
 
-    self.stack.push(layer);
-  });
+    this.stack.push(layer);
+  }, this);
 
   return this;
 };

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -131,7 +131,6 @@ Route.prototype.dispatch = function(req, res, done){
  */
 
 Route.prototype.all = function(){
-  var self = this;
   var callbacks = utils.flatten([].slice.call(arguments));
   callbacks.forEach(function(fn) {
     if (typeof fn !== 'function') {
@@ -143,16 +142,15 @@ Route.prototype.all = function(){
     var layer = Layer('/', {}, fn);
     layer.method = undefined;
 
-    self.methods._all = true;
-    self.stack.push(layer);
-  });
+    this.methods._all = true;
+    this.stack.push(layer);
+  }, this);
 
-  return self;
+  return this;
 };
 
 methods.forEach(function(method){
   Route.prototype[method] = function(){
-    var self = this;
     var callbacks = utils.flatten([].slice.call(arguments));
 
     callbacks.forEach(function(fn) {
@@ -162,14 +160,14 @@ methods.forEach(function(method){
         throw new Error(msg);
       }
 
-      debug('%s %s', method, self.path);
+      debug('%s %s', method, this.path);
 
       var layer = Layer('/', {}, fn);
       layer.method = method;
 
-      self.methods[method] = true;
-      self.stack.push(layer);
-    });
-    return self;
+      this.methods[method] = true;
+      this.stack.push(layer);
+    }, this);
+    return this;
   };
 });


### PR DESCRIPTION
Hey :)
I've noticed some places in the code where it isn't really necessary to store `this` in a variable. I've passed current context to `forEach` loops as the second argument just to make things little more readable.
