### PR TITLE
Add support for a four-arg view engine

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -90,7 +90,11 @@ View.prototype.lookup = function lookup(name) {
 
 View.prototype.render = function render(options, fn) {
   debug('render "%s"', this.path);
-  this.engine(this.path, options, fn);
+  if (this.engine.length >= 4) {
+    this.engine(this.path, options, this, fn);
+  } else {
+    this.engine(this.path, options, fn);
+  }
 };
 
 /**

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -350,6 +350,26 @@ describe('app', function(){
         })
       })
     })
+
+    describe('view engine calling', function (){
+      it('should accept a four-parameter view engine', function(done){
+        var app = express();
+        var count = 0;
+
+        app.set('view engine', 'tmpl');
+        app.set('views', __dirname + '/fixtures');
+        app.engine('tmpl', function (name, options, view, callback) {
+          view.constructor.should.equal(app.get('view'));
+          callback(null, 'done');
+        })
+
+        app.render('user.tmpl', function(err, str){
+          if (err) return done(err);
+          str.should.equal('done');
+          done();
+        })
+      })
+    })
   })
 })
 


### PR DESCRIPTION
It gets a reference to the view object itself, so that the view object can provide services (like lookup) for partials and be configured by Express.
