### PR TITLE
Added Route.prototype.verbs

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -489,6 +489,25 @@ app.all = function(path){
   return this;
 };
 
+/**
+ * Special-cased "verbs" method,
+ *
+ * @param {String} path
+ * @param {Object} handlers
+ * @return {app} for chaining
+ * @api public
+ */
+
+app.verbs = function(path){
+  this.lazyrouter();
+
+  var route = this._router.route(path);
+  var args = slice.call(arguments, 1);
+  route.verbs.apply(route, args);
+
+  return this;
+};
+
 // del -> delete alias
 
 app.del = deprecate.function(app.delete, 'app.del: Use app.delete instead');

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -159,6 +159,21 @@ Route.prototype.all = function(){
   return this;
 };
 
+Route.prototype.register = function (routes) {
+  if (typeof routes !== 'object' && Array.isArray(routes)) {
+    var type = {}.toString.call(routes);
+    var msg = "Route.register() requires and object but got " + type;
+    throw new Error(msg);
+  }
+  methods.forEach(function(method){
+    var callback = routes[method] || routes.default;
+    if (callback) {
+      this[method](callback);
+    }
+  };
+  return this;
+}
+
 methods.forEach(function(method){
   Route.prototype[method] = function(){
     var callbacks = utils.flatten([].slice.call(arguments));

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -175,7 +175,7 @@ Route.prototype.all = function(){
  * }
  *
  * route
- *   .register({
+ *   .verbs({
  *     get: get,
  *     post: post,
  *     default: others
@@ -193,7 +193,7 @@ Route.prototype.all = function(){
  * @return {Route} for chaining
  * @api public
  */
-Route.prototype.register = function (handlers) {
+Route.prototype.verbs = function (handlers) {
   if (typeof handlers !== 'object' && Array.isArray(handlers)) {
     var type = {}.toString.call(handlers);
     var msg = "Route.register() requires and object but got " + type;

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -159,18 +159,52 @@ Route.prototype.all = function(){
   return this;
 };
 
-Route.prototype.register = function (routes) {
-  if (typeof routes !== 'object' && Array.isArray(routes)) {
-    var type = {}.toString.call(routes);
+/**
+ * Add a set of handlers for all the HTTP verbs listed in the input to this route.
+ *
+ * All the methods are optional.
+ * The default is used for all the non explicitly defined ones.
+ * function get(get, res) {
+ *   // manage get
+ * }
+ * function post(get, res) {
+ *   // manage post
+ * }
+ * function others(get, res) {
+ *   // manage other
+ * }
+ *
+ * route
+ *   .register({
+ *     get: get,
+ *     post: post,
+ *     default: others
+ *   });
+ *
+ * Is the same as
+ * 
+ * route
+ *   .get(get)
+ *   .post(post)
+ *   .put(others)
+ *   .delete(others);
+ *
+ * @param {object} handlers
+ * @return {Route} for chaining
+ * @api public
+ */
+Route.prototype.register = function (handlers) {
+  if (typeof handlers !== 'object' && Array.isArray(handlers)) {
+    var type = {}.toString.call(handlers);
     var msg = "Route.register() requires and object but got " + type;
     throw new Error(msg);
   }
   methods.forEach(function(method){
-    var callback = routes[method] || routes.default;
+    var callback = handlers[method] || handlers.default;
     if (callback) {
       this[method](callback);
     }
-  };
+  }, this);
   return this;
 }
 

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -194,7 +194,7 @@ Route.prototype.all = function(){
  * @api public
  */
 Route.prototype.verbs = function (handlers) {
-  if (typeof handlers !== 'object' && Array.isArray(handlers)) {
+  if (typeof handlers !== 'object' || Array.isArray(handlers)) {
     var type = {}.toString.call(handlers);
     var msg = "Route.register() requires and object but got " + type;
     throw new Error(msg);

--- a/test/Router.js
+++ b/test/Router.js
@@ -113,6 +113,41 @@ describe('Router', function(){
       router.route('/foo').all(function(){}).all(function(){});
     })
   })
+  
+  describe('.verbs handlers', function(){
+    it('should throw if the handlers object is null', function(){
+      assert.throws(function () {
+        var router = new Router();
+        router.route('/foo').verbs(null);
+      })
+    })
+
+    it('should throw if the handlers object is undefined', function(){
+      assert.throws(function () {
+        var router = new Router();
+        router.route('/foo').verbs(undefined);
+      })
+    })
+
+    it('should throw if the handlers object is not an object', function(){
+      assert.throws(function () {
+        var router = new Router();
+        router.route('/foo').verbs('not an object');
+      })
+    })
+
+    it('should throw if the handlers object is an array', function(){
+      assert.throws(function () {
+        var router = new Router();
+        router.route('/foo').verbs([]);
+      })
+    })
+
+    it('should not throw if all callbacks are an object', function(){
+      var router = new Router();
+      router.route('/foo').verbs({}).verbs({});
+    })
+  })
 
   describe('error', function(){
     it('should skip non error middleware', function(done){

--- a/test/app.route.js
+++ b/test/app.route.js
@@ -36,6 +36,27 @@ describe('app.route', function(){
     .post('/foo')
     .expect('post', done);
   });
+  
+  it('should all .VERB after .register with default', function(done){
+    var app = express();
+
+    app.route('/foo')
+    .register({
+      get : function(req, res) {
+        res.send('get');
+      },
+      default : function(req, res, next) {
+         next();
+      }
+    })
+    .post(function(req, res) {
+      res.send('post');
+    });
+
+    request(app)
+    .post('/foo')
+    .expect('post', done);
+  });
 
   it('should support dynamic routes', function(done){
     var app = express();
@@ -58,5 +79,5 @@ describe('app.route', function(){
     request(app)
     .get('/test')
     .expect(404, done);
-  });
+  });  
 });

--- a/test/app.route.js
+++ b/test/app.route.js
@@ -37,11 +37,11 @@ describe('app.route', function(){
     .expect('post', done);
   });
   
-  it('should all .VERB after .register with default', function(done){
+  it('should all .VERB after .verbs with default', function(done){
     var app = express();
 
     app.route('/foo')
-    .register({
+    .verbs({
       get : function(req, res) {
         res.send('get');
       },

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -923,19 +923,26 @@ describe('app.router', function(){
       next();
     });
 
+    app.verbs('/user/:id', {
+      default: function(req, res, next){
+        path.push(4);
+        next();
+      }
+    });
+
     app.get('*', function(req, res, next){
-      path.push(4);
+      path.push(5);
       next();
     });
 
     app.use(function(req, res, next){
-      path.push(5);
+      path.push(6);
       res.end(path.join(','))
     });
 
     request(app)
     .get('/user/1')
-    .expect(200, '0,1,2,3,4,5', done);
+    .expect(200, '0,1,2,3,4,5,6', done);
   })
 
   it('should be chainable', function(){

--- a/test/app.verbs.js
+++ b/test/app.verbs.js
@@ -1,0 +1,39 @@
+
+var express = require('../')
+  , request = require('supertest');
+
+describe('app.verbs()', function(){
+  it('should add a router per method', function(done){
+    var app = express();
+
+    app.verbs('/tobi', {
+      default: function(req, res){
+        res.end(req.method);
+      }
+    });
+
+    request(app)
+    .put('/tobi')
+    .expect('PUT', function(){
+      request(app)
+      .get('/tobi')
+      .expect('GET', done);
+    });
+  })
+
+  it('should ', function(done){
+    var app = express()
+      , n = 0;
+
+    app.verbs('/*', {
+      default: function(req, res, next){
+        if (n++) return done(new Error('DELETE called several times'));
+        next();
+      }
+    });
+
+    request(app)
+    .del('/tobi')
+    .expect(404, done);
+  })
+})


### PR DESCRIPTION
This method allows to register a set of verbs in just one call and allows to define a default route for all the Others.

This is different from using all, because the default route is added only to the verbs for which there is not a defined one.
