### PR TITLE
Add append option for setting response headers.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -648,7 +648,7 @@ res.attachment = function attachment(filename) {
  *
  * Aliased as `res.header()`.
  *
- * @param {String|Object|Array} field
+ * @param {String|Object} field
  * @param {String} val
  * @param {Boolean} append True to append the header instead of overwrite it
  * @return {ServerResponse} for chaining
@@ -657,7 +657,7 @@ res.attachment = function attachment(filename) {
 
 res.set =
 res.header = function header(field, val, append) {
-  if (arguments.length >= 2) {
+  if (typeof field === 'string') {
     if (Array.isArray(val)) val = val.map(String);
     else val = String(val);
     if ('content-type' == field.toLowerCase() && !/;\s*charset\s*=/.test(val)) {
@@ -673,7 +673,7 @@ res.header = function header(field, val, append) {
     }
   } else {
     for (var key in field) {
-      this.set(key, field[key], false);
+      this.set(key, field[key], val);
     }
   }
   return this;

--- a/lib/response.js
+++ b/lib/response.js
@@ -650,23 +650,30 @@ res.attachment = function attachment(filename) {
  *
  * @param {String|Object|Array} field
  * @param {String} val
+ * @param {Boolean} append True to append the header instead of overwrite it
  * @return {ServerResponse} for chaining
  * @api public
  */
 
 res.set =
-res.header = function header(field, val) {
-  if (arguments.length === 2) {
+res.header = function header(field, val, append) {
+  if (arguments.length >= 2) {
     if (Array.isArray(val)) val = val.map(String);
     else val = String(val);
     if ('content-type' == field.toLowerCase() && !/;\s*charset\s*=/.test(val)) {
       var charset = mime.charsets.lookup(val.split(';')[0]);
       if (charset) val += '; charset=' + charset.toLowerCase();
     }
-    this.setHeader(field, val);
+    if (append) {
+      var cur = this.getHeader(field);
+      if (!Array.isArray(cur)) cur = [cur];
+      this.setHeader(field, cur.concat(val));
+    } else {
+      this.setHeader(field, val);
+    }
   } else {
     for (var key in field) {
-      this.set(key, field[key]);
+      this.set(key, field[key], false);
     }
   }
   return this;

--- a/lib/response.js
+++ b/lib/response.js
@@ -666,6 +666,7 @@ res.header = function header(field, val, append) {
     }
     if (append) {
       var cur = this.getHeader(field);
+      if (!cur) cur = [ ];
       if (!Array.isArray(cur)) cur = [cur];
       this.setHeader(field, cur.concat(val));
     } else {

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -4,7 +4,7 @@ var express = require('../')
   , res = express.response;
 
 describe('res', function(){
-  describe('.set(field, value)', function(){
+  describe('.set(field, value, append)', function(){
     it('should set the response header field', function(done){
       var app = express();
 
@@ -23,9 +23,17 @@ describe('res', function(){
       res.set('X-Number', 123);
       res.get('X-Number').should.equal('123');
     })
+
+    it('should create an array out of a string header', function() {
+        res.headers = {};
+        res.set('Fruit', 'banana');
+        res.set('Fruit', 'apple', true);
+        JSON.stringify(res.get('fruit'))
+        .should.equal('["banana","apple"]');
+    })
   })
 
-  describe('.set(field, values)', function(){
+  describe('.set(field, values, append)', function(){
     it('should set multiple response header fields', function(done){
       var app = express();
 
@@ -50,6 +58,14 @@ describe('res', function(){
       res.headers = {};
       res.set('Content-Type', 'text/html; charset=lol');
       res.get('content-type').should.equal('text/html; charset=lol');
+    })
+
+    it('should work on already existing multi-valued headers', function() {
+        res.headers = {};
+        res.set('Fruit', ['banana', 'apple']);
+        res.set('Fruit', 'mango', true);
+        JSON.stringify(res.get('fruit'))
+        .should.equal('["banana","apple","mango"]');
     })
   })
 

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -31,6 +31,15 @@ describe('res', function(){
       JSON.stringify(res.get('fruit'))
       .should.equal('["banana","apple"]');
     })
+
+    it('should handle append-first', function() {
+      res.headers = {};
+      res.removeHeader('Fruit');
+      res.set('Fruit', 'banana', true);
+      res.set('Fruit', 'apple', true);
+      JSON.stringify(res.get('fruit'))
+      .should.equal('["banana","apple"]');
+    })
   })
 
   describe('.set(field, values, append)', function(){

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -25,11 +25,11 @@ describe('res', function(){
     })
 
     it('should create an array out of a string header', function() {
-        res.headers = {};
-        res.set('Fruit', 'banana');
-        res.set('Fruit', 'apple', true);
-        JSON.stringify(res.get('fruit'))
-        .should.equal('["banana","apple"]');
+      res.headers = {};
+      res.set('Fruit', 'banana');
+      res.set('Fruit', 'apple', true);
+      JSON.stringify(res.get('fruit'))
+      .should.equal('["banana","apple"]');
     })
   })
 
@@ -61,15 +61,15 @@ describe('res', function(){
     })
 
     it('should work on already existing multi-valued headers', function() {
-        res.headers = {};
-        res.set('Fruit', ['banana', 'apple']);
-        res.set('Fruit', 'mango', true);
-        JSON.stringify(res.get('fruit'))
-        .should.equal('["banana","apple","mango"]');
+      res.headers = {};
+      res.set('Fruit', ['banana', 'apple']);
+      res.set('Fruit', 'mango', true);
+      JSON.stringify(res.get('fruit'))
+      .should.equal('["banana","apple","mango"]');
     })
   })
 
-  describe('.set(object)', function(){
+  describe('.set(object, append)', function(){
     it('should set multiple fields', function(done){
       var app = express();
 
@@ -91,6 +91,14 @@ describe('res', function(){
       res.headers = {};
       res.set({ 'X-Number': 123 });
       res.get('X-Number').should.equal('123');
+    })
+
+    it('should work on already existing multi-valued headers', function() {
+      res.headers = {};
+      res.set({ 'Fruit': ['banana', 'apple'] });
+      res.set({ 'Fruit': 'mango' }, true);
+      JSON.stringify(res.get('fruit'))
+      .should.equal('["banana","apple","mango"]');
     })
   })
 })


### PR DESCRIPTION
By default both express and node opt replace any header you set which makes it somewhat inconvenient when you need to append a header instead of replace one. A third parameter to `res.set` now controls whether or not the header is set or appended.

The default behavior remains the same as before (so all existing code works as usual), and the appropriate tests have been added.

One example where this behavior might be desirable is when setting cookies. You can do things like:

``` javascript
res.set('Cookie', 'foo=bar', true);
```

and _NOT_ interfere with anyone else who has happened to also set a cookie for the response.
