### PR TITLE
Add releases.md

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -13,9 +13,9 @@ must have the following access permissions:
 ### 1. Github release access
 
 The individual making the release will need to be a member of the
-expressjs/express team with Write or Admin permission level so they are
-able to tag the release commit and push changes to the expressjs/express
-repository (see Steps 4 and 5).
+expressjs/express team with Write permission level so they are able to tag the
+release commit and push changes to the expressjs/express repository
+(see Steps 4 and 5).
 
 [tunniclm: Is there  a separate way to indicate whether an individual is allowed
            to tag a release, or some higher level of permission?]

--- a/releases.md
+++ b/releases.md
@@ -46,53 +46,63 @@ Before publishing, the following preconditions should be met:
 
 There are two main release flows: patch and non-patch.
 
-The patch flow is for making **patch releases** of the **current version of
-Express**. As per semantic versioning, patch releases are for simple changes,
+The patch flow is for making **patch releases**.
+As per semantic versioning, patch releases are for simple changes,
 eg: typo fixes, patch dependency updates, and simple/low-risk bug fixes.
 Every other type of change is made via the non-patch flow.
 
-### Patch flow
+### Branch terminology
 
-In the patch flow, simple changes are committed to the `master` branch which
-acts as an ever-present branch for the next patch release of the current major
-version of Express.
-
-"Main development branch"
-- For the current major version of Express there is a branch in git named
+"Master branch"
+- There is a branch in git used for the current major version of Express, named
   `master`.
 - This branch contains the completed commits for the next patch release of the
   current major version.
-- Patch releases for the current major version are published from this branch.
+- Releases for the current major version are published from this branch.
 
