### PR TITLE
fix small typo: eachother to each other

### DIFF
--- a/lib/middleware/init.js
+++ b/lib/middleware/init.js
@@ -1,6 +1,6 @@
 /**
  * Initialization middleware, exposing the
- * request and response to eachother, as well
+ * request and response to each other, as well
  * as defaulting the X-Powered-By header field.
  *
  * @param {Function} app


### PR DESCRIPTION
I've fixed a small typo in init.js
