### PR TITLE
Fix fqdn detection when stripping prefixes from routes

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -126,7 +126,7 @@ proto.handle = function(req, res, done) {
 
   var search = 1 + req.url.indexOf('?');
   var pathlength = search ? search - 1 : req.url.length;
-  var fqdn = 1 + req.url.substr(0, pathlength).indexOf('://');
+  var fqdn = req.url[0] !== '/' && 1 + req.url.substr(0, pathlength).indexOf('://');
   var protohost = fqdn ? req.url.substr(0, req.url.indexOf('/', 2 + fqdn)) : '';
   var idx = 0;
   var removed = '';

--- a/test/Router.js
+++ b/test/Router.js
@@ -219,6 +219,17 @@ describe('Router', function(){
       });
     });
 
+    it('should ignore FQDN in a later part of the URL', function(done){
+      var router = new Router();
+
+      router.get('/test/*', function (req, res){
+        req.params[0].should.equal('http://expressjs.com');
+        done();
+      });
+
+      router.handle({ url: '/test/http://expressjs.com', method: 'GET' }, {}, done);
+    });
+
     it('should adjust FQDN req.url', function (done) {
       var request = { hit: 0, url: 'http://example.com/blog/post/1', method: 'GET' };
       var router = new Router();


### PR DESCRIPTION
A URL as a parameter (unescaped, so `://` shows) would cause too much of
the URL to be chopped, assuming the entire URL through the parameter was
a prefix to be maintained as the 'protocol and host' of the path.
