### PR TITLE
Cleaner way for redirecting back to the Referrer

### DIFF
--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -112,7 +112,7 @@ app.post('/login', function(req, res){
         req.session.success = 'Authenticated as ' + user.name
           + ' click to <a href="/logout">logout</a>. '
           + ' You may now access <a href="/restricted">/restricted</a>.';
-        res.redirect('back');
+        res.redirect(req.back);
       });
     } else {
       req.session.error = 'Authentication failed, please check your '

--- a/examples/cookies/index.js
+++ b/examples/cookies/index.js
@@ -32,13 +32,13 @@ app.get('/', function(req, res){
 
 app.get('/forget', function(req, res){
   res.clearCookie('remember');
-  res.redirect('back');
+  res.redirect(req.back);
 });
 
 app.post('/', function(req, res){
   var minute = 60000;
   if (req.body.remember) res.cookie('remember', 1, { maxAge: minute });
-  res.redirect('back');
+  res.redirect(req.back);
 });
 
 /* istanbul ignore next */

--- a/examples/route-separation/user.js
+++ b/examples/route-separation/user.js
@@ -41,5 +41,5 @@ exports.update = function(req, res){
   var user = req.body.user;
   req.user.name = user.name;
   req.user.email = user.email;
-  res.redirect('back');
+  res.redirect(req.back);
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -473,6 +473,18 @@ defineGetter(req, 'xhr', function xhr(){
 });
 
 /**
+ * Return the referrer, or "/" if not present.
+ * Useful as argument to res.redirect().
+ *
+ * @return {String}
+ * @public
+ */
+
+defineGetter(req, 'back', function back(){
+  return this.get('Referrer') || '/';
+});
+
+/**
  * Helper function for creating a getter on an object.
  *
  * @param {Object} obj

--- a/lib/response.js
+++ b/lib/response.js
@@ -828,7 +828,8 @@ res.location = function location(url) {
 
   // "back" is an alias for the referrer
   if (url === 'back') {
-    loc = this.req.get('Referrer') || '/';
+    deprecate('res.location("back"): Use res.location(req.back) instead');
+    loc = this.req.back;
   }
 
   // set location


### PR DESCRIPTION
The 'back' special case has been moved from `res.location()` to a new `req.back` getter. In the future, this will make it possible to redirect to a regular 'back' page.
