### PR TITLE
return values of next()

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -79,9 +79,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    return fn(req, res, next);
   } catch (err) {
-    next(err);
+    return next(err);
   }
 };
 

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -105,9 +105,9 @@ Route.prototype.dispatch = function(req, res, done){
     }
 
     if (err) {
-      layer.handle_error(err, req, res, next);
+      return layer.handle_error(err, req, res, next);
     } else {
-      layer.handle_request(req, res, next);
+      return layer.handle_request(req, res, next);
     }
   }
 };


### PR DESCRIPTION
I use promises a lot in my express apps, and I was curious about how to handle errors from routes that used promises in a more general way. What I wanted to do was install some middleware that could handle any error from any route below it, whether it was a normal error thrown or an asynchronous error in the form of a rejected promise.

This is what I wanted to do:

```
function handleErrors(req, res, next) {
  function sendError(error) {
    console.log(error);
    res.status(500).send({message: error.message});
  }

  var result;
  try {
    result = next();
  } catch (error) {
    sendError(error);
  }

  if (result && typeof result.then === 'function') {
    result.then(undefined, sendError);
  }
}

app.use(handleErrors);

// one of many routes
app.get('/thing', function (req, res) {
  return mongoDb.find({_id: 'thing'}).exec().then(function (thing) {
    res.send(thing);
  });
});
```

Now, if something happens to the mongo DB, the `/thing` route will NOT `res.send()` anything, simply return the promise to the error handling middleware, which will detect the error and all is (kinda) ok. At least the server returns _something_.

Problem is that express and connect don't really think about returning the result of `next()` functions. This is, on the surface at least, fairly easy to fix. I've made a start in the files below. But the connect API is very well understood already, and while this is not a breaking change, it is a very subtle extension to the API.

I've started putting `return` statements into express in the parts that matter, just to get this example working. I haven't finished yet, I intend to write tests and explore the wider scope of this change.

Is appetite for this?

(and I really don't mean to start an argument about promises vs callbacks vs generators)
