### PR TITLE
Security improvement: don't reveal powered-by

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -85,7 +85,6 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this.enable('x-powered-by');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');
@@ -149,11 +148,6 @@ app.handle = function handle(req, res, callback) {
     env: this.get('env'),
     onerror: logerror.bind(this)
   });
-
-  // set powered by header
-  if (this.enabled('x-powered-by')) {
-    res.setHeader('X-Powered-By', 'Express');
-  }
 
   // set circular references
   req.res = res;

--- a/test/req.secure.js
+++ b/test/req.secure.js
@@ -3,6 +3,21 @@ var express = require('../')
   , request = require('supertest');
 
 describe('req', function(){
+  it('should not reveal powered-by', function(done){
+    var app = express();
+
+    app.get('/', function(req, res){
+      res.send('hello world');
+    });
+
+    request(app)
+    .get('/')
+    .expect(function (res) {
+      res.header.should.not.have.property('x-powered-by');
+    })
+    .expect(200, done)
+  })
+
   describe('.secure', function(){
     describe('when X-Forwarded-Proto is missing', function(){
       it('should return false when http', function(done){


### PR DESCRIPTION
The first thing recommended when setting up an Express instance is to secure it by removing its "X-Powered-By" header.

https://www.npmjs.com/package/helmet
https://blog.risingstack.com/node-js-security-checklist/
https://strongloop.com/strongblog/best-practices-for-express-in-production-part-one-security/

So let's save cycles by not setting this header in the first place.

This header is also totally useless. If some people are needing it somewhere for a very specific usecase they can add a little custom middleware that returns the "X-Powered-By" header again.
