### PR TITLE
add a public API:remove

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -128,6 +128,43 @@ proto.param = function param(name, fn) {
 };
 
 /**
+ * Add a handler for deleting route path(s) and handler(s).
+ *
+ * example:
+ * route.remove('/index.html'); //remove the path and handler
+ * route.remove(['/index.html', '/user.html']); //remove paths and handlers
+ * route.remove(); //remove this route all paths and handlers
+ *
+ * @param {function} handler
+ * @return {Route} for chaining
+ * @api public
+ */
+
+proto.remove = function remove() {
+  var path = arguments[0];
+  if (!path) { //delete all
+    this.stack = [];
+  } else if('string' === typeof path) { //delete one path/handler
+    for(var i = 0; i< this.stack.length; i++) {
+      if (this.stack[i].path === path) {
+        this.stack.splice(i, 1);
+        break;
+      }
+    }
+  } else {
+    for(var j = 0; j < path.length; j++) {
+      for(var k = this.stack.length - 1; k > -1; k--) {
+        if (path[j] === this.stack[k].path) {
+          this.stack.splice(k, 1);
+          break;
+        }
+      }
+    }
+  }
+  return this;
+};
+
+/**
  * Dispatch a req, res into the router.
  * @private
  */


### PR DESCRIPTION
When I develop a dynamic web server I find no method to  unregister route(s), so I add this API to remove path(s) and handler(s).
