### PR TITLE
https:// instead of git://

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ $ npm start
   Clone the Express repo, then install the dev dependencies to install all the example / test suite dependencies:
 
 ```bash
-$ git clone git://github.com/strongloop/express.git --depth 1
+$ git clone https://github.com/strongloop/express.git --depth 1
 $ cd express
 $ npm install
 ```


### PR DESCRIPTION
I had a problem to git pull with the current url:

```
c:\wamp\www\myplay_node_3>git clone git://github.com/strongloop/express.git
Cloning into 'express'...
fatal: unable to connect to github.com:
github.com[0: 192.30.252.128]: errno=No such file or directory
```

so i updated the link with https:// instead of git:// and it worked

```
c:\wamp\www\myplay_node_3>git clone https://github.com/strongloop/express.git
Cloning into 'express'...
remote: Counting objects: 26224, done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 26224 (delta 18), reused 0 (delta 0)
Receiving objects: 100% (26224/26224), 10.25 MiB | 167.00 KiB/s, done.
Resolving deltas: 100% (11641/11641), done.
Checking connectivity... done.
```
