### PR TITLE
Adding additional template variable scopes

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -544,13 +544,13 @@ app.render = function render(name, options, callback) {
   // merge app.locals
   merge(renderOptions, this.locals);
 
-  // merge options._locals
-  if (opts._locals) {
-    merge(renderOptions, opts._locals);
-  }
-
   // merge options
-  merge(renderOptions, opts);
+  if (Array.isArray(opts)) {
+    opts.reduce(merge, renderOptions);
+  }
+  else {
+    merge(renderOptions, opts);
+  }
 
   // set .cache unless explicitly provided
   if (renderOptions.cache == null) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -949,7 +949,8 @@ res.render = function render(view, options, callback) {
   }
 
   // merge res.locals
-  opts._locals = self.locals;
+  var resVars = [self.locals || {}, opts];
+  var varStack = self.tmplVars ? self.tmplVars.concat( resVars ) : resVars;
 
   // default callback to respond
   done = done || function (err, str) {
@@ -958,8 +959,23 @@ res.render = function render(view, options, callback) {
   };
 
   // render
-  app.render(view, opts, done);
+  app.render(view, varStack, done);
 };
+
+/**
+ * Add `options` to the top of the reponse's template variables stack.
+ * Creates the stack the first time called.
+ *
+ * @public
+ */
+res.addTmplVars = function addTmplVars(options) {
+  if (this.tmplVars) {
+    this.tmplVars.push(options);
+  }
+  else {
+    this.tmplVars = [options];
+  }
+}
 
 // pipe the send file stream
 function sendfile(res, file, options, callback) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -950,7 +950,7 @@ res.render = function render(view, options, callback) {
 
   // merge res.locals
   var resVars = [self.locals || {}, opts];
-  var varStack = self.tmplVars ? self.tmplVars.concat( resVars ) : resVars;
+  var varStack = self.scopeStack ? self.scopeStack.concat(resVars) : resVars;
 
   // default callback to respond
   done = done || function (err, str) {
@@ -963,18 +963,37 @@ res.render = function render(view, options, callback) {
 };
 
 /**
- * Add `options` to the top of the reponse's template variables stack.
+ * Add `scope` to the top of the reponse's template variables stack.
  * Creates the stack the first time called.
  *
  * @public
  */
-res.addTmplVars = function addTmplVars(options) {
-  if (this.tmplVars) {
-    this.tmplVars.push(options);
+res.scope = function scope(name, scope, replace) {
+  if (!this.scopeStack) {
+    this.scopeStack = [];
+    this.scopeIndex = {};
+  }
+  if (arguments.length <= 1) {
+    if (!(name in this.scopeIndex)) {
+      this.scopeStack.push(this.scopeIndex[name] = {});
+    }
   }
   else {
-    this.tmplVars = [options];
+    if (!(name in this.scopeIndex)) {
+      this.scopeStack.push(this.scopeIndex[name] = scope);
+    }
+    else {
+      var index = this.scopeStack.indexOf(this.scopeIndex[name]);
+      if (replace) {
+        this.scopeStack[index] = this.scopeIndex[name] = scope;
+      }
+      else {
+        this.scopeStack.splice(index, 1);
+        this.scopeStack.push(this.scopeIndex[name] = scope);
+      }
+    }
   }
+  return this.scopeIndex[name];
 }
 
 // pipe the send file stream

--- a/test/fixtures/scope.tmpl
+++ b/test/fixtures/scope.tmpl
@@ -1,0 +1,1 @@
+<p>$fee, $fie, $foe, $fum</p>

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -218,7 +218,7 @@ describe('res', function(){
       app.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
-        res.addTmplVars({ user: tobi });
+        res.scope('aux', { user: tobi });
         res.render('user.tmpl');
       });
 
@@ -244,13 +244,12 @@ describe('res', function(){
 
     it('should give precedence to auxiliary variables over app.locals', function(done){
       var app = createApp();
-      var jane = { name: 'jane' };
 
       app.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.use(function(req, res){
-        res.addTmplVars({ user: jane });
+        res.scope('aux').user = { name: 'jane' };
         res.render('user.tmpl');
       });
 
@@ -261,18 +260,16 @@ describe('res', function(){
 
     it('should give precedence to later auxiliary variables over earlier ones', function(done){
       var app = createApp();
-      var tobi = { name: 'tobi' };
-      var jane = { name: 'jane' };
 
       app.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res, next){
-        res.addTmplVars({ user: tobi });
+        res.scope('aux').user = { name: 'tobi' };
         next();
       })
 
       app.use(function(req, res){
-        res.addTmplVars({ user: jane });
+        res.scope('aux2').user = { name: 'jane' };
         res.render('user.tmpl');
       });
 
@@ -283,12 +280,11 @@ describe('res', function(){
 
     it('should give precedence to res.locals over auxiliary variables', function(done){
       var app = createApp();
-      var tobi = { name: 'tobi' };
 
       app.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
-        res.addTmplVars({ user: tobi });
+        res.scope('aux').user = { name: 'tobi' };
         res.locals.user = { name: 'jane' };
         res.render('user.tmpl', {});
       });
@@ -332,13 +328,12 @@ describe('res', function(){
 
     it('should give precedence to res.render() locals over auxiliary variables', function(done){
       var app = createApp();
-      var tobi = { name: 'tobi' };
       var jane = { name: 'jane' };
 
       app.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
-        res.addTmplVars({ user: tobi });
+        res.scope('aux').user = { name: 'tobi' };
         res.render('user.tmpl', { user: jane });
       });
 
@@ -373,7 +368,7 @@ describe('res', function(){
       app.locals.fum = 1;
 
       app.use(function(req, res){
-        res.addTmplVars({ fie: 2, foe: 2, fum: 2} );
+        res.scope('aux', { fie: 2, foe: 2, fum: 2 });
         res.locals.foe = 3;
         res.locals.fum = 3;
         res.render('scope.tmpl', { fum: 4 });

--- a/test/res.scope.js
+++ b/test/res.scope.js
@@ -1,0 +1,127 @@
+
+var express = require('..');
+var request = require('supertest');
+
+describe('res', function() {
+  describe('.scope(name)', function() {
+    it('should create and retrieve scope objects', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next) {
+        res.scope('aux').foo = 'foo';
+        res.send(res.scope('aux').foo);
+      });
+
+      request(app)
+        .get('/')
+        .expect('foo', done);
+    })
+
+    it('should keep scope objects distinct', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next) {
+        res.scope('aux1').foo = 'foo';
+        next();
+      });
+
+      app.use(function(req, res, next) {
+        res.scope('aux2').bar = 'bar';
+        next();
+      });
+
+      app.use(function(req, res, next) {
+        var bits = [
+          res.scope('aux1').foo,
+          res.scope('aux1').bar,
+          res.scope('aux2').foo,
+          res.scope('aux2').bar
+        ];
+        res.send(bits.join(','));
+      });
+
+      request(app)
+        .get('/')
+        .expect('foo,,,bar', done);
+    })
+
+    it('should place scopes created later at the end of the stack', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next) {
+        res.scope('aux1').foo = 'foo';
+        res.scope('aux2').bar = 'bar';
+
+        var bits = [
+          res.scopeStack[0].foo,
+          res.scopeStack[1].bar
+        ];
+        res.send(bits.join(','));
+      });
+
+      request(app)
+        .get('/')
+        .expect('foo,bar', done);
+    })
+  })
+
+  describe('.scope(name, scope, replace)', function() {
+    it('should store and retrieve scope objects', function(done) {
+      var app = express();
+
+      var scope = {};
+
+      app.use(function(req, res, next) {
+        res.scope('aux', scope);
+        scope.foo = 'foo';
+        res.send(res.scope('aux').foo);
+      });
+
+      request(app)
+        .get('/')
+        .expect('foo', done);
+    })
+
+    it('should reorder when overwriting scopes', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next) {
+        res.scope('aux1', { foo: 'foo' });
+        res.scope('aux2', { bar: 'bar' });
+        res.scope('aux1', { foo: 'goo' });
+
+        var bits = [
+          res.scopeStack[0].bar,
+          res.scopeStack[1].foo,
+          res.scopeStack.length
+        ];
+        res.send(bits.join(','));
+      });
+
+      request(app)
+        .get('/')
+        .expect('bar,goo,2', done);
+    })
+
+    it('should keep same ordering when replacing scopes', function(done) {
+      var app = express();
+
+      app.use(function(req, res, next) {
+        res.scope('aux1', { foo: 'foo' });
+        res.scope('aux2', { bar: 'bar' });
+        res.scope('aux1', { foo: 'goo' }, true);
+
+        var bits = [
+          res.scopeStack[0].foo,
+          res.scopeStack[1].bar,
+          res.scopeStack.length
+        ];
+        res.send(bits.join(','));
+      });
+
+      request(app)
+        .get('/')
+        .expect('goo,bar,2', done);
+    })
+  })
+})


### PR DESCRIPTION
This is a follow up to #2924.  It addresses the issue of exposing session variables to template engines using a more general approach.  Note that unlike #2924, this request does not involve exposing scopes explicitly using certain names.

Each response (potentially) has a stack of template variable scopes.  Each scope is an object whose properties define the variables to be exposed.  A method was added to the response object named `addTmplVars`.  The parameter to this method is a scope to be pushed on the scope stack.  Here is an example:

``` javascript
res.addTmplVars({ name: 'gfoust', count: 3 });
```

The scope is stored directly on the scope stack.  Therefore, any changes made to that scope will be visible to the template engine.  For example, the following code listing has the same effect as the previous one.

``` javascript
var obj = {};
res.addTmplVars(obj);
obj.name = 'gfoust';
obj.count = 3;
```

When a template is rendered, the objects on the scope stack are "flattened" into a single object.  This "flattening" does not alter the scopes in any way; it merely copies their properties to a new object.  In the case of conflicts, variables from scopes higher up in the stack will replace those from scopes lower in the stack.

Prior to this "flattening", the variables of `app.locals` are effectively added to the bottom of the stack, and variables from `res.locals` are added to the top of the stack, followed by variables passed to `res.render`.  This augmented stack may be represented as follows:

variables passed to `res.render` -> `res.locals` -> scope stack (high to low) -> `app.locals`

The arrows here represent precedence:  variables from scopes on the left of the arrow will override variables from scopes on the right should a conflict occur.

The idea here is that any middleware can expose a scope to the template engine.  For example, when using express-session, it could push the session object onto the scope stack, allowing session variables to be directly accessed by the template.  Should multiple middlewares push scopes to the stack, the order in which they execute will define precedence.

I used the `tmplVars` property of the response object to hold the scope stack.  I would expect this to be considered a private variable.  The property is not created until the first time `addTmplVars` is called.
