### PR TITLE
separate locals from config values

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -515,6 +515,16 @@ app.render = function(name, options, fn){
   var cache = this.cache;
   var engines = this.engines;
   var view;
+  var cleanLocals = {};
+
+  // saving a clean copy of locals
+  if (this.locals) {
+    merge(cleanLocals, this.locals);
+  }
+
+  if (options._locals) {
+    merge(cleanLocals, options._locals);
+  }
 
   // support callback function as second arg
   if ('function' == typeof options) {
@@ -531,6 +541,9 @@ app.render = function(name, options, fn){
 
   // merge options
   merge(opts, options);
+
+  // export a clean copy of the locals, separate from express settings
+  opts.locals = cleanLocals;
 
   // set .cache unless explicitly provided
   opts.cache = null == opts.cache


### PR DESCRIPTION
Keeping a separate namespace so that what's sent per-request is separate from long-lived configuration values.
