### PR TITLE
Support rejected promises

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -82,8 +82,8 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     var result = fn(req, res, next);
     
     // support promises
-    if (typeof result !== 'undefined' && result !== null && typeof result.catch == 'function') {
-      result.catch(next);
+    if (typeof result !== 'undefined' && result !== null && typeof result.then == 'function') {
+      result.then(void 0, next);
     }
   } catch (err) {
     next(err);

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -79,7 +79,12 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    var result = fn(req, res, next);
+    
+    // support promises
+    if (typeof result !== 'undefined' && result !== null && typeof result.catch == 'function') {
+      result.catch(next);
+    }
   } catch (err) {
     next(err);
   }

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "method-override": "~2.3.1",
     "morgan": "~1.5.1",
     "multiparty": "~4.1.1",
-    "vhost": "~3.0.0",
-    "q": "~1.2.0"
+    "vhost": "~3.0.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "method-override": "~2.3.1",
     "morgan": "~1.5.1",
     "multiparty": "~4.1.1",
-    "vhost": "~3.0.0"
+    "vhost": "~3.0.0",
+    "q": "~1.2.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/test/Router.js
+++ b/test/Router.js
@@ -204,8 +204,8 @@ describe('Router', function(){
       router.get('/foo', function(req, res, next){
         // fake a rejected promise
         return {
-          catch: function (fn) {
-            process.nextTick(fn.bind(null, new Error('foo')));
+          then: function (resolve, reject) {
+            process.nextTick(reject.bind(null, new Error('foo')));
           }
         };
       });

--- a/test/Router.js
+++ b/test/Router.js
@@ -3,8 +3,7 @@ var after = require('after');
 var express = require('../')
   , Router = express.Router
   , methods = require('methods')
-  , assert = require('assert')
-  , Q = require('q');
+  , assert = require('assert');
 
 describe('Router', function(){
   it('should return a function with router methods', function() {
@@ -203,7 +202,12 @@ describe('Router', function(){
       var router = new Router();
       
       router.get('/foo', function(req, res, next){
-        return Q.reject(new Error('foo'));
+        // fake a rejected promise
+        return {
+          catch: function (fn) {
+            process.nextTick(fn.bind(null, new Error('foo')));
+          }
+        };
       });
       
       router.use(function(err, req, res, next) {

--- a/test/Router.js
+++ b/test/Router.js
@@ -3,7 +3,8 @@ var after = require('after');
 var express = require('../')
   , Router = express.Router
   , methods = require('methods')
-  , assert = require('assert');
+  , assert = require('assert')
+  , Q = require('q');
 
 describe('Router', function(){
   it('should return a function with router methods', function() {
@@ -196,6 +197,21 @@ describe('Router', function(){
       });
 
       router.handle({ url: '/', method: 'GET' }, {}, done);
+    });
+    
+    it('should handle rejected promises', function (done) {
+      var router = new Router();
+      
+      router.get('/foo', function(req, res, next){
+        return Q.reject(new Error('foo'));
+      });
+      
+      router.use(function(err, req, res, next) {
+        assert.equal(err.message, 'foo');
+        done();
+      });
+      
+      router.handle({ url: '/foo', method: 'GET' }, {}, function() {});
     });
   })
 


### PR DESCRIPTION
This pull request allows rejected promises to be handled nicely:

``` javascript
router.get('/foo', function(req, res, next){
  return Q.reject(new Error('foo'));
});

router.use(function(err, req, res, next) {
  // err.message == 'foo'
});
```
