### PR TITLE
Fix typos in req.accepts comments.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -63,12 +63,12 @@ req.header = function(name){
  * the best match when true, otherwise `undefined`, in which
  * case you should respond with 406 "Not Acceptable".
  *
- * The `type` value may be a single mime type string
- * such as "application/json", the extension name
- * such as "json", a comma-delimted list such as "json, html, text/plain",
+ * The `type` value may be a single MIME type string
+ * such as "application/json", an extension name
+ * such as "json", a comma-delimited list such as "json, html, text/plain",
  * an argument list such as `"json", "html", "text/plain"`,
  * or an array `["json", "html", "text/plain"]`. When a list
- * or array is given the _best_ match, if any is returned.
+ * or array is given, the _best_ match, if any is returned.
  *
  * Examples:
  *


### PR DESCRIPTION
- "mime type" -> "MIME type"
- "delimted" -> "delimited"

Basically fixes a bunch of grammatical errors in the `req.accepts` docs.
