### PR TITLE
response.js: use statusCodes short cut instead of http.STATUS_CODES

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -119,7 +119,7 @@ res.send = function send(body) {
 
     deprecate('res.send(status): Use res.sendStatus(status) instead');
     this.statusCode = chunk;
-    chunk = http.STATUS_CODES[chunk];
+    chunk = statusCodes[chunk];
   }
 
   switch (typeof chunk) {
@@ -324,7 +324,7 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
-  var body = http.STATUS_CODES[statusCode] || String(statusCode);
+  var body = statusCodes[statusCode] || String(statusCode);
 
   this.statusCode = statusCode;
   this.type('txt');


### PR DESCRIPTION
At the top of the file there is a short cut for http.STATUS_CODES:

  var statusCodes = http.STATUS_CODES;

A couple of places in the module still referenced http.STATUS_CODES
directly. Replace those references with the short cut, statusCodes.
