### PR TITLE
Add support for conditional loading of middleware

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -208,6 +208,14 @@ app.use = function use(fn) {
   return this;
 };
 
+app.useif = function(condition) {
+  if (condition) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return this.use.apply(this, args);
+  }
+  return this;
+};
+
 /**
  * Proxy to the app `Router#route()`
  * Returns a new `Route` instance for the _path_.

--- a/test/app.useif.js
+++ b/test/app.useif.js
@@ -1,0 +1,43 @@
+var express = require('..');
+var request = require('supertest');
+
+describe('app', function(){
+  describe('.useif(condition, ...)', function(){
+    it('should delegate to app.use if condition is true', function (done) {
+      var blog = express()
+        , app = express();
+
+      blog.get('/blog', function(req, res){
+        res.end('blog');
+      });
+
+      app.useif(true, function (req, res) {
+        res.end('middleware');
+      });
+
+      app.use(blog);
+
+      request(app)
+      .get('/blog')
+      .expect('middleware', done);
+    });
+    it('should not register the middleware if the condition is false', function (done) {
+      var blog = express()
+        , app = express();
+
+      blog.get('/blog', function(req, res){
+        res.end('blog');
+      });
+
+      app.useif(false, function (req, res) {
+        res.end('middleware');
+      });
+
+      app.use(blog);
+
+      request(app)
+      .get('/blog')
+      .expect('blog', done);
+    });
+  })
+})


### PR DESCRIPTION
I have a need to be able to install middleware based on the value of configuration.

It could be done with [express-noop](https://www.npmjs.com/package/express-noop) like this:

``` js
app.use(condition ? middleware : require('express-noop')());
```

That is doing it's job, but it is wasteful, as there is no need to register any middleware if the condition is false. It's only being evaluated up front any way.

It could also be done by using an if sentence.

``` js
var app = express();

if (condition) {
    app.use(middleware);
}
```

But it is annoying when you are nesting express applications to build structures:

``` js
var app = express();
var app2 = express();

if (condition) {
    app2.use(middleware);
}

app2.use(bar)

app.use(foo)
   .use(app2);
```

With this PR you could use `.useif()` instead of use and make it all much more convenient and readable:

``` js
var app = express();

app
  .use(foo)
  .use(express()
    .useif(condition, middleware)
    .use(bar));
```

I hope that I made my motivation and use-case clear, and that the test coverage and code style lives up to your expectations. If there is anything that I can improve, I'll be more than happy to change it.
