### PR TITLE
node foundation proposed express WG governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+### Express WG Code of Conduct
+
+The [Node.js Code of Conduct][] applies to this WG.
+
+[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,6 @@
-### Express WG Code of Conduct
+# Express WG Code of Conduct
 
-## Code of Conduct
-
-### Conduct
+## Conduct
 
 * We are committed to providing a friendly, safe and welcoming
   environment for all, regardless of level of experience, gender
@@ -40,17 +38,17 @@
   documentation. There is no need to address persons when explaining
   code (e.g. "When the developer").
 
-### Contact
+## Contact
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by:
 
 * Emailing [report@nodejs.org](mailto:report@nodejs.org) (this will email all TSC members)
 * Contacting [individual TSC members](https://nodejs.org/en/foundation/tsc/#current-members-of-the-technical-steering-committee).
 
-### Moderation
+## Moderation
 See the TSC's [moderation policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md) for details about moderation.
 
-### Attribution
+## Attribution
 
 This Code of Conduct is adapted from [Rust's wonderful
 CoC](http://www.rust-lang.org/conduct.html) as well as the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,59 @@
 ### Express WG Code of Conduct
 
-The [Node.js Code of Conduct][] applies to this WG.
+## Code of Conduct
+
+### Conduct
+
+* We are committed to providing a friendly, safe and welcoming
+  environment for all, regardless of level of experience, gender
+  identity and expression, sexual orientation, disability,
+  personal appearance, body size, race, ethnicity, age, religion,
+  nationality, or other similar characteristic.
+* Please avoid using overtly sexual nicknames or other nicknames that
+  might detract from a friendly, safe and welcoming environment for
+  all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that some individuals and cultures consider the casual use of
+  profanity offensive and off-putting.
+* Respect that people have differences of opinion and that every
+  design or implementation choice carries a trade-off and numerous
+  costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid
+  ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass
+  anyone. That is not welcome behavior. We interpret the term
+  "harassment" as including the definition in the [Citizen Code of
+  Conduct](http://citizencodeofconduct.org/); if you have any lack of
+  clarity about what might be included in that concept, please read
+  their definition. In particular, we don't tolerate behavior that
+  excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if
+  you feel you have been or are being harassed or made uncomfortable
+  by a community member, please contact one of the channel ops or any
+  of the TSC members immediately with a capture (log, photo, email) of
+  the harassment if possible. Whether you're a regular contributor or
+  a newcomer, we care about making this community a safe place for you
+  and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other
+  attention-stealing behavior is not welcome.
+* Avoid the use of personal pronouns in code comments or
+  documentation. There is no need to address persons when explaining
+  code (e.g. "When the developer").
+
+### Contact
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by:
+
+* Emailing [report@nodejs.org](mailto:report@nodejs.org) (this will email all TSC members)
+* Contacting [individual TSC members](https://nodejs.org/en/foundation/tsc/#current-members-of-the-technical-steering-committee).
+
+### Moderation
+See the TSC's [moderation policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md) for details about moderation.
+
+### Attribution
+
+This Code of Conduct is adapted from [Rust's wonderful
+CoC](http://www.rust-lang.org/conduct.html) as well as the
+[Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).
 
 [Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md

--- a/Contributing.md
+++ b/Contributing.md
@@ -122,8 +122,8 @@ address, apply your changes in a separate commit and push that to your feature
 branch. Post a comment in the pull request afterwards; GitHub does not send out
 notifications when you add commits.
 
-[Code of Conduct]: governance/CodeOfConduct.md
-[Express governance document]: governance/Governance.md
+[Code of Conduct]: CODE_OF_CONDUCT.md
+[Express governance document]: GOVERNANCE.md
 [expressjs.com GitHub repository]: https://github.com/strongloop/expressjs.com
-[on GitHub]: https://github.com/strongloop/express
-[Developer's Certificate of Origin]: governance/DCO.md
+[on GitHub]: https://github.com/expressjs/express
+[Developer's Certificate of Origin]: GOVERNANCE.md#developers-certificate-of-origin-11

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,36 +1,129 @@
+# Contributing to Express
 
-## Website Issues
+## Code of Conduct
 
-Issues for the expressjs.com website go here https://github.com/strongloop/expressjs.com
+The [Code of Conduct][] explains the bare minimum behavior expectations for all
+contributors to Express. Please read it before participating.
 
-## PRs and Code contributions
+## Developer's Certificate of Origin
 
-* Tests must pass.
-* Follow existing coding style.
-* If you fix a bug, add a test.
+All code contributions to Express fall under the Express
+[Developer's Certificate of Origin][].
 
-## Branches
+## Issue Contributions
 
-* Use the `master` branch for bug fixes or minor work that is intended for the current release stream
-* Use the correspondingly named branch, e.g. `5.0`, for anything intended for a future release of Express 
+When opening new issues or commenting on existing issues on this repository
+please make sure discussions are related to concrete technical issues with the
+Express software.
 
-## Steps for contributing
+The issues tracker in this repository is not ideal for posting general help
+using Express. Helpful information and documentation can be found at
+http://expressjs.com.
 
-* [Create an issue](https://github.com/strongloop/express/issues/new) for the bug you want to fix or the feature that you want to add.
-* Create your own [fork](https://github.com/strongloop/express) on github, then checkout your fork.
-* Write your code in your local copy. It's good practice to create a branch for each new issue you work on, although not compulsory.
-* To run the test suite, first install the dependencies by running `npm install`, then run `npm test`.
-* If the tests pass, you can commit your changes to your fork and then create a pull request from there. Make sure to reference your issue from the pull request comments by including the issue number e.g. #123.
+Issues for the expressjs.com website should be directed to the
+[expressjs.com GitHub repository][].
 
-## Issues which are questions
+## Code contributions
 
-We will typically close any vague issues or questions that are specific to some app you are writing. Please double check the docs and other references before being trigger happy with posting a question issue.
+The Express project has an Open Governance model and welcomes new contributors.
+Individuals making significant and valuable contributions are made
+Collaborators and given commit-access to the project. See the
+[Express governance document][] for more information about how this works.
 
-Things that will help get your question issue looked at:
+This document will guide you through the contribution process.
 
-* Full and runnable JS code.
-* Clear description of the problem or unexpected behavior.
-* Clear description of the expected result.
-* Steps you have taken to debug it yourself.
+### Step 1: Fork
 
-If you post a question and do not outline the above items or make it easy for us to understand and reproduce your issue, it will be closed.
+Fork the project [on GitHub][] and check out your copy locally.
+
+```
+$ git clone git@github.com:username/express.git
+$ cd express
+$ git remote add upstream git://github.com/strongloop/express.git
+```
+
+### Step 2: Branch
+
+Create a feature branch and start hacking:
+
+```
+$ git checkout -b my-feature-branch -t origin/master
+```
+
+Please follow the existing coding style.
+
+### Step 3: Commit
+
+Make sure git knows your name and email address:
+
+```
+$ git config --global user.name "J. Random User"
+$ git config --global user.email "j.random.user@example.com"
+```
+
+Writing good commit logs is important. A commit log should describe what
+changed and why. Follow these guidelines when writing one:
+
+* The first line should be 50 characters or less and contain a short
+  description of the change.
+* Keep the second line blank.
+* Wrap all other lines at 72 columns.
+
+A good commit log can look something like this:
+
+```
+explaining the commit in one line
+
+Body of commit message is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue
+being fixed, etc. etc.
+
+The body of the commit message can be several paragraphs, and
+please do proper word-wrap and keep columns shorter than about
+72 characters or so. That way `git log` will show things
+nicely even when it is indented.
+```
+
+The header line should be meaningful; it is what other people see when they run
+`git shortlog` or `git log --oneline`.
+
+### Step 4: Rebase
+
+Use `git rebase` (*not* `git merge`) to sync your work from time to time.
+
+```
+$ git fetch upstream
+$ git rebase upstream/master
+```
+
+### Step 5: Test
+
+Bug fixes and features should come with tests. Add your tests in the `test/`
+directory. Look at other tests to see how they should be structured (license
+boilerplate, common includes, etc.).
+
+```
+$ npm test
+```
+
+All tests must pass. Please do not submit pull requests with failing tests.
+
+### Step 6: Push
+
+```
+$ git push origin my-feature-branch
+```
+
+Go to https://github.com/yourusername/express and select your feature branch.
+Click the 'Pull Request' button and fill out the form.
+
+Pull requests are usually reviewed within a few days. If there are comments to
+address, apply your changes in a separate commit and push that to your feature
+branch. Post a comment in the pull request afterwards; GitHub does not send out
+notifications when you add commits.
+
+[Code of Conduct]: governance/CodeOfConduct.md
+[Express governance document]: governance/Governance.md
+[expressjs.com GitHub repository]: https://github.com/strongloop/expressjs.com
+[on GitHub]: https://github.com/strongloop/express
+[Developer's Certificate of Origin]: governance/DCO.md

--- a/Contributing.md
+++ b/Contributing.md
@@ -39,7 +39,7 @@ Fork the project [on GitHub][] and check out your copy locally.
 ```
 $ git clone git@github.com:username/express.git
 $ cd express
-$ git remote add upstream git://github.com/strongloop/express.git
+$ git remote add upstream git://github.com/expressjs/express.git
 ```
 
 ### Step 2: Branch

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,140 @@
+## Express Working Group Governance
+
+### Collaborators
+
+The nodejs/express GitHub repository is maintained by the WG and additional
+Collaborators who are added by the WG on an ongoing basis.
+
+Individuals making significant and valuable contributions are made
+Collaborators and given commit-access to the project. These individuals are
+identified by the WG and their addition as Collaborators is discussed during
+the weekly WG meeting.
+
+Individuals who have made significant contributions and who wish to be
+considered for commit-access may create an issue or contact a WG member
+directly. It is not necessary to wait for a WG member to nominate the
+individual.
+
+Modifications of the contents of the nodejs/express repository are made on
+a collaborative basis. Anybody with a GitHub account may propose a
+modification via pull request and it will be considered by the project
+Collaborators. All pull requests must be reviewed and accepted by a
+Collaborator with sufficient expertise who is able to take full
+responsibility for the change. In the case of pull requests proposed
+by an existing Collaborator, an additional Collaborator is required
+for sign-off. Consensus should be sought if additional Collaborators
+participate and there is disagreement around a particular
+modification. See _Consensus Seeking Process_ below for further detail
+on the consensus model used for governance.
+
+Collaborators may opt to esacalate discussion about significant or
+controversial modifications to the WG as a whole by assigning the
+`express-agenda` tag to a pull request or issue. The WG should serve as the
+final arbiter where required.
+
+For the current list of Collaborators, see the project [README.md][].
+
+### WG Membership
+
+WG seats are not time-limited.  There is no fixed size of the WG.
+However, the expected target is between 6 and 12, to ensure adequate
+coverage of important areas of expertise, balanced with the ability to
+make decisions efficiently.
+
+There is no specific set of requirements or qualifications for WG
+membership beyond these rules.
+
+The WG may add additional members to the WG by consensus. If there are
+any objections to adding any individual member, an attempt should be
+made to resolve those objections following the WG's Consensus Seeking
+Process.
+
+A WG member may be removed from the WG by voluntary resignation, or by
+consensus of all other WG members.
+
+Changes to WG membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "WG Meetings" below).
+
+If an addition or removal is proposed during a meeting, and the full
+WG is not in attendance to participate, then the addition or removal
+is added to the agenda for the subsequent meeting.  This is to ensure
+that all members are given the opportunity to participate in all
+membership decisions.  If a WG member is unable to attend a meeting
+where a planned membership decision is being made, then their consent
+is assumed.
+
+If the WG membership consists of more than 3 active participants, no more than
+1/3 of the WG members may be affiliated with the same employer.  If removal or
+resignation of a WG member, or a change of employment by a WG member, creates a
+situation where more than 1/3 of the WG membership shares an employer, then the
+situation must be immediately remedied by the resignation or removal of one or
+more WG members affiliated with the over-represented employer(s).
+
+### WG Meetings
+
+The WG meets bi-weekly using Google Hangouts on Air or similar tool that allows
+public viewing or participation. A designated moderator approved by the WG runs
+the meeting. A recording of each meeting should be published to either YouTube
+or similar service and all meeting minutes should be posted to the
+nodejs/express GitHub repository.
+
+Items are added to the WG agenda that are considered contentious or
+are modifications of governance, contribution policy, WG membership,
+or release process.
+
+The intention of the agenda is not to approve or review all patches;
+that should happen continuously on GitHub and be handled by the larger
+group of Collaborators.
+
+Any community member or contributor can ask that something be added to
+the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
+WG member or the moderator can add the item to the agenda by adding
+the `express-agenda` tag to the issue.
+
+Prior to each WG meeting the moderator will share the Agenda with
+members of the WG. WG members can add any items they like to the
+agenda at the beginning of each meeting. The moderator and the WG
+cannot veto or remove items.
+
+The WG may invite persons or representatives from certain projects to
+participate in a non-voting capacity.
+
+The moderator is responsible for summarizing the discussion of each
+agenda item and sends it as a pull request after the meeting.
+
+### Consensus Seeking Process
+
+The WG follows a [Consensus Seeking][] decision-making model.
+
+When an agenda item has appeared to reach a consensus the moderator
+will ask "Does anyone object?" as a final call for dissent from the
+consensus.
+
+If an agenda item cannot reach a consensus a WG member can call for
+either a closing vote or a vote to table the issue to the next
+meeting. The call for a vote must be seconded by a majority of the WG
+or else the discussion will continue. Simple majority wins.
+
+Note that changes to WG membership require consensus. If there are any
+objections to adding or removing individual members, an effort must be
+made to resolve those objections. If consensus cannot be reached, a
+vote may be called following the process above.
+
+### Developer's Certificate of Origin 1.0
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license indicated
+  in the file; or
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source license
+  and I have the right under that license to submit that work with
+  modifications, whether created in whole or in part by me, under the
+  same open source license (unless I am permitted to submit under a
+  different license), as indicated in the file; or
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified it.
+
+[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[README.md]: ./README.md#current-project-team-members

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,20 +2,20 @@
 
 ### Collaborators
 
-The nodejs/express GitHub repository is maintained by the WG and additional
-Collaborators who are added by the WG on an ongoing basis.
+The expressjs/express GitHub repository is maintained by the Express TC and 
+additional Collaborators who are added by the TC on an ongoing basis.
 
 Individuals making significant and valuable contributions are made
 Collaborators and given commit-access to the project. These individuals are
-identified by the WG and their addition as Collaborators is discussed during
-the weekly WG meeting.
+identified by the TC and their addition as Collaborators is discussed during
+the weekly TC meeting.
 
 Individuals who have made significant contributions and who wish to be
-considered for commit-access may create an issue or contact a WG member
-directly. It is not necessary to wait for a WG member to nominate the
+considered for commit-access may create an issue or contact a TC member
+directly. It is not necessary to wait for a TC member to nominate the
 individual.
 
-Modifications of the contents of the nodejs/express repository are made on
+Modifications of the contents of the expressjs/express repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
 Collaborators. All pull requests must be reviewed and accepted by a
@@ -27,59 +27,59 @@ participate and there is disagreement around a particular
 modification. See _Consensus Seeking Process_ below for further detail
 on the consensus model used for governance.
 
-Collaborators may opt to esacalate discussion about significant or
-controversial modifications to the WG as a whole by assigning the
-`express-agenda` tag to a pull request or issue. The WG should serve as the
+Collaborators may opt to escalate discussion about significant or
+controversial modifications to the TC as a whole by assigning the
+`express-agenda` tag to a pull request or issue. The TC should serve as the
 final arbiter where required.
 
 For the current list of Collaborators, see the project [README.md][].
 
-### WG Membership
+### TC Membership
 
-WG seats are not time-limited.  There is no fixed size of the WG.
+TC seats are not time-limited.  There is no fixed size of the TC.
 However, the expected target is between 6 and 12, to ensure adequate
 coverage of important areas of expertise, balanced with the ability to
 make decisions efficiently.
 
-There is no specific set of requirements or qualifications for WG
+There is no specific set of requirements or qualifications for TC
 membership beyond these rules.
 
-The WG may add additional members to the WG by consensus. If there are
+The TC may add additional members to the TC by consensus. If there are
 any objections to adding any individual member, an attempt should be
-made to resolve those objections following the WG's Consensus Seeking
+made to resolve those objections following the TC's Consensus Seeking
 Process.
 
-A WG member may be removed from the WG by voluntary resignation, or by
-consensus of all other WG members.
+A TC member may be removed from the TC by voluntary resignation, or by
+consensus of all other TC members.
 
-Changes to WG membership should be posted in the agenda, and may be
-suggested as any other agenda item (see "WG Meetings" below).
+Changes to TC membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "TC Meetings" below).
 
 If an addition or removal is proposed during a meeting, and the full
-WG is not in attendance to participate, then the addition or removal
+TC is not in attendance to participate, then the addition or removal
 is added to the agenda for the subsequent meeting.  This is to ensure
 that all members are given the opportunity to participate in all
-membership decisions.  If a WG member is unable to attend a meeting
+membership decisions.  If a TC member is unable to attend a meeting
 where a planned membership decision is being made, then their consent
 is assumed.
 
-If the WG membership consists of more than 3 active participants, no more than
-1/3 of the WG members may be affiliated with the same employer.  If removal or
-resignation of a WG member, or a change of employment by a WG member, creates a
-situation where more than 1/3 of the WG membership shares an employer, then the
+If the TC membership consists of more than 3 active participants, no more than
+1/3 of the TC members may be affiliated with the same employer.  If removal or
+resignation of a TC member, or a change of employment by a TC member, creates a
+situation where more than 1/3 of the TC membership shares an employer, then the
 situation must be immediately remedied by the resignation or removal of one or
-more WG members affiliated with the over-represented employer(s).
+more TC members affiliated with the over-represented employer(s).
 
-### WG Meetings
+### TC Meetings
 
-The WG meets bi-weekly using Google Hangouts on Air or similar tool that allows
-public viewing or participation. A designated moderator approved by the WG runs
+The TC meets bi-weekly using Google Hangouts on Air or similar tool that allows
+public viewing or participation. A designated moderator approved by the TC runs
 the meeting. A recording of each meeting should be published to either YouTube
 or similar service and all meeting minutes should be posted to the
-nodejs/express GitHub repository.
+expressjs/express GitHub repository.
 
-Items are added to the WG agenda that are considered contentious or
-are modifications of governance, contribution policy, WG membership,
+Items are added to the TC agenda that are considered contentious or
+are modifications of governance, contribution policy, TC membership,
 or release process.
 
 The intention of the agenda is not to approve or review all patches;
@@ -88,15 +88,15 @@ group of Collaborators.
 
 Any community member or contributor can ask that something be added to
 the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
-WG member or the moderator can add the item to the agenda by adding
+TC member or the moderator can add the item to the agenda by adding
 the `express-agenda` tag to the issue.
 
-Prior to each WG meeting the moderator will share the Agenda with
-members of the WG. WG members can add any items they like to the
-agenda at the beginning of each meeting. The moderator and the WG
+Prior to each TC meeting the moderator will share the Agenda with
+members of the TC. TC members can add any items they like to the
+agenda at the beginning of each meeting. The moderator and the TC
 cannot veto or remove items.
 
-The WG may invite persons or representatives from certain projects to
+The TC may invite persons or representatives from certain projects to
 participate in a non-voting capacity.
 
 The moderator is responsible for summarizing the discussion of each
@@ -104,37 +104,47 @@ agenda item and sends it as a pull request after the meeting.
 
 ### Consensus Seeking Process
 
-The WG follows a [Consensus Seeking][] decision-making model.
+The TC follows a [Consensus Seeking][] decision-making model.
 
 When an agenda item has appeared to reach a consensus the moderator
 will ask "Does anyone object?" as a final call for dissent from the
 consensus.
 
-If an agenda item cannot reach a consensus a WG member can call for
+If an agenda item cannot reach a consensus a TC member can call for
 either a closing vote or a vote to table the issue to the next
-meeting. The call for a vote must be seconded by a majority of the WG
+meeting. The call for a vote must be seconded by a majority of the TC
 or else the discussion will continue. Simple majority wins.
 
-Note that changes to WG membership require consensus. If there are any
+Note that changes to TC membership require consensus. If there are any
 objections to adding or removing individual members, an effort must be
 made to resolve those objections. If consensus cannot be reached, a
 vote may be called following the process above.
 
-### Developer's Certificate of Origin 1.0
+## Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
 * (a) The contribution was created in whole or in part by me and I
-  have the right to submit it under the open source license indicated
-  in the file; or
+  have the right to submit it under the open source license
+  indicated in the file; or
+
 * (b) The contribution is based upon previous work that, to the best
-  of my knowledge, is covered under an appropriate open source license
-  and I have the right under that license to submit that work with
-  modifications, whether created in whole or in part by me, under the
-  same open source license (unless I am permitted to submit under a
-  different license), as indicated in the file; or
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
 * (c) The contribution was provided directly to me by some other
-  person who certified (a), (b) or (c) and I have not modified it.
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: ./README.md#current-project-team-members

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
-## Express Working Group Governance
+# Express Governance
 
-### Collaborators
+## Collaborators
 
 The expressjs/express GitHub repository is maintained by the Express TC and 
 additional Collaborators who are added by the TC on an ongoing basis.
@@ -34,7 +34,7 @@ final arbiter where required.
 
 For the current list of Collaborators, see the project [README.md][].
 
-### TC Membership
+## TC Membership
 
 TC seats are not time-limited.  There is no fixed size of the TC.
 However, the expected target is between 6 and 12, to ensure adequate
@@ -70,7 +70,7 @@ situation where more than 1/3 of the TC membership shares an employer, then the
 situation must be immediately remedied by the resignation or removal of one or
 more TC members affiliated with the over-represented employer(s).
 
-### TC Meetings
+## TC Meetings
 
 The TC meets bi-weekly using Google Hangouts on Air or similar tool that allows
 public viewing or participation. A designated moderator approved by the TC runs
@@ -102,7 +102,7 @@ participate in a non-voting capacity.
 The moderator is responsible for summarizing the discussion of each
 agenda item and sends it as a pull request after the meeting.
 
-### Consensus Seeking Process
+## Consensus Seeking Process
 
 The TC follows a [Consensus Seeking][] decision-making model.
 

--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,7 @@
 Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
 Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) Express contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,0 +1,5 @@
+### Express WG Moderation Policy
+
+The [Node.js Moderation Policy] applies to this WG.
+
+[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,4 +1,4 @@
-### Express WG Moderation Policy
+# Express WG Moderation Policy
 
 The [Node.js Moderation Policy] applies to this WG.
 

--- a/Readme.md
+++ b/Readme.md
@@ -136,7 +136,7 @@ $ npm test
 
 * [TJ Holowaychuk](https://github.com/tj)
 * [Douglas Christopher Wilson](https://github.com/dougwilson)
-* [List of all contributors](https://github.com/strongloop/express/graphs/contributors)
+* [List of all contributors](https://github.com/expressjs/express/graphs/contributors)
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,10 @@ app.get('/', function (req, res) {
 app.listen(3000)
 ```
 
+The Express project is supported by the [Node.js Foundation][foundation].
+Contributions, policies and releases are managed under an 
+[open governance model][]. We are also bound by a [Code of Conduct][].
+
 ## Installation
 
 ```bash
@@ -114,18 +118,33 @@ $ npm install
 $ npm test
 ```
 
-## People
+## Current Project Team Members
 
-The original author of Express is [TJ Holowaychuk](https://github.com/tj) [![TJ's Gratipay][gratipay-image-visionmedia]][gratipay-url-visionmedia]
+### Technical Committee
 
-The current lead maintainer is [Douglas Christopher Wilson](https://github.com/dougwilson) [![Doug's Gratipay][gratipay-image-dougwilson]][gratipay-url-dougwilson]
+* (TODO: Complete members list)
 
-[List of all contributors](https://github.com/expressjs/express/graphs/contributors)
+### Collaborators
+
+* (TODO: Complete collaborators list)
+
+### Release Team
+
+* (TODO: Complete release team members list)
+
+### Original author, lead maintainer(s), other contributors
+
+* [TJ Holowaychuk](https://github.com/tj)
+* [Douglas Christopher Wilson](https://github.com/dougwilson)
+* [List of all contributors](https://github.com/strongloop/express/graphs/contributors)
 
 ## License
 
   [MIT](LICENSE)
 
+[Node.js Foundation]: https://nodejs.org/foundation
+[open governance model]: GOVERNANCE.md
+[Code of Conduct]: CODE_OF_CONDUCT.md
 [npm-image]: https://img.shields.io/npm/v/express.svg
 [npm-url]: https://npmjs.org/package/express
 [downloads-image]: https://img.shields.io/npm/dm/express.svg


### PR DESCRIPTION
Per the proposal to add express to the Node.js Foundation incubator (https://github.com/nodejs/TSC/pull/39) an Express WG under the Node.js TSC would be chartered to oversee the nodejs/express github repository. Per the TSC guidelines, every WG needs a minimum set of governance policies in place that describe how the WG will operate. This adds an initial draft that is based directly on the base policy templates provided by the TSC. 
