### PR TITLE
Make automatic 304 responses configurable.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -71,6 +71,7 @@ app.defaultConfiguration = function defaultConfiguration() {
 
   // default settings
   this.enable('x-powered-by');
+  this.enable('automatic 304s');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');

--- a/lib/response.js
+++ b/lib/response.js
@@ -186,7 +186,7 @@ res.send = function send(body) {
   }
 
   // freshness
-  if (req.fresh) this.statusCode = 304;
+  if (app.enabled('automatic 304s') && req.fresh) this.statusCode = 304;
 
   // strip irrelevant headers
   if (204 == this.statusCode || 304 == this.statusCode) {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -330,6 +330,23 @@ describe('res', function(){
     .expect(304, done);
   })
 
+  it('should not respond with 304 Not Modified when "automatic 304s" is disabled', function(done){
+    var app = express();
+    var etag = '"asdf"';
+
+    app.disable('automatic 304s');
+    app.use(function(req, res){
+      var str = Array(1000).join('-');
+      res.set('ETag', etag);
+      res.send(str);
+    });
+
+    request(app)
+    .get('/')
+    .set('If-None-Match', etag)
+    .expect(200, done);
+  })
+
   it('should not perform freshness check unless 2xx or 304', function(done){
     var app = express();
     var etag = '"asdf"';


### PR DESCRIPTION
I needed to disable this behavior in an application I'm working on. It seemed to me that disabling ETags should disable the automatic comparing of `If-None-Match` and the response `ETag` so [I opened this pull request](https://github.com/strongloop/express/pull/2772).

@dougwilson asked that I configure this behavior specifically and I've done that here.
