### PR TITLE
Change express.logger in route-separation example

### DIFF
--- a/examples/route-separation/index.js
+++ b/examples/route-separation/index.js
@@ -21,7 +21,7 @@ app.set('views', __dirname + '/views');
 
 /* istanbul ignore next */
 if (!module.parent) {
-  app.use(express.logger('dev'));
+  app.use(logger('dev'));
 }
 
 app.use(methodOverride('_method'));


### PR DESCRIPTION
In the route-separation example, morgan had been included in index.js and assigned to variable 'logger'. However, express.logger was used instead of the variable assigned to morgan. This generated the following error in Express 4: 

```
Error: Most middleware (like logger) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
    at Function.Object.defineProperty.get (/Users/alexdixon/express/lib/express.js:89:13)
    at Object.<anonymous> (/Users/alexdixon/express/examples/route-separation/index.js:24:19)
```

express.logger has been replaced with the existing variable for morgan. The example can now be run in the current version of the app.
