### PR TITLE
router: add async route handler support

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -68,7 +68,10 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    var maybe_promise = fn(error, req, res, next);
+    if (maybe_promise && maybe_promise.catch && typeof maybe_promise.catch === 'function') {
+      maybe_promise.catch(next);
+    }
   } catch (err) {
     next(err);
   }
@@ -92,7 +95,10 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    var maybe_promise = fn(req, res, next);
+    if (maybe_promise && maybe_promise.catch && typeof maybe_promise.catch === 'function') {
+      maybe_promise.catch(next);
+    }
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
While the async/await feature is still highly experimental and not official, it does have preliminary support in tools like babel. There are even blog posts [1] about how to use the async/await feature with express routes.

However, these posts along with issue #2789 and #2788 show that using async/await is still a bit of a manual process and not clear. This change inspects the return value of a route handler to see if it is potentially a pomise. If the return value appears to be a promise then we attach to the error handler of the promise via .catch()

Now a user who is using babel can write the following without needing any wrap functions as most examples to date require.

``` js
app.get('/', async (req, res, next) => {
    let user = await User.findById(); // assuming .findById() returns a primise
    let org = await Org.findById();
    res.json({
        user: user,
        org: org,
    });
});
```

[1] https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/

---

Note on testing:
I have not added any tests since it would require instrumenting with babel but I can do that if the current maintainers think it would be useful. Alternatively, a fake test that just passes a promise like object to a route could simulate the same results.

Alternative implementation:
If the conditional checking is not desired in the hot path, then a wrap function could be applied upon adding the actual route versus at runtime. Additionally, that would open up the possibility of putting this behind an express setting which I didn't want to do in the hot path but maybe that would also be ok.
