### PR TITLE
Fix for req.protocol when set('trust proxies', n) is used

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -358,7 +358,7 @@ req.__defineGetter__('protocol', function(){
     : 'http';
   var trust = this.app.get('trust proxy fn');
 
-  if (!trust(this.connection.remoteAddress)) {
+  if (!trust(this.connection.remoteAddress, 1)) {
     return proto;
   }
 

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -109,7 +109,7 @@ describe('req', function(){
         .expect('https', done);
       })
 
-      it('should ignore X-Forwarded-Proto if range is great than hops', function(done){
+      it('should respect X-Forwarded-Proto even if range is great than hops', function(done){
         var app = express();
 
         app.set('trust proxy', 2);
@@ -121,8 +121,8 @@ describe('req', function(){
         request(app)
         .get('/')
         .set('X-Forwarded-Proto', 'https')
-        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.2')
-        .expect('http', done);
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.3')
+        .expect('https', done);
       })
 
       it('should default to http', function(done){

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -62,6 +62,69 @@ describe('req', function(){
         .expect('http', done);
       })
 
+      it('should respect X-Forwarded-Proto hops without X-Forwarded-For', function(done){
+        var app = express();
+
+        app.set('trust proxy', 2);
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .expect('https', done);
+      })
+
+      it('should respect X-Forwarded-Proto if range is less than hops', function(done){
+        var app = express();
+
+        app.set('trust proxy', 2);
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1')
+        .expect('https', done);
+      })
+
+      it('should respect X-Forwarded-Proto if range equal to hops', function(done){
+        var app = express();
+
+        app.set('trust proxy', 2);
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2')
+        .expect('https', done);
+      })
+
+      it('should ignore X-Forwarded-Proto if range is great than hops', function(done){
+        var app = express();
+
+        app.set('trust proxy', 2);
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.2')
+        .expect('http', done);
+      })
+
       it('should default to http', function(done){
         var app = express();
 

--- a/test/req.secure.js
+++ b/test/req.secure.js
@@ -78,6 +78,54 @@ describe('req', function(){
         .set('X-Forwarded-Proto', 'https, http')
         .expect('yes', done)
       })
+
+      it('should return true when initial proxy is https and within hops', function(done){
+        var app = express();
+
+        app.enable('trust proxy', 2);
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1')
+        .expect('yes', done)
+      })
+
+      it('should return true when initial proxy is https at hops', function(done){
+        var app = express();
+
+        app.enable('trust proxy', 2);
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2')
+        .expect('yes', done)
+      })
+
+      it('should return false when initial proxy is https but beyond hops', function(done){
+        var app = express();
+
+        app.enable('trust proxy', 2);
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.2')
+        .expect('yes', done)
+      })
     })
   })
 })


### PR DESCRIPTION
Fix for #2569 
