### PR TITLE
Update `path-to-regexp@0.1.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "methods": "~1.1.1",
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.0",
-    "path-to-regexp": "0.1.6",
+    "path-to-regexp": "0.1.7",
     "proxy-addr": "~1.0.8",
     "qs": "4.0.0",
     "range-parser": "~1.0.2",

--- a/test/app.routes.error.js
+++ b/test/app.routes.error.js
@@ -3,6 +3,22 @@ var express = require('../')
 
 describe('app', function(){
   describe('.VERB()', function(){
+    it('should not get invoked without error handler on error', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next){
+        next(new Error('boom!'))
+      });
+
+      app.get('/bar', function(req, res){
+        res.send('hello, world!');
+      });
+
+      request(app)
+      .post('/bar')
+      .expect(500, /Error: boom!/, done);
+    });
+
     it('should only call an error handling routing callback when an error is propagated', function(done){
       var app = express();
 


### PR DESCRIPTION
Properly handles escaped brackets with params array.

Closes https://github.com/strongloop/expressjs.com/issues/417. See commit: https://github.com/pillarjs/path-to-regexp/commit/22a301696755ea501154a9f466549688555303e7.
