### PR TITLE
Fixed: res.format crashing when only default option is provided

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -604,8 +604,10 @@ res.format = function(obj){
   if (fn) delete obj.default;
   var keys = Object.keys(obj);
 
-  var key = req.accepts(keys);
-  key = typeof key === 'string' ? key : false;
+  var key = false;
+  if (keys.length > 0) {
+    key = req.accepts(keys);
+  }
 
   this.vary("Accept");
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -605,6 +605,7 @@ res.format = function(obj){
   var keys = Object.keys(obj);
 
   var key = req.accepts(keys);
+  key = typeof key === 'string' ? key : false;
 
   this.vary("Accept");
 

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -67,6 +67,14 @@ app4.use(function(err, req, res, next){
   res.send(err.status, 'Supports: ' + err.types.join(', '));
 })
 
+var app5 = express();
+
+app5.use(function (req, res, next) {
+  res.format({
+    default: function () { res.send('hey') }
+  });
+});
+
 describe('res', function(){
   describe('.format(obj)', function(){
     describe('with canonicalized mime types', function(){
@@ -101,6 +109,13 @@ describe('res', function(){
         .get('/')
         .set('Accept', 'text/html')
         .expect('default', done);
+      })
+
+      it('should work when only .default is provided', function (done) {
+        request(app5)
+        .get('/')
+        .set('Accept', '*/*')
+        .expect('hey', done);
       })
     })
 


### PR DESCRIPTION
`res.format` crashes when provided only the default parameter.

Code:

```
  res.format({
    'default': function () {
      res.status(statusCode).send({ error: error });
    }
  });
```

Stack:

```
TypeError: Object application/json has no method 'replace'
    at Mime.lookup (/expressApp/node_modules/express/node_modules/send/node_modules/mime/mime.js:70:18)
    at exports.normalizeType (/expressApp/node_modules/express/lib/utils.js:103:21)
    at ServerResponse.res.format (/expressApp/node_modules/express/lib/response.js:613:30)
    at /expressApp/index.js:61:7
```

curl request
`
curl -H 'Content-Type: application/json' -H 'Accept: application/json' -v htt p://127.0.0.1:5555/
`

After brief debugging _response.js > res.format_ function I found that `req.accepts()` short circuits when `!keys.length` (which is zero, since we deleted obj.default) and returns internal function `this.negotiator.mediaTypes()`, which is in array type. Then it calls `mime.lookup(type)` on _utils.js > exports.normalizeType_ with the array which we previously got from `req.accepts`, and crashes.
