### PR TITLE
disabled x-powered-by by default

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -70,7 +70,7 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this.enable('x-powered-by');
+  this.disable('x-powered-by');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');

--- a/test/app.js
+++ b/test/app.js
@@ -4,6 +4,13 @@ var express = require('..')
 var request = require('supertest')
 
 describe('app', function(){
+  it('should disabled x-powered-by by default', function(done){
+    var app = express();
+    app.on('foo', done);
+    app.enabled('x-powered-by').should.be.false;
+    done()
+  })
+
   it('should inherit from event emitter', function(done){
     var app = express();
     app.on('foo', done);


### PR DESCRIPTION
Don’t give too much information about the technology used by default. Plus probably some bites saved it :smile:

This required to update the documentation as well.
