### PR TITLE
Throw error if argument to res.status is null or undefined

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -56,7 +56,11 @@ var charsetRegExp = /;\s*charset\s*=/;
  */
 
 res.status = function status(code) {
-  this.statusCode = code;
+  if (code !== null && code !== undefined) {
+    this.statusCode = code;
+  } else {
+    throw new TypeError('Invalid status code.')
+  }
   return this;
 };
 

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -16,5 +16,37 @@ describe('res', function(){
       .expect('Created')
       .expect(201, done);
     })
+
+    it('should throw a TypeError if code is undefined', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.status(undefined).end('Created');
+      });
+
+      request(app)
+      .get('/')
+      .expect(invalidCode)
+      .expect(500, done);
+    })
+
+    it('should throw a TypeError if code is null', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.status(null).end('Created');
+      });
+
+      request(app)
+      .get('/')
+      .expect(invalidCode)
+      .expect(500, done);
+    })
+
   })
 })
+
+function invalidCode(res) {
+  if (!(res.error.text.match(/TypeError/ && res.error.text.match(/status code/)))) {
+    throw new Error('Expected a TypeError for invalid status code.');
+  }
+}
+


### PR DESCRIPTION
Fixes #2795 where res.status gives undescriptive error when the argument is null or undefined. I tested and all other inputs don't seem to have the same issue as null and undefined since they have .toString methods. I added unit tests to verify the new behaviour of res.status.

This is my first pull request on an open source project so if I formatted something wrong or went about submitting this wrong please let me know.
