### PR TITLE
Support custom router

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -4,7 +4,6 @@
 
 var finalhandler = require('finalhandler');
 var flatten = require('./utils').flatten;
-var Router = require('./router');
 var methods = require('methods');
 var middleware = require('./middleware/init');
 var query = require('./middleware/query');
@@ -103,7 +102,7 @@ app.defaultConfiguration = function(){
  */
 app.lazyrouter = function() {
   if (!this._router) {
-    this._router = new Router({
+    this._router = new this.Router({
       caseSensitive: this.enabled('case sensitive routing'),
       strict: this.enabled('strict routing')
     });

--- a/lib/express.js
+++ b/lib/express.js
@@ -31,6 +31,7 @@ function createApplication() {
   mixin(app, proto);
   mixin(app, EventEmitter.prototype);
 
+  app.Router = Router;
   app.request = { __proto__: req, app: app };
   app.response = { __proto__: res, app: app };
   app.init();


### PR DESCRIPTION
Add a new parameter to `express` function to provide a custom `Router`
constructor.

Example:

``` js
var PromisedRouter = require('router-as-promised');
var app = express(PromisedRouter);
```

**Rationale**

This patch make it easier to experiment with different router implementations, as it enables developers (express users) to swap out the default Router implementation and replace it with their own.
- As promises are coming to ES6, there is an initiative to get promise support into express (see #2259). The last recommendation was to create a new router implementation supporting promises ([promise-kernel](https://www.npmjs.org/package/promise-kernel)).
- In LoopBack, StrongLoop's API framework based on express, we are experimenting with a different way of registering middleware (https://github.com/strongloop/loopback/pull/757). Our current solution involves overriding the default router used by express.

**Discussion points**

An existing workaround is to copy and edit `app.lazyrouter` to call a different Router constructor. This is very brittle as the copied version must be manually synchronized with any changes made in express.

Adding the first parameter to `express()` may be seen as controversial. Frankly, I don't really care about the API. I am happy to rework the PR to a different API as long as it allows me to change the Router ctor used by `app.lazyrouter`.

Example:

``` js
var app = expres();
app.Router = MyCustomRouterCtor;

// perhaps a different name would be better?
app.routerFactory = MyCustomRouterCtor;
```

@dougwilson @jonathanong Thoughts?
