### PR TITLE
ETag should not be generated for no-store

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -165,7 +165,7 @@ res.send = function send(body) {
   // ETag support
   if (len !== undefined && (isHead || req.method === 'GET')) {
     var etag = app.get('etag fn');
-    if (etag && !this.get('ETag')) {
+    if (etag && !this.get('ETag') && this.get('Cache-Control') !== 'no-store') {
       etag = etag(chunk, encoding);
       etag && this.set('ETag', etag);
     }


### PR DESCRIPTION
Cache-Control: no-store does not allow the User-Agent to consult anything for caching, as it does not allow caching at all.
This is opposed to no-cache where ETag can be consulted and compared against a HEAD request.
