### PR TITLE
Fix: 'trust proxy' setting not inherited by mounted app.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -56,7 +56,6 @@ app.defaultConfiguration = function(){
   this.set('env', env);
   this.set('query parser', 'extended');
   this.set('subdomain offset', 2);
-  this.set('trust proxy', false);
 
   debug('booting in %s mode', env);
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -12,6 +12,11 @@ var parseRange = require('range-parser');
 var parse = require('parseurl');
 var proxyaddr = require('proxy-addr');
 
+// Helper for proxy-addr
+function trustNone(){
+  return false;
+}
+
 /**
  * Request prototype.
  */
@@ -268,7 +273,7 @@ defineGetter(req, 'protocol', function protocol(){
     : 'http';
   var trust = this.app.get('trust proxy fn');
 
-  if (!trust(this.connection.remoteAddress)) {
+  if (!trust || !trust(this.connection.remoteAddress)) {
     return proto;
   }
 
@@ -303,7 +308,7 @@ defineGetter(req, 'secure', function secure(){
 
 defineGetter(req, 'ip', function ip(){
   var trust = this.app.get('trust proxy fn');
-  return proxyaddr(this, trust);
+  return proxyaddr(this, trust || trustNone);
 });
 
 /**
@@ -320,7 +325,7 @@ defineGetter(req, 'ip', function ip(){
 
 defineGetter(req, 'ips', function ips() {
   var trust = this.app.get('trust proxy fn');
-  var addrs = proxyaddr.all(this, trust);
+  var addrs = proxyaddr.all(this, trust || trustNone);
   return addrs.slice(1).reverse();
 });
 
@@ -378,7 +383,7 @@ defineGetter(req, 'hostname', function hostname(){
   var trust = this.app.get('trust proxy fn');
   var host = this.get('X-Forwarded-Host');
 
-  if (!host || !trust(this.connection.remoteAddress)) {
+  if (!host || !trust || !trust(this.connection.remoteAddress)) {
     host = this.get('Host');
   }
 

--- a/test/req.ips.js
+++ b/test/req.ips.js
@@ -35,6 +35,24 @@ describe('req', function(){
           .set('X-Forwarded-For', 'client, p1, p2')
           .expect('["p1","p2"]', done);
         })
+
+        // Regression test for https://github.com/strongloop/express/issues/2550
+        it('should be inherited by mounted servers', function(done){
+          var app = express();
+
+          app.enable('trust proxy');
+
+          app.use('/subapp', express()
+            .get('/', function (req, res) {
+              res.send(req.ips);
+            })
+          );
+
+          request(app)
+          .get('/subapp/')
+          .set('X-Forwarded-For', '77.66.55.44')
+          .expect('["77.66.55.44"]', done);
+        });
       })
 
       describe('when "trust proxy" is disabled', function(){


### PR DESCRIPTION
The issue was introduced in 566720be where `app.defaultConfiguration` was updated to set 'trust proxy' unconditionally, which means that the default value of false would always shadow the value that should be inherited from the parent app.

This fix avoids setting a default value and instead handles the absence of a 'trust proxy fn' setting whenever it's used.

From a cursory glance I think a better fix would involve changing the `all` function exported by the `proxy-addr` module to treat a `trust` parameter of `false` or `undefined` as "trust none" instead of "trust all".

Fixes #2550.
