### PR TITLE
Fix for the 'app.render' docs comments

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -522,7 +522,7 @@ app.del = deprecate.function(app.delete, 'app.del: Use app.delete instead');
  *    })
  *
  * @param {String} name
- * @param {String|Function} options or fn
+ * @param {Object|Function} options or fn
  * @param {Function} callback
  * @public
  */


### PR DESCRIPTION
It sits there since `TJ` 2011 :)
I know the `express` is not using these comments anywhere in the docs generation, hence this patch is negligible.
Just noticed it while has been learning via the source code.
