### PR TITLE
add request.{local,inside,outside} getters to test where a request is coming from

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -461,6 +461,51 @@ defineGetter(req, 'stale', function stale(){
 });
 
 /**
+ * Check if request is local, aka
+ * if it originates from localhost
+ *
+ * @reutrn {Boolean}
+ * @public
+ */
+
+defineGetter(req, 'local', function local(){
+  var ip = this.ip;
+
+  return [ '127.0.0.1', '::', '::1', 'fe80::1' ].some(function (a) { return a === ip; });
+});
+
+/**
+ * Check if the request is from inside, aka
+ * if it originates from the LAN
+ *
+ * @reutrn {Boolean}
+ * @public
+ */
+
+defineGetter(req, 'inside', function inside(){
+  var ip = this.ip;
+
+  return this.local
+    || ip.match(/^1(0|27)\./) !== null
+    || ip.match(/^f(e8|c0)0/) !== null
+    || ip.match(/^192\.168/) !== null
+    || ip.match(/^172\.(1[6-9]|2\d|30|31)\./) !== null
+    || ip.match(/^169\.254/) !== null;
+});
+
+/**
+ * Check if the request is from outside, aka
+ * if it originates from beyond the LAN
+ *
+ * @reutrn {Boolean}
+ * @public
+ */
+
+defineGetter(req, 'outside', function outside() {
+  return !this.inside;
+});
+
+/**
  * Check if the request was an _XMLHttpRequest_.
  *
  * @return {Boolean}


### PR DESCRIPTION
Hello - this pull request is in response to #2745 

I was writing an express app that bound to any address on port 5000.  (*:5000)

It needed to receive POSTs from anywhere, but only serve GETs from local connections (localhost).  I thought it would be nice if express had getters on the request object to test if the connecting client is localhost, on the lan, or from the greater internet.

I defined getters for: `request.local`, `request.inside`, and `request.outside`

I intended for it to be used like:

``` javascript
app.get('/', function (req, res, next) { if (req.local) next(); }, ...);
```

This isn't meant to be as complete as express-ipfilter.

`request.local` - coming from localhost
`request.inside` - coming from LAN
`request.outside` - coming from ... not-LAN (lol)

Considerations / Acknowledgements:

1) I took what I needed from the node-ip module: https://github.com/indutny/node-ip/blob/master/lib/ip.js#L261
  I tried to rewrite the regular expressions there so they were more concise/readable.  It's assumed that we're getting a valid IP from `request.ip` - but the getter for `request.ip` may take into account the x-requested-for header if 'trust proxy' is enabled.  In my opinion we don't need to be certain it's a valid IP, so these expressions can be more concise/minimal.

2) I am hoping this is a complete list of private subnets.  I followed what I found in the node-ip module and what was on Wikipedia: https://en.wikipedia.org/wiki/Private_network

3) I had trouble coming up with names for these getters.  I initially wanted `request.private` and `request.public`, but because they're so close to common language keywords I avoided it.  I'm still not happy with `request.local`, but I feel it 'passes'.

4) It might be poor separation of concerns to have this as part of express' core.  I originally used node-ip to do: `app.get('/', function (req, res, next) { if (require(ip).isPrivate(req.ip)) next(); })` which isn't much longer than what I'm proposing.  I looked at the source for node-ip and I wasn't very happy with how it was written.  I saw that those 3 functions weren't dependent on the rest of the module so it also felt like something express could offer by itself.  I was also bored so I thought I'd make the pull request anyway. :-)

Tahh!

PS: I am somewhat worried I am fetching the ip wrong in these getters.  I'm also hoping I kept to the formatting style of express.
