### PR TITLE
Add path to router layer.

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -28,7 +28,7 @@ function Layer(path, options, fn) {
   this.handle = fn;
   this.name = fn.name || '<anonymous>';
   this.params = undefined;
-  this.path = undefined;
+  this.path = path;
   this.regexp = pathRegexp(path, this.keys = [], options);
 
   if (path === '/' && options.end === false) {


### PR DESCRIPTION
I have added the path value to the router (similar to the way routes have path) to allow full routes to be pieced together by traversing router stacks.
I've included a gist demonstrating my use case: https://gist.github.com/tonymilne/27108e905043d84f0733
