### PR TITLE
No automatic 304s when `etag` feature is disabled.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -186,7 +186,7 @@ res.send = function send(body) {
   }
 
   // freshness
-  if (req.fresh) this.statusCode = 304;
+  if (app.get('etag fn') && req.fresh) this.statusCode = 304;
 
   // strip irrelevant headers
   if (204 == this.statusCode || 304 == this.statusCode) {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -316,6 +316,23 @@ describe('res', function(){
     .expect(304, done);
   })
 
+  it('should not respond with 304 Not Modified when etag is disabled', function(done){
+    var app = express();
+    var etag = '"asdf"';
+
+    app.set('etag', false);
+    app.use(function(req, res){
+      var str = Array(1000).join('-');
+      res.set('ETag', etag);
+      res.send(str);
+    });
+
+    request(app)
+    .get('/')
+    .set('If-None-Match', etag)
+    .expect(200, done);
+  })
+
   it('should not perform freshness check unless 2xx or 304', function(done){
     var app = express();
     var etag = '"asdf"';


### PR DESCRIPTION
I disabled the `etag` feature (`app.set('etag', false);`) because I didn't want
express managing my ETags.  This worked to prevent automatic ETag generation,
but Express was still checking ETag headers, altering the status code, and
stripping the body.
