### PR TITLE
For redirects, url was not being put in response body when 2 arguments were being passed

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -818,11 +818,11 @@ res.redirect = function redirect(url) {
   // Support text/{plain,html} by default
   this.format({
     text: function(){
-      body = statusCodes[status] + '. Redirecting to ' + encodeURI(url);
+      body = statusCodes[status] + '. Redirecting to ' + encodeURI(address);
     },
 
     html: function(){
-      var u = escapeHtml(url);
+      var u = escapeHtml(address);
       body = '<p>' + statusCodes[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>';
     },
 

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -90,6 +90,24 @@ describe('res', function(){
       })
     })
 
+    it('should respond with html with response in body when two arguments are passed', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(301, 'http://google.com');
+      });
+
+      request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+      .end(function(err, res){
+        res.statusCode.should.equal(301);
+        res.headers.should.have.property('location', 'http://google.com');
+        res.text.should.equal('<p>Moved Permanently. Redirecting to <a href="http://google.com">http://google.com</a></p>');
+        done();
+      })
+    })
+
     it('should escape the url', function(done){
       var app = express();
 


### PR DESCRIPTION
fixing bug with redirects where the url was not being put in response body when 2 arguments were being passed
