### PR TITLE
req.fresh throws when no response headers are set

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -412,7 +412,7 @@ defineGetter(req, 'fresh', function(){
 
   // 2xx or 304 as per rfc2616 14.26
   if ((s >= 200 && s < 300) || 304 == s) {
-    return fresh(this.headers, this.res._headers);
+    return fresh(this.headers || {}, this.res._headers || {});
   }
 
   return false;

--- a/test/req.fresh.js
+++ b/test/req.fresh.js
@@ -32,5 +32,19 @@ describe('req', function(){
       .set('If-None-Match', '"12345"')
       .expect(200, 'false', done);
     })
+
+    it('should succeed even if no response headers are present', function(done){
+      var app = express();
+      app.disable('x-powered-by'); // ensure there are no default response headers
+
+      app.use(function(req, res){
+        res.send(req.fresh);
+      });
+
+      // this would previously fail because jshttp/fresh is expecting res.headers to not be undefined
+      request(app)
+      .get('/')
+      .expect(200, done);
+    })
   })
 })


### PR DESCRIPTION
Currently any request to a simplistic Express app like so will fail with a 500 because [jshttp/fresh](https://github.com/jshttp/fresh) does not expect a response's headers to be `undefined`:

``` javascript
(function () {
  'use strict';

  var app = require('express')();

  app.disable('x-powered-by'); // no default headers are set, so `res.headers` is now `undefined`

  app.get('/', function (req, res) {
    res.status(204).send();
  });

  module.exports = app;

}());
```

This Pull Request ensures that at the very least an empty hash is sent to [jshttp/fresh](https://github.com/jshttp/fresh) to prevent requests to that application from erroring out with a 500.
