### PR TITLE
Express Issue-2893

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -172,8 +172,11 @@ res.send = function send(body) {
       encoding = undefined;
     }
 
-    len = chunk.length;
-    this.set('Content-Length', len);
+
+    if (this.getHeader('transfer-encoding') !== 'chunked') {
+      len = chunk.length;
+      this.set('Content-Length', len);
+    }
   }
 
   // populate ETag

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -178,6 +178,38 @@ describe('res', function(){
       .expect('Content-Type', 'text/plain; charset=iso-8859-1')
       .expect(200, 'hi', done);
     })
+
+    it('should set content-length', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(new Buffer('hi'));
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Length', '2')
+      .expect(200, 'hi', done);
+    })
+
+    it('should not set content-length', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Transfer-Encoding', 'chunked').send(new Buffer('hi'));
+      });
+
+      request(app)
+      .get('/')
+      .expect(function (res) {
+        if (!res.headers['content-length']) {
+          return false;
+        }
+        return true;
+      })
+      .expect('Transfer-Encoding', 'chunked')
+      .expect(200, 'hi', done);
+    })
   })
 
   describe('.send(Buffer)', function(){


### PR DESCRIPTION
Added a logical check in express response send to keep from setting the content-length header when the transfer encoding is set to chunked.
