### PR TITLE
Optional custom json replacer/spaces per response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -194,6 +194,25 @@ res.send = function send(body) {
 };
 
 /**
+ * Create JSON response.
+ *
+ * Examples:
+ *
+ *     res.json(null);
+ *     res.json({ user: 'tj' });
+ *
+ * @param {string|number|boolean|object} obj
+ * @api public
+ */
+res.createJSON = function createJSON(obj) {
+  var app = this.app;
+  var replacer = app.get('json replacer');
+  var spaces = app.get('json spaces');
+  var body = JSON.stringify(obj, replacer, spaces);
+  return body;
+};
+
+/**
  * Send JSON response.
  *
  * Examples:
@@ -221,11 +240,8 @@ res.json = function json(obj) {
     }
   }
 
-  // settings
-  var app = this.app;
-  var replacer = typeof res.jsonReplacer !== 'undefined' ? res.jsonReplacer : app.get('json replacer');
-  var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  // json
+  var body = this.createJSON(val);
 
   // content-type
   if (!this.get('Content-Type')) {
@@ -264,14 +280,8 @@ res.jsonp = function jsonp(obj) {
   }
 
   // settings
-  var app = this.app;
-  var replacer = res.get('json replacer');
-  if (typeof replacer === 'undefined') {
-    replacer = app.get('json replacer');
-  }
-  var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
-  var callback = this.req.query[app.get('jsonp callback name')];
+  var body = this.createJSON(val);
+  var callback = this.req.query[this.app.get('jsonp callback name')];
 
   // content-type
   if (!this.get('Content-Type')) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -223,7 +223,7 @@ res.json = function json(obj) {
 
   // settings
   var app = this.app;
-  var replacer = app.get('json replacer');
+  var replacer = typeof res.jsonReplacer !== 'undefined' ? res.jsonReplacer : app.get('json replacer');
   var spaces = app.get('json spaces');
   var body = JSON.stringify(val, replacer, spaces);
 
@@ -265,7 +265,7 @@ res.jsonp = function jsonp(obj) {
 
   // settings
   var app = this.app;
-  var replacer = app.get('json replacer');
+  var replacer = typeof res.jsonReplacer !== 'undefined' ? res.jsonReplacer : app.get('json replacer');
   var spaces = app.get('json spaces');
   var body = JSON.stringify(val, replacer, spaces);
   var callback = this.req.query[app.get('jsonp callback name')];

--- a/lib/response.js
+++ b/lib/response.js
@@ -265,7 +265,10 @@ res.jsonp = function jsonp(obj) {
 
   // settings
   var app = this.app;
-  var replacer = typeof res.jsonReplacer !== 'undefined' ? res.jsonReplacer : app.get('json replacer');
+  var replacer = res.get('json replacer');
+  if (typeof replacer === 'undefined') {
+    replacer = app.get('json replacer');
+  }
   var spaces = app.get('json spaces');
   var body = JSON.stringify(val, replacer, spaces);
   var callback = this.req.query[app.get('jsonp callback name')];


### PR DESCRIPTION
In some cases it is useful to be able to overwrite the json replacer at response level, in the end it is something related to the response.

This change also makes it possible to simply say: `res.jsonReplacer = null; res.json(data);` to prevent the jsonReplacer from kicking in.
