### PR TITLE
Fix do not invoke Router as constructor

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -135,7 +135,7 @@ app.defaultConfiguration = function defaultConfiguration() {
  */
 app.lazyrouter = function lazyrouter() {
   if (!this._router) {
-    this._router = new Router({
+    this._router = Router({
       caseSensitive: this.enabled('case sensitive routing'),
       strict: this.enabled('strict routing')
     });


### PR DESCRIPTION
`Router` is not a constructor function, it does not need the `new` keyword.
