### PR TITLE
Support multiple functions in app.param

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@ $ npm install express
   * [Github Organization](https://github.com/expressjs) for Official Middleware & Modules
   * Visit the [Wiki](https://github.com/strongloop/express/wiki)
   * [Google Group](https://groups.google.com/group/express-js) for discussion
+  * [Gitter](https://gitter.im/strongloop/express) for support and discussion
   * [Русскоязычная документация](http://jsman.ru/express/)
 
 **PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/strongloop/express/wiki/New-features-in-4.x).

--- a/lib/application.js
+++ b/lib/application.js
@@ -312,23 +312,34 @@ app.engine = function engine(ext, fn) {
  * See the Router#param() docs for more details.
  *
  * @param {String|Array} name
- * @param {Function} fn
+ * @param {Function} ...
  * @return {app} for chaining
  * @public
  */
 
-app.param = function param(name, fn) {
+app.param = function param(name, fn){
+  var args = slice.apply(arguments);
+  var name = args[0];
+  var fns = args.slice(1);
+
   this.lazyrouter();
 
   if (Array.isArray(name)) {
-    for (var i = 0; i < name.length; i++) {
-      this.param(name[i], fn);
-    }
+    name.forEach(function(key) {
+      var params = [key].concat(fns);
+      this.param.apply(this, params);
+    }, this);
 
     return this;
   }
 
-  this._router.param(name, fn);
+  if (fns.length == 0) {
+    this._router.param(name);
+  } else {
+    fns.forEach(function(fn){
+      this._router.param(name, fn);
+    }, this);
+  }
 
   return this;
 };

--- a/test/app.param.js
+++ b/test/app.param.js
@@ -364,4 +364,28 @@ describe('app', function(){
       .expect('1 2 bob', done);
     })
   })
+
+  describe('.param(name, fns)', function(){
+    it('should map logic for a series of functions', function(done){
+      var app = express();
+      var fns = [];
+
+      app.param('id', function(req, res, next, id){
+        fns.push(1);
+        next();
+      }, function(req, res, next, id){
+        fns.push(2);
+        next();
+      });
+
+      app.get('/user/:id', function(req, res){
+        res.send('' + fns.join(''));
+      });
+
+      request(app)
+      .get('/user/123')
+      .expect('12', done);
+    })
+  })
+
 })


### PR DESCRIPTION
#2603

A simple change but it might be useful in some cases where we can write shorter code to reuse middleware in `app.param`
