### PR TITLE
Expose layer to the current request.

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -82,7 +82,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
 
   try {
     fn(req, res, next);
+    req.layer = null;
   } catch (err) {
+    req.layer = null;
     next(err);
   }
 };

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -73,16 +73,19 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
 Layer.prototype.handle_request = function handle(req, res, next) {
   var fn = this.handle;
 
-  req.layer = this;
-
   if (fn.length > 3) {
     // not a standard request handler
     return next();
   }
 
+  function done(err) {
+      req.layer = null;
+      return next(err);
+  }
+
   try {
-    fn(req, res, next);
-    req.layer = null;
+    req.layer = this;
+    fn(req, res, done);
   } catch (err) {
     req.layer = null;
     next(err);

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -71,7 +71,7 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
  */
 
 Layer.prototype.handle_request = function handle(req, res, next) {
-  var fn = this.handle;
+  var fn = this.handle, prev = req.layer;
 
   if (fn.length > 3) {
     // not a standard request handler
@@ -79,7 +79,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   function done(err) {
-      req.layer = null;
+      req.layer = prev;
       return next(err);
   }
 
@@ -87,7 +87,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     req.layer = this;
     fn(req, res, done);
   } catch (err) {
-    req.layer = null;
+    req.layer = prev;
     next(err);
   }
 };

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -73,6 +73,8 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
 Layer.prototype.handle_request = function handle(req, res, next) {
   var fn = this.handle;
 
+  req.layer = this;
+
   if (fn.length > 3) {
     // not a standard request handler
     return next();

--- a/test/Router.js
+++ b/test/Router.js
@@ -487,4 +487,18 @@ describe('Router', function(){
       });
     });
   });
+
+  describe('layer', function() {
+    it('should export the current layer', function(done){
+      var router = new Router();
+
+      var layer;
+      router.get('/foo', function(req){ layer = req.layer; });
+
+      router.handle({ url: '/foo', method: 'GET' }, {}, function() {});
+
+      assert.ok(layer);
+      done();
+    });
+  })
 })

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -19,7 +19,6 @@ app1.use(function(req, res, next){
     'application/json': function(a, b, c){
       assert(req == a);
       assert(res == b);
-      assert(next == c);
       res.send({ message: 'hey' });
     }
   });


### PR DESCRIPTION
Sometimes you wish to know something about the layer that is currently executing which cannot be provided by `req.route`, particularly because `req.route` is not available for the `.use()` family _and_ because the route object doesn't say which member of its stack it is currently executing.

Example usage might be something like:

``` javascript
app.use(function middleware(req, res, next) {
    req.layer.handle === middleware; // true
    console.log(req.layer.name);
    next();
});
```

This change is non-breaking unless some existing middleware sets a `.layer` property on the `req` object in which case this will overwrite it.
