### PR TITLE
Inconsistent router behavior

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -356,8 +356,11 @@ proto.process_params = function(layer, called, req, res, done) {
       return param();
     }
 
-    // param previously called with same value or error occurred
-    if (paramCalled && (paramCalled.error || paramCalled.match === paramVal)) {
+    // param previously called with same value or non-route error occurred
+    if (paramCalled && (
+        (paramCalled.error && paramCalled.error !== 'route') ||
+        paramCalled.match === paramVal
+    )) {
       // restore value
       req.params[name] = paramCalled.value;
 


### PR DESCRIPTION
Fixes an inconsistency within the router:

``` coffeescript
express = require "express"

app = express()


app.param "num", (req, res, next, value) ->
  if value.match(/[0-9]+/)
    next()
  else
    next("route")


app.param "alpha", (req, res, next, value) ->
  if value.match(/[a-z]+/)
    next()
  else
    next("route")


app.get "/:alpha/:num", (req, res) ->
  # this works for /asd/123
  res.status(200).send("Matched Alpha/Num")


app.get "/:alpha/static", (req, res) ->
  # this works for /asd/static
  res.status(200).send("Matched Alpha/Static")


app.get "/:num/static", (req, res) ->
  # this works for /123/static
  res.status(200).send("Matched Num/Static")


app.get "/:num/:alpha", (req, res) ->
  # but this doesn't work for /123/asd (generic 'no route matched' 404 error)
  res.status(200).send("Matched Num/Alpha")


app.listen 1234, ->
  console.log("Ready")
```

This could probably be fixed by using a param regexp instead of a function. However there are cases when that's not enough, for example if you're trying to get an object from a database and fall back onto another route if you couldn't find said object.
