### PR TITLE
Not adding Content Length header in the response if Transfer Encoding is chunked

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@ $ npm install express
   * [Github Organization](https://github.com/expressjs) for Official Middleware & Modules
   * Visit the [Wiki](https://github.com/strongloop/express/wiki)
   * [Google Group](https://groups.google.com/group/express-js) for discussion
+  * [Gitter](https://gitter.im/strongloop/express) for support and discussion
   * [Русскоязычная документация](http://jsman.ru/express/)
 
 **PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/strongloop/express/wiki/New-features-in-4.x).

--- a/lib/response.js
+++ b/lib/response.js
@@ -165,7 +165,7 @@ res.send = function send(body) {
   }
 
   // populate Content-Length
-  if (chunk !== undefined) {
+  if (chunk !== undefined && this.get('Transfer-Encoding') !== 'chunked') {
     if (!Buffer.isBuffer(chunk)) {
       // convert chunk to Buffer; saves later double conversions
       chunk = new Buffer(chunk, encoding);


### PR DESCRIPTION
According to the RFC 2616 Hypertext Transfer Protocol -- HTTP/1.1, Section 4.4 (https://tools.ietf.org/html/rfc2616#section-4.4):

"Messages MUST NOT include both a Content-Length header field and a non-identity transfer-coding. If the message does include a non-identity transfer-coding, the Content-Length MUST be ignored."

Including both headers in the response crashes some http clients.
