### PR TITLE
It must be assert.equal(actual, expected)

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -12,7 +12,7 @@ describe('app', function(){
 
   it('should be callable', function(){
     var app = express();
-    assert(typeof app, 'function');
+    assert.equal(typeof app, 'function');
   })
 
   it('should 404 without routes', function(done){


### PR DESCRIPTION
```
  it.only('should be callable', function(){
    var app = express();
    // BUG HERE!
    assert(typeof app, 'function');
  })
```
