### PR TITLE
Fix res.sendfile logging standard write errors

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -467,8 +467,8 @@ res.sendfile = function(path, options, fn){
     if (fn) return fn(err);
     if (err && err.code === 'EISDIR') return next();
 
-    // next() all but aborted errors
-    if (err && err.code !== 'ECONNABORT') {
+    // next() all but write errors
+    if (err && err.code !== 'ECONNABORT' && err.syscall !== 'write') {
       next(err);
     }
   });

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -476,6 +476,27 @@ describe('res', function(){
       .expect(200, '20%', done);
     });
 
+    it('should not error if the client aborts', function (done) {
+      var cb = after(1, done);
+      var app = express();
+
+      app.use(function (req, res) {
+        setImmediate(function () {
+          res.sendfile(path.resolve(fixtures, 'name.txt'));
+          cb();
+        });
+        test.abort();
+      });
+
+      app.use(function (err, req, res, next) {
+        err.code.should.be.empty;
+        cb();
+      });
+
+      var test = request(app).get('/');
+      test.expect(200, cb);
+    })
+
     describe('with an absolute path', function(){
       it('should transfer the file', function(done){
         var app = express();


### PR DESCRIPTION
releated to #2433 and b326ae89df48faac64f22be0eca0a86c87b203ee
