### PR TITLE
Delegate `.VERB(...)` calls to `router.VERB(...)` to avoid duplication

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -461,8 +461,8 @@ methods.forEach(function(method){
 
     this.lazyrouter();
 
-    var route = this._router.route(path);
-    route[method].apply(route, slice.call(arguments, 1));
+    var router = this._router;
+    router[method].apply(router, arguments);
     return this;
   };
 });


### PR DESCRIPTION
In the [comment](https://github.com/strongloop/express/blob/6d43bacb4691f255e8d67a8d074e7a3062c8cd5a/lib/application.js#L455) of `lib/application.js`, it says "Delegate `.VERB(...)` calls to `router.VERB(...)`". However, the current implementation just copies the code from the [router methods](https://github.com/strongloop/express/blob/6d43bacb4691f255e8d67a8d074e7a3062c8cd5a/lib/router/index.js#L497-L498) to [app methods](https://github.com/strongloop/express/blob/6d43bacb4691f255e8d67a8d074e7a3062c8cd5a/lib/application.js#L464-L465). To avoid code duplication (and perhaps a little bit of maintenance burden), I made it a real "delegation".
