### PR TITLE
Fix .use with empty string as path

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -159,7 +159,7 @@ app.use = function use(fn) {
   // default path to '/'
   // disambiguate app.use([fn])
   if (typeof fn !== 'function') {
-    var arg = fn;
+    var arg = fn || null;
 
     while (Array.isArray(arg) && arg.length !== 0) {
       arg = arg[0];

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -503,5 +503,17 @@ describe('app', function(){
       .get('/get/zoo')
       .expect(404, cb);
     })
+
+    it('should tolerate empty path', function (done) {
+      var app = express();
+
+      app.use('', function(req, res){
+        res.status(200).send();
+      });
+
+      request(app)
+      .get('/')
+      .expect(200, done);
+    });
   })
 })


### PR DESCRIPTION
I don't know if this was ever intended, but prior to 4.9.1 (specifically, https://github.com/strongloop/express/commit/cf41a8f25434bde16ee8606ce12bb699ef9de39e#diff-5372f626ee15242f1e2c6eb31655b4faR168) an empty path "worked". I'm not saying it was a good practice, but the ensuing error message after upgrading to 4.9.1 is a bit unhelpful ("expected function but got Object").

So this 'restores' the tolerance for `app.use` with an empty string as the path. Alternatively, maybe checking if `fn` is an empty string and throwing a more specific error message would be better if the intention was to actually disallow it.
