### PR TITLE
test: Fixed done typo

### DIFF
--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -29,7 +29,7 @@ describe('req', function(){
         .get('/')
         .set('Cookie', cookie)
         .end(function(err, res){
-          if (err) return don(err);
+          if (err) return done(err);
           res.body.should.eql({ obj: { foo: 'bar' } });
           done();
         });


### PR DESCRIPTION
Noticed line 32 had the typo `if (err) return don(err);`
