### PR TITLE
add Layer.pathOriginal to list all route paths

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -42,6 +42,7 @@ function Layer(path, options, fn) {
   this.name = fn.name || '<anonymous>';
   this.params = undefined;
   this.path = undefined;
+  this.pathOriginal = path;
   this.regexp = pathRegexp(path, this.keys = [], opts);
 
   if (path === '/' && opts.end === false) {

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -1031,4 +1031,15 @@ describe('app.router', function(){
     var app = express();
     app.get('/', function(){}).should.equal(app);
   })
+
+  it('should check for Later pathOriginal', function(){
+    var app = express();
+    var router = new express.Router();
+    app.use("/users", router);
+    app._router.stack.forEach(function(middleware){
+      if(middleware.name === 'router'){
+        assert.equal(middleware.pathOriginal, "/users");
+      }
+    });
+  })
 })


### PR DESCRIPTION
This PR is to solve the problem of listing all routes. Right now, it is not possible to get the full path of a route. A new member `pathOriginal` is added to `Layer`. 
