### PR TITLE
better detection of forwarded / proxied HTTP protocol

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -11,6 +11,7 @@ var fresh = require('fresh');
 var parseRange = require('range-parser');
 var parse = require('parseurl');
 var proxyaddr = require('proxy-addr');
+var forwarded = require('forwarded-http');
 
 /**
  * Request prototype.
@@ -266,6 +267,7 @@ defineGetter(req, 'protocol', function protocol(){
   var proto = this.connection.encrypted
     ? 'https'
     : 'http';
+
   var trust = this.app.get('trust proxy fn');
 
   if (!trust(this.connection.remoteAddress, 0)) {
@@ -274,7 +276,7 @@ defineGetter(req, 'protocol', function protocol(){
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  proto = this.get('X-Forwarded-Proto') || proto;
+  proto = forwarded(this).proto || proto;
   return proto.split(/\s*,\s*/)[0];
 });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "escape-html": "1.0.1",
     "etag": "~1.6.0",
     "finalhandler": "0.3.6",
+    "forwarded-http": "^0.3.0",
     "fresh": "0.2.4",
     "merge-descriptors": "1.0.0",
     "methods": "~1.1.1",
@@ -49,8 +50,8 @@
     "send": "0.12.3",
     "serve-static": "~1.9.3",
     "type-is": "~1.6.2",
-    "vary": "~1.0.0",
-    "utils-merge": "1.0.0"
+    "utils-merge": "1.0.0",
+    "vary": "~1.0.0"
   },
   "devDependencies": {
     "after": "0.8.1",


### PR DESCRIPTION
while `X-Forwarded-Proto` is the defacto-standard, it is not _actually_ a standard, and there has been many other alternative headers used that serve the same purpose, from the common _(e.g. `X-Real-Proto`)_ to the obscure _(e.g. `cf-visitor`)_ etc ...

[`forwarded-http`](https://github.com/ahmadnassri/forwarded-http) handles all the commen headers as well as the less common ones, in addition to (and most importantly) defaulting to the [`RFC 7239`](https://tools.ietf.org/html/rfc7239) standard.
