### PR TITLE
Include listen errors in app.listen() callback

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -27,6 +27,7 @@ var deprecate = require('depd')('express');
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var slice = Array.prototype.slice;
+var eeFirst = require('ee-first');
 
 /**
  * Application prototype.
@@ -592,7 +593,14 @@ app.render = function(name, options, fn){
 
 app.listen = function(){
   var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
+  var args = Array.prototype.slice.call(arguments);
+  if (typeof args[args.length - 1] === 'function'){
+    var done = args.pop();
+    eeFirst([[server, 'error', 'listening']], function(err, ee, event, eventArgs){
+      done.apply(ee, eventArgs);
+    });
+  }
+  return server.listen.apply(server, args);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cookie-signature": "1.0.6",
     "debug": "~2.1.3",
     "depd": "~1.0.0",
+    "ee-first": "~1.1.0",
     "escape-html": "1.0.1",
     "etag": "~1.5.1",
     "finalhandler": "0.3.4",
@@ -49,8 +50,8 @@
     "send": "0.12.2",
     "serve-static": "~1.9.2",
     "type-is": "~1.6.1",
-    "vary": "~1.0.0",
-    "utils-merge": "1.0.0"
+    "utils-merge": "1.0.0",
+    "vary": "~1.0.0"
   },
   "devDependencies": {
     "after": "0.8.1",

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -1,5 +1,6 @@
 
 var express = require('../')
+  , assert = require('assert')
   , request = require('supertest');
 
 describe('app.listen()', function(){
@@ -13,6 +14,20 @@ describe('app.listen()', function(){
     var server = app.listen(9999, function(){
       server.close();
       done();
+    });
+  })
+
+  it('should callback on HTTP server errors', function(done){
+    var app = express();
+    var app2 = express();
+
+    var server = app.listen(9999, function(err){
+      assert(err === undefined);
+      app2.listen(9999, function(err){
+        assert(err.code === 'EADDRINUSE');
+        server.close();
+        done();
+      });
     });
   })
 })


### PR DESCRIPTION
I know that you can listen on the server instance, but it seems like this might be nicer to just proxy up the error event.  Thoughts?
