### PR TITLE
Remove res.vary() (no arguments) signature

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,9 @@
 
 This incorporates all changes after 4.13.1 up to 4.14.0.
 
+  * remove:
+    - `res.vary()` (no arguments) -- provide a field name 
+
 5.0.0-alpha.2 / 2015-07-06
 ==========================
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -808,12 +808,6 @@ res.redirect = function redirect(url) {
  */
 
 res.vary = function(field){
-  // checks for back-compat
-  if (!field || (Array.isArray(field) && !field.length)) {
-    deprecate('res.vary(): Provide a field name');
-    return this;
-  }
-
   vary(this, field);
 
   return this;

--- a/test/res.vary.js
+++ b/test/res.vary.js
@@ -6,7 +6,7 @@ var utils = require('./support/utils');
 
 describe('res.vary()', function(){
   describe('with no arguments', function(){
-    it('should not set Vary', function (done) {
+    it('should error missing field and not set Vary', function (done) {
       var app = express();
 
       app.use(function (req, res) {
@@ -17,7 +17,7 @@ describe('res.vary()', function(){
       request(app)
       .get('/')
       .expect(utils.shouldNotHaveHeader('Vary'))
-      .expect(200, done);
+      .expect(500, /field.*required/, done);
     })
   })
 
@@ -33,6 +33,21 @@ describe('res.vary()', function(){
       request(app)
       .get('/')
       .expect(utils.shouldNotHaveHeader('Vary'))
+      .expect(200, done);
+    })
+
+    it('should not change Vary', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.vary('Accept');
+        res.vary([]);
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Vary', 'Accept')
       .expect(200, done);
     })
   })


### PR DESCRIPTION
Changed `res.vary()` to throw `TypeError` if no `field` argument is passed or if the value of `field` argument is an empty array. (Similar to how `res.sendFile()` deals with a missing `path` argument).
