### PR TITLE
Test against Node.js v4.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "1.8"
   - "2.0"
   - "2.3"
+  - "4"
 sudo: false
 before_install: "npm rm --save-dev connect-redis"
 script: "npm run-script test-ci"


### PR DESCRIPTION
It is stated "4" and not "4.0" to test against minor updates of Node.js. Only the newest 4.x release is supported by upstream so it doesn't make sense to test specifically on 4.0. Node now follows semver so no breaking changes are allowed to land before Node 5.0.0.