-`master` is usually kept in a state where it is ready to release. Releases are
-made when sufficient time or change has been made to warrant it. This is usually
-proposed and decided using a github issue.
+"Version branch"
+- For any given major version of Express (current, previous or next) there is
+  a branch in git for that release named `<major-version>.x` (eg: `4.x`).
+- This branch contains the completed commits for the next patch release of the
+  associated major version. [ What about the current version? ]
+- Releases are published from these branches, except for the current major
+  branch mean for the current version? Since `master` is used for releases etc.
+  Is it just a placeholder? How up-to-date should it be?]
+  release of Express, which uses `master` instead. [What does the release
+
+"Release branch"
+- For any given major version of Express, there is a branch used for publishing
+  releases.
+- For the current major version of Express, the release branch is the
+  "Master branch" named `master`.
+- For all other major versions of Express, the release branch is the
+  "Version branch" named `<major-version>.x`.
+
+"Proposal branch"
+- A branch in git representing a proposed new release of Express. This can be a
+  minor or major release, named `<major-version>.0` for a major release,
+  `<major-version>.<minor-version>` for a minor release.
+- A tracking pull request should exist to document the proposed release,
+  targeted at the appropriate release branch. Prior to opening the tracking
+  pull request the content of the release may have be discussed in an issue.
+- This branch contains the commits accepted so far that implement the proposal
+  in the tracking pull request.
+
+### Patch flow
+
+In the patch flow, simple changes are committed to the release branch which
+acts as an ever-present branch for the next patch release of the associated
+major version of Express.
+
+The release branch is usually kept in a state where it is ready to release.
+Releases are made when sufficient time or change has been made to warrant it.
+This is usually proposed and decided using a github issue.
 
 ### Non-patch flow
 
 In the non-patch flow, changes are committed to a temporary proposal branch
 created specifically for that release proposal. The branch is based on the
 most recent release of the major version of Express that the release targets.
-
-"Release branch"
-- For any given major version of Express (current, previous or next) there is
-  a branch in git for that release named `<major-version>.x` (eg: `4.x`).
-- This branch contains the code from the most recently published minor or
-  patch version of the release.
-- Releases are published from these branches.
-  [Not true presently, since releases are published from master for current
-   version. Maybe it should be true though, since 4.x is out of date]
-
-"Proposal branch"
-- A branch in git representing a proposed new release of Express. This can be a
-  patch, minor or major release, named `<major-version>.0` for a major release,
-  `<major-version>.<minor-version>` for a minor release, or `<major-version>.<minor-version>.<patch-version>` for a patch release.
-- A tracking pull request should exist to document the proposed release,
-  targeted at the appropriate release branch. Prior to opening the tracking
-  pull request the content of the release may have be discussed in an issue.
-  [ These may be skipped for a patch release of the current major version ]
-- This branch contains the commits accepted so far that implement the proposal
-  in the tracking pull request.
 
 Releases are made when all the changes on a proposal branch are complete and
 approved. This is done by merging the proposal branch into the release branch
@@ -120,7 +130,7 @@ $ git checkout <release-branch>
 $ git merge --ff-only <proposal-branch>
 ```
 
-<release-branch> - see "Release branch" of "Non-patch flow" above.
+<release-branch> - see "Release branch" of "Branches" above.
 <proposal-branch> - see "Proposal branch" of "Non-patch flow" above.
 
 **NOTE:** You may need to rebase the proposal branch to allow a fast-forward
@@ -149,14 +159,11 @@ the new release version (eg: `4.13.3`).
 
 In a local clone of expressjs/express:
 ```shell
-git checkout <branch>
+git checkout <release-branch>
 <..edit files..>
 git add History.md package.json
 git commit -m '<version-number>'
 ```
-
-In the patch flow: <branch> = `master`
-In the non-patch flow: <branch> = <release-branch>
 
 ### Step 4. Identify and tag the release commit with the new release version
 
@@ -175,7 +182,7 @@ The branch and tag should be pushed directly to the main repository
 
 Following directly from Step 4:
 ```shell
-git push origin <branch>
+git push origin <release-branch>
 git push origin <version-number>
 ```
 

--- a/releases.md
+++ b/releases.md
@@ -77,7 +77,7 @@ most recent release of the major version of Express that the release targets.
 
 "Release branch"
 - For any given major version of Express (current, previous or next) there is
-  a branch in git for that release named ``<major-version>.x` (eg: `4.x`).
+  a branch in git for that release named `<major-version>.x` (eg: `4.x`).
 - This branch contains the code from the most recently published minor or
   patch version of the release.
 - Releases are published from these branches.

--- a/releases.md
+++ b/releases.md
@@ -39,7 +39,6 @@ Before publishing, the following preconditions should be met:
   - the type of release: patch, minor or major
   - the version number (according to semantic versioning - http://semver.org)
 - The proposed changes should be complete.
-[Link to document for more info on proposing a release etc]
 [Add "For more information..." link here to another document (contributor
  guide?), for more detailed information about the general
  development/contribution process works? Perhaps move some of this detail there

--- a/releases.md
+++ b/releases.md
@@ -12,44 +12,127 @@ must have the following access permissions:
 
 ### 1. Github release access
 
-The individual making the release will need to be a member of the 
-expressjs/express team with Write or Admin permission level so they are 
-able to tag the release commit (see Step 4).
+The individual making the release will need to be a member of the
+expressjs/express team with Write or Admin permission level so they are
+able to tag the release commit and push changes to the expressjs/express
+repository (see Steps 4 and 5).
 
 [tunniclm: Is there  a separate way to indicate whether an individual is allowed
            to tag a release, or some higher level of permission?]
 
-### 2. npmjs.com release accesss
+### 2. npmjs.com release access
 
-The individual making the release will need to be a member of the expressjs 
-organisation on npmjs.com so they are able to publish the release package 
+The individual making the release will need to be a member of the expressjs
+organisation on npmjs.com so they are able to publish the release package
 (see Step 6).
 
-## How to create a release
+## When to publish a release
 
-### 1. Check all the code and doc changes are in
+[Link to another document here?]
 
-Check the milestone and labels for the release in github, depending on the
-express major version (eg: 4 vs 5) to ensure all the code, tests and
-documentation updates are complete.
+## How to publish a release
 
-### 2. Update the History.md and package.json to the new version number
+Before publishing, the following preconditions should be met:
+- A release proposal issue or tracking pull request (see "Proposal branch"
+  below) will exist documenting:
+  - the proposed changes
+  - the type of release: patch, minor or major
+  - the version number (according to semantic versioning - http://semver.org)
+- The proposed changes should be complete.
+[Link to document for more info on proposing a release etc]
+[Add "For more information..." link here to another document (contributor
+ guide?), for more detailed information about the general
+ development/contribution process works? Perhaps move some of this detail there
+ as well?]
 
-The new release version number is determined by semver and whether the code
-for the release includes any semver-minor or semver-major changes.
-[tunniclm: link to or explain the semver rules here? Or the semver command-line
-           tool?]
+There are two main release flows: patch and non-patch.
 
-The branch to use depends on the major version to be released:
+The patch flow is for making **patch releases** of the **current version of
+Express**. As per semantic versioning, patch releases are for simple changes,
+eg: typo fixes, patch dependency updates, and simple/low-risk bug fixes.
+Every other type of change is made via the non-patch flow.
 
- Major version | Branch
----------------|--------
-           4.x | master [tunniclm: how does the 4.x branch get updated?]
-           5.x | 5.0    [tunniclm: is this correct?]
+### Patch flow
+
+In the patch flow, simple changes are committed to the `master` branch which
+acts as an ever-present branch for the next patch release of the current major
+version of Express.
+
+"Main development branch"
+- For the current major version of Express there is a branch in git named
+  `master`.
+- This branch contains the completed commits for the next patch release of the
+  current major version.
+- Patch releases for the current major version are published from this branch.
+
+`master` is usually kept in a state where it is ready to release. Releases are
+made when sufficient time or change has been made to warrant it. This is usually
+proposed and decided using a github issue.
+
+### Non-patch flow
+
+In the non-patch flow, changes are committed to a temporary proposal branch
+created specifically for that release proposal. The branch is based on the
+most recent release of the major version of Express that the release targets.
+
+"Release branch"
+- For any given major version of Express (current, previous or next) there is
+  a branch in git for that release named ``<major-version>.x` (eg: `4.x`).
+- This branch contains the code from the most recently published minor or
+  patch version of the release.
+- Releases are published from these branches.
+  [Not true presently, since releases are published from master for current
+   version. Maybe it should be true though, since 4.x is out of date]
+
+"Proposal branch"
+- A branch in git representing a proposed new release of Express. This can be a
+  patch, minor or major release, named `<major-version>.0` for a major release,
+  `<major-version>.<minor-version>` for a minor release, or `<major-version>.<minor-version>.<patch-version>` for a patch release.
+- A tracking pull request should exist to document the proposed release,
+  targeted at the appropriate release branch. Prior to opening the tracking
+  pull request the content of the release may have be discussed in an issue.
+  [ These may be skipped for a patch release of the current major version ]
+- This branch contains the commits accepted so far that implement the proposal
+  in the tracking pull request.
+
+Releases are made when all the changes on a proposal branch are complete and
+approved. This is done by merging the proposal branch into the release branch
+(using a fast-forward merge), tagging it with the new version number and
+publishing the release package to npmjs.com.
+
+### Flow
+
+Below is a detailed description of the steps to publish a release.
+
+#### Step 1. Check the release is ready to publish
+
+Check any relevant information to ensure the release is ready, eg: any
+milestone, label, issue or tracking pull request for the release. The release
+is ready when all proposed code, tests and documentation updates are complete
+(either merged, closed or re-targeted to another release).
+
+#### Step 2. (Non-patch flow only) Merge the proposal branch into the release branch
+
+In the patch flow: skip this step.
+
+In the non-patch flow:
+```sh
+$ git checkout <release-branch>
+$ git merge --ff-only <proposal-branch>
+```
+
+<release-branch> - see "Release branch" of "Non-patch flow" above.
+<proposal-branch> - see "Proposal branch" of "Non-patch flow" above.
+
+**NOTE:** You may need to rebase the proposal branch to allow a fast-forward
+          merge. Using a fast-forward merge keeps the history clean as it does
+          not introduce merge commits.
+
+### Step 3. Update the History.md and package.json to the new version number
 
 The changes so far for the release should already be documented under the
-"unreleased" section at the top of the History.md file on the release branch,
-as per the usual development practice.
+"unreleased" section at the top of the History.md file, as per the usual
+development practice.
 Change "unreleased" to the new release version / date.
 Example diff fragment:
 ```diff
@@ -65,45 +148,48 @@ the previous release. Change it to the new release version.
 Commit these changes together under a single commit with the message set to
 the new release version (eg: `4.13.3`).
 
-Example (in a local clone of expressjs/express):
+In a local clone of expressjs/express:
 ```shell
-git checkout master
+git checkout <branch>
 <..edit files..>
 git add History.md package.json
-git commit -m '4.13.3'
+git commit -m '<version-number>'
 ```
 
-As per the usual development practice, the commit should follow directly from
-the release branch with no merge commit.
+In the patch flow: <branch> = `master`
+In the non-patch flow: <branch> = <release-branch>
 
-### 4. Identify and tag the release commit with the new release version
+### Step 4. Identify and tag the release commit with the new release version
 
 Create a lightweight tag (rather than an annotated tag) named after the new
 release version (eg: `4.13.3`).
 
-Example:
+Following directly from Step 3:
 ```shell
-git tag 4.13.3
+git tag <version-number>
 ```
 
-### 5. Push the release branch changes and tag to github
+### Step 5. Push the release branch changes and tag to github
 
-The commit should be pushed directly to the main repository
+The branch and tag should be pushed directly to the main repository
 (https://github.com/expressjs/express).
 
-Example:
+Following directly from Step 4:
 ```shell
-git push origin master
-git push origin 4.13.3
+git push origin <branch>
+git push origin <version-number>
 ```
 
-### 6. Publish to npmjs.com
+### Step 6. Publish to npmjs.com
 
 Ensure your local working copy is completely clean (no extra or changed files).
 You can use `git status` for this purpose.
 
-Example:
+Following directly from Step 5:
 ```shell
-npm login tunniclm
+npm login <npm-username>
 npm publish
 ```
+
+**NOTE:** The version number to publish will be picked up automatically from
+          package.json.

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,106 @@
+# Express Release Process
+
+This document contains the technical aspects of the Express release process. The
+intended audience is those who have been authorized by the Express Technical
+Committee (TC) to create, promote and sign official release builds for Express,
+as npm packages hosted on https://npmjs.com/package/express.
+
+## Who can make releases?
+
+Release authorization is given by the Express TC. Once authorized, an individual
+must have the following:
+
+### 1. Github release access
+
+Releases can be tagged by members of the @expressjs/express team with Write or
+Admin permission level.
+[tunniclm: Is there  a separate way to indicate whether an individual is allowed
+           to tag a release, or some higher level of permission?]
+
+### 2. npmjs.com release accesss
+
+Releases can be published to npmjs.com by members of the npmjs.com express
+organisation.
+
+## How to create a release
+
+### 1. Check all the code and doc changes are in
+
+Check the milestone and labels for the release in github, depending on the
+express major version (eg: 4 vs 5) to ensure all the code, tests and
+documentation updates are complete.
+
+### 2. Update the History.md and package.json to the new version number
+
+The new release version number is determined by semver and whether the code
+for the release includes any semver-minor or semver-major changes.
+[tunniclm: link to or explain the semver rules here? Or the semver command-line
+           tool?]
+
+The branch to use depends on the major version to be released:
+
+ Major version | Branch
+---------------|--------
+           4.x | master [tunniclm: how does the 4.x branch get updated?]
+           5.x | 5.0    [tunniclm: is this correct?]
+
+The changes so far for the release should already be documented under the
+"unreleased" section at the top of the History.md file on the release branch,
+as per the usual development practice.
+Change "unreleased" to the new release version / date.
+Example diff fragment:
+```diff
+-unreleased
+-==========
++4.13.3 / 2015-08-02
++===================
+```
+
+The version property in the package.json should already contain the version of
+the previous release. Change it to the new release version.
+
+Commit these changes together under a single commit with the message set to
+the new release version (eg: `4.13.3`).
+
+Example (in a local clone of expressjs/express):
+```shell
+git checkout master
+<..edit files..>
+git add History.md package.json
+git commit -m '4.13.3'
+```
+
+As per the usual development practice, the commit should follow directly from
+the release branch with no merge commit.
+
+### 4. Identify and tag the release commit with the new release version
+
+Create a lightweight tag (rather than an annotated tag) named after the new
+release version (eg: `4.13.3`).
+
+Example:
+```shell
+git tag 4.13.3
+```
+
+### 5. Push the release branch changes and tag to github
+
+The commit should be pushed directly to the main repository
+(https://github.com/expressjs/express).
+
+Example:
+```shell
+git push origin master
+git push origin 4.13.3
+```
+
+### 6. Publish to npmjs.com
+
+Ensure your local working copy is completely clean (no extra or changed files).
+You can use `git status` for this purpose.
+
+Example:
+```shell
+npm login tunniclm
+npm publish
+```

--- a/releases.md
+++ b/releases.md
@@ -22,8 +22,8 @@ release commit and push changes to the expressjs/express repository
 
 ### 2. npmjs.com release access
 
-The individual making the release will need to be a member of the expressjs
-organisation on npmjs.com so they are able to publish the release package
+The individual making the release will need to be a collaborator on the
+`express` package on npmjs.com so they are able to publish the release
 (see Step 6).
 
 ## When to publish a release

--- a/releases.md
+++ b/releases.md
@@ -8,19 +8,22 @@ as npm packages hosted on https://npmjs.com/package/express.
 ## Who can make releases?
 
 Release authorization is given by the Express TC. Once authorized, an individual
-must have the following:
+must have the following access permissions:
 
 ### 1. Github release access
 
-Releases can be tagged by members of the @expressjs/express team with Write or
-Admin permission level.
+The individual making the release will need to be a member of the 
+expressjs/express team with Write or Admin permission level so they are 
+able to tag the release commit (see Step 4).
+
 [tunniclm: Is there  a separate way to indicate whether an individual is allowed
            to tag a release, or some higher level of permission?]
 
 ### 2. npmjs.com release accesss
 
-Releases can be published to npmjs.com by members of the npmjs.com express
-organisation.
+The individual making the release will need to be a member of the expressjs 
+organisation on npmjs.com so they are able to publish the release package 
+(see Step 6).
 
 ## How to create a release
 


### PR DESCRIPTION
To get things started on #2857 I have drafted up a releases document based loosely on https://github.com/nodejs/node/blob/master/doc/releases.md.

Since I have never created a release I have made guesses about the access and steps that would be involved. I have mentioned the Express TC in there, since the repository has now moved to expressjs and the project has moved/is in the proces of moving to the Node.js foundation. I've also added some questions inline inside `[]`s.

I'd appreciate any comments on this and would be happy to rework it as needed. Thanks!
