### PR TITLE
responses to HEAD requests have content-length 0

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -172,6 +172,10 @@ res.send = function send(body) {
       encoding = undefined;
     }
 
+    if (req.method === 'HEAD') {
+      chunk = '';
+    }
+
     len = chunk.length;
     this.set('Content-Length', len);
   }

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -243,6 +243,23 @@ describe('res', function(){
       .head('/')
       .expect('', done);
     })
+
+    it('should send a content-length of 0', function(done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.send('yay');
+      });
+
+      request(app)
+      .head('/')
+      .end(function(err, res) {
+        res.text.should.equal('');
+        res.headers['content-length'].should.equal('0');
+
+        done();
+      })
+    })
   })
 
   describe('when .statusCode is 204', function(){
@@ -364,6 +381,7 @@ describe('res', function(){
 
       methods.forEach(function (method) {
         if (method === 'connect') return;
+        if (method === 'head') return;
 
         it('should send ETag in response to ' + method.toUpperCase() + ' request', function (done) {
           var app = express();
@@ -378,6 +396,19 @@ describe('res', function(){
           .expect(200, done);
         })
       });
+
+      it('should send ETag in response to HEAD request', function (done) {
+        var app = express();
+
+        app.head('/', function (req, res) {
+          res.send('kajdslfkasdf');
+        });
+
+        request(app)
+        .head('/')
+        .expect('ETag', 'W/"0-1B2M2Y8AsgTpgAmY7PhCfg"')
+        .expect(200, done);
+      })
 
       it('should send ETag for empty string response', function (done) {
         var app = express();


### PR DESCRIPTION
Hello nice people,

When developing an application that has HEAD handlers and using `curl` to test those routes, curl will hang on the response at times if the request handler doesn't explicitly `res.send('')`.

It looks like it hangs because express will set a content-length based on the content that is used in `res.send(<whatever>)` to generate a content-length header, and curl will wait for that number of bytes before considering the response complete.  Note that the old deprecated `res.send(200)` has default text that will also generate a non-zero content length.

A workaround is to tell curl to ignore the body of the response with `curl -I` but this may not help other client implementations that don't expect to see a content-length that does not match the response body length.

Another workaround is code your application to have `app.head` handlers explicitly `res.send('')`

One question I have is around the etag generation.  This change will break the current behavior of the etag plugin because it changes the signature of the etag between a head request and a get request.  I'm not sure how others use etags, so this might be a breaking change for some use cases.

Feedback welcome, and thank you for time!
