### PR TITLE
res.sendFile: inherit etag setting from app

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -63,7 +63,7 @@ app.init = function init() {
   Object.defineProperty(this, 'router', {
     configurable: true,
     enumerable: true,
-    get: function getrouter() {
+    get: function getRouter() {
       if (router === null) {
         router = new Router({
           caseSensitive: this.enabled('case sensitive routing'),
@@ -100,7 +100,7 @@ app.defaultConfiguration = function defaultConfiguration() {
 
   debug('booting in %s mode', env);
 
-  this.on('mount', function onmount(parent) {
+  this.on('mount', function onMount(parent) {
     // inherit trust proxy
     if (this.settings[trustProxyDefaultSymbol] === true
       && typeof parent.settings['trust proxy fn'] === 'function') {

--- a/lib/application.js
+++ b/lib/application.js
@@ -63,7 +63,7 @@ app.init = function init() {
   Object.defineProperty(this, 'router', {
     configurable: true,
     enumerable: true,
-    get: function getRouter() {
+    get: function getrouter() {
       if (router === null) {
         router = new Router({
           caseSensitive: this.enabled('case sensitive routing'),
@@ -100,7 +100,7 @@ app.defaultConfiguration = function defaultConfiguration() {
 
   debug('booting in %s mode', env);
 
-  this.on('mount', function onMount(parent) {
+  this.on('mount', function onmount(parent) {
     // inherit trust proxy
     if (this.settings[trustProxyDefaultSymbol] === true
       && typeof parent.settings['trust proxy fn'] === 'function') {

--- a/lib/response.js
+++ b/lib/response.js
@@ -370,8 +370,8 @@ res.sendFile = function sendFile(path, options, callback) {
     opts = {};
   }
   
-  if(typeof opts.etag == 'undefined') {
-      opts.etag = app.set('etag');
+  if (typeof opts.etag === 'undefined') {
+    opts.etag = Boolean(app.set('etag'));
   }
 
   if (!opts.root && !pathIsAbsolute(path)) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -353,6 +353,7 @@ res.sendStatus = function sendStatus(statusCode) {
  */
 
 res.sendFile = function sendFile(path, options, callback) {
+  var app = this.app;
   var done = callback;
   var req = this.req;
   var res = this;
@@ -367,6 +368,10 @@ res.sendFile = function sendFile(path, options, callback) {
   if (typeof options === 'function') {
     done = options;
     opts = {};
+  }
+  
+  if(! ('etag' in opts) ) {
+      opts.etag = app.set('etag');
   }
 
   if (!opts.root && !pathIsAbsolute(path)) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -358,6 +358,9 @@ res.sendFile = function sendFile(path, options, callback) {
   var res = this;
   var next = req.next;
   var opts = options || {};
+  
+  // settings
+  var app = this.app;
 
   if (!path) {
     throw new TypeError('path argument is required to res.sendFile');
@@ -367,6 +370,10 @@ res.sendFile = function sendFile(path, options, callback) {
   if (typeof options === 'function') {
     done = options;
     opts = {};
+  }
+  
+  if (app.settings.etag == false) {
+        opts.etag = app.settings.etag;
   }
 
   if (!opts.root && !pathIsAbsolute(path)) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -370,7 +370,7 @@ res.sendFile = function sendFile(path, options, callback) {
     opts = {};
   }
   
-  if(! ('etag' in opts) ) {
+  if(typeof opts.etag == 'undefined') {
       opts.etag = app.set('etag');
   }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -358,9 +358,6 @@ res.sendFile = function sendFile(path, options, callback) {
   var res = this;
   var next = req.next;
   var opts = options || {};
-  
-  // settings
-  var app = this.app;
 
   if (!path) {
     throw new TypeError('path argument is required to res.sendFile');
@@ -370,10 +367,6 @@ res.sendFile = function sendFile(path, options, callback) {
   if (typeof options === 'function') {
     done = options;
     opts = {};
-  }
-  
-  if (app.settings.etag == false) {
-        opts.etag = app.settings.etag;
   }
 
   if (!opts.root && !pathIsAbsolute(path)) {

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -297,12 +297,10 @@ describe('res', function(){
      
        request(app)
         .get('/')
-        .end(function(err, res) {
-            if (err) {
-                return done(err);
-            }
-            assert.equal('etag' in res.headers, false);
-            done();
+        .expect(200, function (err, res) {
+          if (err) return done(err);
+          res.headers.should.not.have.property('ETag');
+          done();
         });
     })
     

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -287,7 +287,7 @@ describe('res', function(){
       .expect(200, 'got it', done);
     })
 
-    describe('should set settings according to app settings', function () {
+    describe('when app etag is set', function () {
       it('should inherit app setting', function (done) {
         var app = express();
 

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -286,79 +286,80 @@ describe('res', function(){
       .get('/')
       .expect(200, 'got it', done);
     })
-    
-    it('should set etag according to app settings', function (done) {
-       var app = express();
-        
-       app.disable('etag');
-       app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'));
+
+    describe('should set settings according to app settings', function () {
+      it('should inherit app setting', function (done) {
+        var app = express();
+
+        app.disable('etag');
+        app.use(function (req, res) {
+          res.sendFile(path.resolve(fixtures, 'name.txt'));
         });
-     
-       request(app)
+
+        request(app)
         .get('/')
         .expect(200, function (err, res) {
           if (err) return done(err);
           res.headers.should.not.have.property('ETag');
           done();
         });
-    })
-    
-    it('should set etag according to app settings, with input args priority', function (done) {
-       var app = express();
-        
-       app.disable('etag');
-       app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'),{etag:'weak'});
-        });
-     
-       request(app)
-        .get('/')
-        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
-    })
-    
-    it('should contain etag weak', function (done) {
-       var app = express();
-        
-       app.set('etag', 'weak');
-       app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'));
-        });
-     
-       request(app)
-        .get('/')
-        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
-    })
-    
-    it('should not fail at etag custom', function (done) {
-        var app = express();
-        
-        app.set('etag', function (body, encoding) {
-            return '"custom"';
-        });
+      })
 
+      it('should input args have priority over app settings', function (done) {
+        var app = express();
+
+        app.disable('etag');
         app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'));
+          res.sendFile(path.resolve(fixtures, 'name.txt'),{etag:'weak'});
         });
 
         request(app)
+        .get('/')
+        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
+      })
+    })
+
+    it('should contain etag weak', function (done) {
+      var app = express();
+
+      app.set('etag', 'weak');
+      app.use(function (req, res) {
+        res.sendFile(path.resolve(fixtures, 'name.txt'));
+      });
+
+      request(app)
+        .get('/')
+        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
+    })
+
+    it('should not fail when generating ETag for file with custom function', function (done) {
+      var app = express();
+
+      app.set('etag', function (body, encoding) {
+        return '"custom"';
+      });
+
+      app.use(function (req, res) {
+        res.sendFile(path.resolve(fixtures, 'name.txt'));
+      });
+
+      request(app)
         .get('/')
         .expect('ETag', /^(?:W\/)"[^"]+"$/)
         .expect(200, done);
     })
     
-    it('should not fail at etag strong', function (done) {
-       var app = express();
-        
-       app.set('etag', 'strong');
-       app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'));
-        });
-     
-       request(app)
+    it('should not fail when generating ETag for file with strong', function (done) {
+      var app = express();
+
+      app.set('etag', 'strong');
+      app.use(function (req, res) {
+        res.sendFile(path.resolve(fixtures, 'name.txt'));
+      });
+
+      request(app)
         .get('/')
         .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
-
     })
   })
 })

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -332,6 +332,23 @@ describe('res', function(){
         .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
     })
     
+    it('should contain etag custom', function (done) {
+        var app = express();
+        
+        app.set('etag', function (body, encoding) {
+            return '"custom"';
+        });
+
+        app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'));
+        });
+
+        request(app)
+        .get('/')
+        .expect('ETag', '"custom"')
+        .expect(200, done);
+    })
+    
     it('should contain etag strong', function (done) {
        var app = express();
         

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -332,7 +332,7 @@ describe('res', function(){
         .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
     })
     
-    it('should contain etag custom', function (done) {
+    it('should not fail at etag custom', function (done) {
         var app = express();
         
         app.set('etag', function (body, encoding) {
@@ -345,11 +345,11 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect('ETag', '"custom"')
+        .expect('ETag', /^(?:W\/)"[^"]+"$/)
         .expect(200, done);
     })
     
-    it('should contain etag strong', function (done) {
+    it('should not fail at etag strong', function (done) {
        var app = express();
         
        app.set('etag', 'strong');
@@ -359,7 +359,7 @@ describe('res', function(){
      
        request(app)
         .get('/')
-        .expect('ETag', /^"[^"]+"$/, done);
+        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
 
     })
   })

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -93,26 +93,6 @@ describe('res', function(){
       .expect('Content-Type', 'application/x-bogus')
       .end(done);
     })
-    
-    it('should set etag according to app settings', function (done) {
-        var app = express();
-        
-        app.disable('etag');
-        app.use(function (req, res) {
-            res.sendFile(path.resolve(fixtures, 'name.txt'));
-        });
-        
-        request(app)
-        .get('/')
-        .end(function(err, res) {
-            if (err) {
-                return done(err);
-            }
-            assert.equal('etag' in res.headers, false);
-            done();
-        });
-    })
-
 
     it('should not error if the client aborts', function (done) {
       var cb = after(1, done);

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -286,6 +286,65 @@ describe('res', function(){
       .get('/')
       .expect(200, 'got it', done);
     })
+    
+    it('should set etag according to app settings', function (done) {
+       var app = express();
+        
+       app.disable('etag');
+       app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'));
+        });
+     
+       request(app)
+        .get('/')
+        .end(function(err, res) {
+            if (err) {
+                return done(err);
+            }
+            assert.equal('etag' in res.headers, false);
+            done();
+        });
+    })
+    
+    it('should set etag according to app settings, with input args priority', function (done) {
+       var app = express();
+        
+       app.disable('etag');
+       app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'),{etag:'weak'});
+        });
+     
+       request(app)
+        .get('/')
+        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
+    })
+    
+    it('should contain etag weak', function (done) {
+       var app = express();
+        
+       app.set('etag', 'weak');
+       app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'));
+        });
+     
+       request(app)
+        .get('/')
+        .expect('ETag', /^(?:W\/)"[^"]+"$/, done);
+    })
+    
+    it('should contain etag strong', function (done) {
+       var app = express();
+        
+       app.set('etag', 'strong');
+       app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'));
+        });
+     
+       request(app)
+        .get('/')
+        .expect('ETag', /^"[^"]+"$/, done);
+
+    })
   })
 })
 

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -93,6 +93,26 @@ describe('res', function(){
       .expect('Content-Type', 'application/x-bogus')
       .end(done);
     })
+    
+    it('should set etag according to app settings', function (done) {
+        var app = express();
+        
+        app.disable('etag');
+        app.use(function (req, res) {
+            res.sendFile(path.resolve(fixtures, 'name.txt'));
+        });
+        
+        request(app)
+        .get('/')
+        .end(function(err, res) {
+            if (err) {
+                return done(err);
+            }
+            assert.equal('etag' in res.headers, false);
+            done();
+        });
+    })
+
 
     it('should not error if the client aborts', function (done) {
       var cb = after(1, done);


### PR DESCRIPTION
feature mentioned in:  #2294 

If ETag is disabled in app settings, res.sendFile inherits this setting in options object
