### PR TITLE
Feature request that makes anything runnable

### DIFF
--- a/examples/runnable/README.md
+++ b/examples/runnable/README.md
@@ -1,0 +1,17 @@
+# Make everything runnable
+
+### Example 1
+```bash
+node index.js
+```
+
+### Example 2
+```bash
+node middlewares/api.js
+```
+
+### Example 3
+```bash
+EXPRESS_PORT=3001 EXPRESS_HOSTNAME=localhost node middlewares/api.js
+EXPRESS_PATH=/var/tmp/http.sock node index.js
+```

--- a/examples/runnable/index.js
+++ b/examples/runnable/index.js
@@ -1,0 +1,17 @@
+var express = require('../../');
+var api = require('./middlewares/api');
+
+module.exports = exports = express();
+
+exports.use('/api', api);
+
+exports.get('/', function(req, res) {
+  res.send('Homepage');
+});
+
+exports.runnable(8000, 'localhost', function(error) {
+  if (error) {
+    return console.error(error);
+  }
+  console.log('Running!');
+});

--- a/examples/runnable/middlewares/api.js
+++ b/examples/runnable/middlewares/api.js
@@ -1,0 +1,9 @@
+var express = require('../../../');
+
+module.exports = exports = express();
+
+exports.get('/', function(req, res) {
+  res.send('Api');
+});
+
+exports.runnable();

--- a/lib/application.js
+++ b/lib/application.js
@@ -27,6 +27,7 @@ var compileTrust = require('./utils').compileTrust;
 var deprecate = require('depd')('express');
 var flatten = require('array-flatten');
 var merge = require('utils-merge');
+var callsite = require('callsite');
 var resolve = require('path').resolve;
 var slice = Array.prototype.slice;
 
@@ -615,6 +616,49 @@ app.render = function render(name, options, callback) {
 app.listen = function listen() {
   var server = http.createServer(this);
   return server.listen.apply(server, arguments);
+};
+
+/**
+ * Listen for connection but only if express parent
+ * module is the first required file. This is good
+ * for microservices. So you be able to run any
+ * middleware as a service.
+ *
+ * @see app.listen()
+ * @return {Server} for chaining
+ * @public
+ */
+app.runnable = function runnable() {
+  var stack = callsite();
+  var env = process.env;
+  var callback;
+  var args;
+
+  if (stack[1].getFileName() === require.main.filename) {
+    args = slice.call(arguments);
+
+    callback = typeof args[args.length - 1] === 'function' ? args.pop() : function(error) {
+      var location;
+      if (error) {
+        return console.error('Failed to start express server:', error.message);
+      }
+      location = this.address();
+      console.log('Express server started at ' + location.address + ':' + location.port);
+    };
+
+    if (env.EXPRESS_PATH) {
+      args = [env.EXPRESS_PATH];
+    } else if(env.EXPRESS_PORT || env.EXPRESS_HOSTNAME || env.EXPRESS_BACKLOG) {
+      args = [env.EXPRESS_PORT || args[0], env.EXPRESS_HOSTNAME || args[1], env.EXPRESS_BACKLOG || args[2]];
+    } else if (!args.length) {
+      // Default express port
+      args = [3000];
+    }
+
+    this.listen.apply(this, args.concat(callback));
+  }
+
+  return this;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "accepts": "~1.2.12",
     "array-flatten": "1.1.1",
+    "callsite": "^1.0.0",
     "content-disposition": "0.5.1",
     "content-type": "~1.0.1",
     "cookie": "0.1.5",


### PR DESCRIPTION
This is a draft for a new method that I call `app.runnable()`. It's almost works the same as `app.listen()` but it will only start the server if the current file is the `require.main`.

I always create my middlewares as express instances instead of just `module.exports = function(req, res, next) {};`. I also add this snippet in the bottom section of all my middlewares:

``` js
var app = require('express')();
// ...
if (require.main === module) {
  app.listen(3000);
}
```

I really like this pattern because it's easy to run any middleware as a service with just `node middlewares/something.js`. If you add some environment variables then it's really easy to scale a specific area of your application as well.

I haven't written any tests because I want to feedback from you guys what you think about this feature before I will write them.

**Examples**

_Example 1_

``` bash
node index.js
```

_Example 2_

``` bash
node middlewares/api.js
```

_Example 3_

``` bash
EXPRESS_PORT=3001 EXPRESS_HOSTNAME=localhost node middlewares/api.js
EXPRESS_PATH=/var/tmp/http.sock node index.js
```
