### PR TITLE
Ability to set a different view directory for each rendering

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@ $ npm install express
   * [Github Organization](https://github.com/expressjs) for Official Middleware & Modules
   * Visit the [Wiki](https://github.com/strongloop/express/wiki)
   * [Google Group](https://groups.google.com/group/express-js) for discussion
+  * [Gitter](https://gitter.im/strongloop/express) for support and discussion
   * [Русскоязычная документация](http://jsman.ru/express/)
 
 **PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/strongloop/express/wiki/New-features-in-4.x).

--- a/lib/application.js
+++ b/lib/application.js
@@ -568,7 +568,7 @@ app.render = function render(name, options, callback) {
 
     view = new View(name, {
       defaultEngine: this.get('view engine'),
-      root: options.root || this.get('views'),
+      root: options.viewRoot || this.get('views'),
       engines: engines
     });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -568,7 +568,7 @@ app.render = function render(name, options, callback) {
 
     view = new View(name, {
       defaultEngine: this.get('view engine'),
-      root: this.get('views'),
+      root: options.root || this.get('views'),
       engines: engines
     });
 


### PR DESCRIPTION
This small change allows developers to specify a custom path to a different `views` directory each time they use `res.render()`. If nothing is specified, the global default will be used.

Here's an example:

``` javascript
res.render('home', {
  viewRoot: './special'
});
```
