### PR TITLE
Optimize `JSON.stringify` performance in V8.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -239,7 +239,12 @@ res.json = function json(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body;
+  if (replacer || spaces) {
+    body = JSON.stringify(val, replacer, spaces);
+  } else {
+    body = JSON.stringify(val);
+  }
 
   // content-type
   if (!this.get('Content-Type')) {
@@ -281,7 +286,12 @@ res.jsonp = function jsonp(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body;
+  if (replacer || spaces) {
+    body = JSON.stringify(val, replacer, spaces);
+  } else {
+    body = JSON.stringify(val);
+  }
   var callback = this.req.query[app.get('jsonp callback name')];
 
   // content-type


### PR DESCRIPTION
Older versions of V8 have a bug [1](https://bugs.chromium.org/p/v8/issues/detail?id=4730) where using empty `replacer` or
`space` arguments decreases performance.
