### PR TITLE
Optionally account for extra wildcard groups, fixing #2617

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -125,11 +125,16 @@ Layer.prototype.match = function match(path) {
   var params = this.params;
   var prop;
   var n = 0;
+  var keyOffset = 0;
   var key;
   var val;
 
   for (var i = 1, len = m.length; i < len; ++i) {
-    key = keys[i - 1];
+    key = keys[i - 1 - keyOffset];
+    if (key && key.index && key.index >= i) {
+      keyOffset++;
+      key = null;
+    }
     prop = key
       ? key.name
       : n++;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "methods": "~1.1.1",
     "on-finished": "~2.2.0",
     "parseurl": "~1.3.0",
-    "path-to-regexp": "0.1.3",
+    "path-to-regexp": "0.1.5",
     "proxy-addr": "~1.0.7",
     "qs": "2.4.1",
     "range-parser": "~1.0.2",

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -6,17 +6,6 @@ var express = require('../')
   , methods = require('methods');
 
 describe('app.router', function(){
-  it('should order params correctly when used with leading wildcard', function(done) {
-    var app = express();
-
-    app.get('*/test/:id', function (req, res) {
-      res.send(req.params[0] + ',' + req.params.id);
-    });
-
-    request(app)
-    .get('/1/test/2')
-    .expect(200, '/1,2', done);
-  })
   it('should restore req.params after leaving router', function(done){
     var app = express();
     var router = new express.Router();
@@ -348,6 +337,18 @@ describe('app.router', function(){
       request(app)
       .get('/user/tj')
       .expect(200, '[["name","tj"]]', done);
+    })
+    
+    it('should order params correctly when used with leading wildcard', function(done) {
+      var app = express();
+
+      app.get('*/test/:id', function (req, res) {
+        res.send(req.params[0] + ',' + req.params.id);
+      });
+
+      request(app)
+      .get('/1/test/2')
+      .expect(200, '/1,2', done);
     })
   })
 

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -10,7 +10,6 @@ describe('app.router', function(){
     var app = express();
 
     app.get('*/test/:id', function (req, res) {
-      console.log(req.param);
       res.send(req.params[0] + ',' + req.params.id);
     });
 

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -6,6 +6,18 @@ var express = require('../')
   , methods = require('methods');
 
 describe('app.router', function(){
+  it('should order params correctly when used with leading wildcard', function(done) {
+    var app = express();
+
+    app.get('*/test/:id', function (req, res) {
+      console.log(req.param);
+      res.send(req.params[0] + ',' + req.params.id);
+    });
+
+    request(app)
+    .get('/1/test/2')
+    .expect(200, '/1,2', done);
+  })
   it('should restore req.params after leaving router', function(done){
     var app = express();
     var router = new express.Router();

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -338,17 +338,17 @@ describe('app.router', function(){
       .get('/user/tj')
       .expect(200, '[["name","tj"]]', done);
     })
-    
+
     it('should order params correctly when used with leading wildcard', function(done) {
       var app = express();
 
-      app.get('*/test/:id', function (req, res) {
+      app.get('/*/test/:id', function (req, res) {
         res.send(req.params[0] + ',' + req.params.id);
       });
 
       request(app)
       .get('/1/test/2')
-      .expect(200, '/1,2', done);
+      .expect(200, '1,2', done);
     })
   })
 


### PR DESCRIPTION
Failing test cases for #2617 and optional support for future index value in path-to-regexp from https://github.com/pillarjs/path-to-regexp/pull/51

The issue is that wildcard *'s result in extra capture groups in the regexp, which is expected, however the keys array doesn't account for this at all. The result is that if you have a \* wildcard before any :named parameters then their values will be flip-flopped.

At first I tried making path-to-regexp return the wildcard groups in the keys array, however it resulted in deadlocking the testcase without any errors, so I deemed it too API breaking. Instead I added an "index" value to the keys which correlates to the index in the array of matches.
