### PR TITLE
req.ips: use `pop` instead of `slice(1)`.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -343,7 +343,8 @@ defineGetter(req, 'ip', function ip(){
 defineGetter(req, 'ips', function ips() {
   var trust = this.app.get('trust proxy fn');
   var addrs = proxyaddr.all(this, trust);
-  return addrs.slice(1).reverse();
+  addrs.reverse().pop();
+  return addrs;
 });
 
 /**


### PR DESCRIPTION
This should make that property access a bit faster.

Some benchmarks [here](https://jsperf.com/slice1-reverse-vs-reverse-pop). Switching the array length from relatively small to huge numbers yields similar results in favour of the proposed implementation.
