### PR TITLE
tests: support IANA compliant header messages

### DIFF
--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -85,7 +85,7 @@ describe('res', function(){
       .set('Accept', 'text/html')
       .end(function(err, res){
         res.headers.should.have.property('location', 'http://google.com');
-        res.text.should.equal('<p>Moved Temporarily. Redirecting to <a href="http://google.com">http://google.com</a></p>');
+        res.text.should.match(/<p>(Moved Temporarily|Found). Redirecting to <a href="http:\/\/google.com">http:\/\/google.com<\/a><\/p>/);
         done();
       })
     })
@@ -102,7 +102,7 @@ describe('res', function(){
       .set('Host', 'http://example.com')
       .set('Accept', 'text/html')
       .end(function(err, res){
-        res.text.should.equal('<p>Moved Temporarily. Redirecting to <a href="&lt;lame&gt;">&lt;lame&gt;</a></p>');
+        res.text.should.match(/<p>(Moved Temporarily|Found). Redirecting to <a href="&lt;lame&gt;">&lt;lame&gt;<\/a><\/p>/);
         done();
       })
     })
@@ -136,8 +136,8 @@ describe('res', function(){
       .set('Accept', 'text/plain, */*')
       .end(function(err, res){
         res.headers.should.have.property('location', 'http://google.com');
-        res.headers.should.have.property('content-length', '51');
-        res.text.should.equal('Moved Temporarily. Redirecting to http://google.com');
+        res.headers.should.have.property('content-length');
+        res.text.should.match(/(Moved Temporarily|Found). Redirecting to http:\/\/google.com/);
         done();
       })
     })
@@ -154,7 +154,7 @@ describe('res', function(){
       .set('Host', 'http://example.com')
       .set('Accept', 'text/plain, */*')
       .end(function(err, res){
-        res.text.should.equal('Moved Temporarily. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E');
+        res.text.should.match(/(Moved Temporarily|Found). Redirecting to http:\/\/example.com\/\?param=%3Cscript%3Ealert\(%22hax%22\);%3C\/script%3E/);
         done();
       })
     })


### PR DESCRIPTION
This commit allows the tests to pass when the node HTTP server uses IANA
compliant header messages rather than the messages the server used to
use. This prevents future test breakage caused by
https://github.com/nodejs/io.js/pull/1470, a pull request tracked for
io.js 3.0.0 semver-major release.

The only pertinent status code change is the 302 code, which used to be
"Moved Temporarily" but is now "Found", according to the document here:
http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
