### PR TITLE
Add test-tap-file npm script that outputs results to a separate file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "method-override": "~2.2.0",
     "morgan": "~1.3.0",
     "multiparty": "~3.3.2",
-    "vhost": "~3.0.0"
+    "vhost": "~3.0.0",
+    "tap-file": "0.0.2"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -77,6 +78,7 @@
   "scripts": {
     "prepublish": "npm prune",
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+    "test-tap-file": "mocha --require test/support/env --reporter tap-file --bail --check-leaks test/ test/acceptance/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
   }


### PR DESCRIPTION
This allows continuous integration platforms to retrieve and parse tests
results easily.
