### PR TITLE
Exposing session variables to template.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -532,7 +532,6 @@ app.render = function render(name, options, callback) {
   var done = callback;
   var engines = this.engines;
   var opts = options;
-  var renderOptions = {};
   var view;
 
   // support callback function as second arg
@@ -541,8 +540,20 @@ app.render = function render(name, options, callback) {
     opts = {};
   }
 
+  var renderOptions = {
+    _application: this.locals || {},
+    _session: opts._session || {},
+    _request: opts._locals || {},
+    _template: opts || {}
+  };
+
   // merge app.locals
   merge(renderOptions, this.locals);
+
+  //merge options._session
+  if (opts._session) {
+    merge(renderOptions, opts._session);
+  }
 
   // merge options._locals
   if (opts._locals) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -948,6 +948,9 @@ res.render = function render(view, options, callback) {
     opts = {};
   }
 
+  // merge res.session
+  opts._session = self.req.session;
+
   // merge res.locals
   opts._locals = self.locals;
 

--- a/test/fixtures/scope.tmpl
+++ b/test/fixtures/scope.tmpl
@@ -1,0 +1,1 @@
+<p>$count,$_application.count,$_session.count,$_request.count,$_template.count</p>

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -211,6 +211,21 @@ describe('res', function(){
       .expect('<p>tobi</p>', done);
     })
 
+    it('should expose req.session', function(done){
+      var app = createApp();
+
+      app.set('views', __dirname + '/fixtures');
+
+      app.use(function(req, res){
+        req.session = { user: { name: 'tobi' } };
+        res.render('user.tmpl');
+      });
+
+      request(app)
+      .get('/')
+      .expect('<p>tobi</p>', done);
+    })
+
     it('should expose res.locals', function(done){
       var app = createApp();
 
@@ -224,6 +239,38 @@ describe('res', function(){
       request(app)
       .get('/')
       .expect('<p>tobi</p>', done);
+    })
+
+    it('should give precedence to req.session over app.locals', function(done){
+      var app = createApp();
+
+      app.set('views', __dirname + '/fixtures');
+      app.locals.user = { name: 'tobi' };
+
+      app.use(function(req, res){
+        req.session = { user: { name: 'jane' } };
+        res.render('user.tmpl', {});
+      });
+
+      request(app)
+      .get('/')
+      .expect('<p>jane</p>', done);
+    })
+
+    it('should give precedence to res.locals over req.session', function(done){
+      var app = createApp();
+
+      app.set('views', __dirname + '/fixtures');
+
+      app.use(function(req, res){
+        req.session = { user: { name: 'tobi' } };
+        res.locals.user = { name: 'jane' };
+        res.render('user.tmpl', {});
+      });
+
+      request(app)
+      .get('/')
+      .expect('<p>jane</p>', done);
     })
 
     it('should give precedence to res.locals over app.locals', function(done){
@@ -258,6 +305,22 @@ describe('res', function(){
       .expect('<p>jane</p>', done);
     })
 
+    it('should give precedence to res.render() locals over req.session', function(done){
+      var app = createApp();
+
+      app.set('views', __dirname + '/fixtures');
+      var jane = { name: 'jane' };
+
+      app.use(function(req, res){
+        req.session = { user: { name: 'tobi' } };
+        res.render('user.tmpl', { user: jane });
+      });
+
+      request(app)
+      .get('/')
+      .expect('<p>jane</p>', done);
+    })
+
     it('should give precedence to res.render() locals over app.locals', function(done){
       var app = createApp();
 
@@ -272,6 +335,22 @@ describe('res', function(){
       request(app)
       .get('/')
       .expect('<p>jane</p>', done);
+    })
+
+    it('should make all scopes explicitly available', function(done){
+      var app = createApp();
+      app.set('views', __dirname + '/fixtures');
+      app.locals.count = 1;
+
+      app.use(function(req, res){
+        req.session = { count: 2 };
+        res.locals.count = 3;
+        res.render('scope.tmpl', { count: 4 });
+      });
+
+      request(app)
+      .get('/')
+      .expect('<p>4,1,2,3,4</p>', done);
     })
   })
 

--- a/test/support/tmpl.js
+++ b/test/support/tmpl.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 
-var variableRegExp = /\$([0-9a-zA-Z\.]+)/g;
+var variableRegExp = /\$([_0-9a-zA-Z\.]+)/g;
 
 module.exports = function renderFile(fileName, options, callback) {
   function onReadFile(err, str) {


### PR DESCRIPTION
This is a request for a change I'd like to see in Express.  It exposes session variables to the template engine.

Currently the template engine is passed a map of variables obtained by combining the variables of `app.locals`, `res.locals`, and those passed directly to `res.render`.  In the case of conflicts, variables of `res.locals` override `app.locals`, and variables passed to `res.render` override both.  The template cannot reference session variables directly; they must be explicitly copied into `res.locals` or into the map passed to `res.render`.

This change adds the properties of the `req.session` object to the variables map passed to the template engine so that they may be referenced directly by the template.  In the case of conflicts, variables of `req.session` override those of `app.locals`, but variables of `res.locals` and those passed to `res.render` override those of `app.session`.  FYI:  this is consistent with the behavior of JSP.  The idea is that `app.locals` holds global variables, `req.session` holds variables specific to the user, `res.locals` holds variables specific to the request, and variables specific to the template are passed to `res.render`.

Furthermore, all four variable maps are exposed through variables `_application` for `app.locals`, `_session` for `req.session`, `_request` for `res.locals`, and `_template` for variables passed to `res.render`.  This allows explicit name-conflict resolution (and, again, follows the behavior of JSP).

This change does not require `req.session` to exist; in the case where it doesn't, no session variables will be added to the map.  Note that all enumerable properties of the session are exposed.  In the case of express-session, this would include object methods such as `save`, `reload`, and `destroy`.  I have submitted a separate pull request to express-session that would make all such methods non-enumerable.

This change does have the potential to break existing applications in rare cases where there is a conflict between a session variable and a variable in `app.locals`.  Prior to the change the variable name would result in the value from `app.locals`, after the change it will result in the value from `req.session`.  This can be fixed in the template by explicitly referencing the desired scope (e.g., `_application.x` instead of just `x`).  However, if this is a concern, a configuration option could be used to determine whether or not session variables are exposed to the template engine.

This change uses `res.req` to access the request object via the response object in order to access the session object.  This property is not listed in the official API documentation.  If there are plans to remove that property, an alternative approach to accessing the session would be required.

Thanks.
