### PR TITLE
Add .npmignore to exclude development files from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,32 @@
+# OS X
+.DS_Store*
+Icon?
+._*
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux
+.directory
+*~
+
+
+# npm
+*.log
+*.gz
+
+
+# Coveralls
+coverage
+
+# Benchmarking
+benchmarks/graphs
+
+# Development files
+/benchmarks/
+/examples/
+/test/
+/.travis.yml
+/appveyor.yml


### PR DESCRIPTION
I copied .gitignore as .npmignore and added a few development files and folders to be excluded from the npm package as they're unnecessary. Also removed node_modules as it's unnecessary as per npm's [documentation](https://docs.npmjs.com/misc/developers).
