### PR TITLE
Add ability to set 'json spaces' on res.json

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -224,7 +224,7 @@ res.json = function json(obj) {
   // settings
   var app = this.app;
   var replacer = app.get('json replacer');
-  var spaces = app.get('json spaces');
+  var spaces = (this.get('json spaces')) ? parseInt(this.get('json spaces')) : app.get('json spaces');
   var body = JSON.stringify(val, replacer, spaces);
 
   // content-type


### PR DESCRIPTION
Currently `json spaces` can only be set at an application level, but it would be nice to be able to override that setting on the response level. For example, in my situation I'd like the root of an API route to pretty print JSON (`app.set('json spaces', 2)`), but an actual response to be minified (`app.get('json spaces', 2)`.  

I [found a way](https://stackoverflow.com/questions/27446799/dynamically-change-json-spacing-with-express-js/27447385#27447385) to get around this by setting the `json spaces` on a response as so:

```
res
   .set("Content-type", "application/json; charset=utf-8")
   .send(JSON.stringify(data, null, 2));
```

This works well, but it would be nice to set `json spaces` directly on `res.json` in the same way you can set something like `Content-type`. This PR allows you to do this - for example:

```
res
   .set("json spaces", 2)
   .json(data);
```

If `json spaces` is not set on a given `response` it falls back to the application's `json spaces` setting.
