### PR TITLE
add publishConfig tag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
     "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+  },
+  "publishConfig": {
+    "tag": "unstable"
   }
 }


### PR DESCRIPTION
if you have aim to publish another 5.x preview
maybe can be useful, to publish it with `unstable` tag instead of `latest`
