### PR TITLE
Allow immediate bail in Router

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -165,7 +165,7 @@ proto.handle = function(req, res, done) {
   next();
 
   function next(err) {
-    var layerError = err === 'route'
+    var layerError = err === 'route' || err === 'break'
       ? null
       : err;
 
@@ -182,7 +182,7 @@ proto.handle = function(req, res, done) {
       removed = '';
     }
 
-    if (!layer) {
+    if (!layer || err === 'break') {
       return done(layerError);
     }
 

--- a/test/Router.js
+++ b/test/Router.js
@@ -43,6 +43,28 @@ describe('Router', function(){
     router.handle({ url: '/test/route', method: 'GET' }, { end: done });
   });
 
+  it('should support early bail', function(done){
+    var main = new Router();
+    var one = new Router();
+    var two = new Router();
+
+    main.use(one);
+    main.use(two);
+
+    one.use(function(req, res, next) {
+      next('break');
+    });
+    one.get('/', function(req, res, next) {
+      assert(false);
+    });
+
+    two.get('/', function(req, res, next) {
+      res.end();
+    });
+
+    main.handle({ url: '/', method: 'GET' }, { end: done });
+  });
+
   describe('.handle', function(){
     it('should dispatch', function(done){
       var router = new Router();


### PR DESCRIPTION
This allows one to bail out of a router immediately. This is useful if you check for some conditions inside a generic handler on the router (via `.use()`) first and then decide to skip the rest of that router's routes.
