### PR TITLE
Use mime-types instead of send.mime

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -27,8 +27,8 @@ var setCharset = require('./utils').setCharset;
 var statusCodes = http.STATUS_CODES;
 var cookie = require('cookie');
 var send = require('send');
+var mime = require('mime-types');
 var extname = path.extname;
-var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
 
@@ -443,7 +443,7 @@ res.download = function download(path, filename, callback) {
 res.contentType =
 res.type = function contentType(type) {
   var ct = type.indexOf('/') === -1
-    ? mime.lookup(type)
+    ? (mime.lookup(type) || 'application/octet-stream')
     : type;
 
   return this.set('Content-Type', ct);
@@ -609,7 +609,7 @@ res.header = function header(field, val) {
 
     // add charset to content-type
     if (field.toLowerCase() === 'content-type' && !charsetRegExp.test(value)) {
-      var charset = mime.charsets.lookup(value.split(';')[0]);
+      var charset = mime.charset(value.split(';')[0]);
       if (charset) value += '; charset=' + charset.toLowerCase();
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@
  * @api private
  */
 
-var mime = require('send').mime;
+var mime = require('mime-types');
 var contentType = require('content-type');
 var etag = require('etag');
 var flatten = require('array-flatten');

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fresh": "0.3.0",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",
+    "mime-types": "~2.1.10",
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.1",
     "path-is-absolute": "1.0.0",

--- a/test/res.type.js
+++ b/test/res.type.js
@@ -13,7 +13,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Content-Type', 'application/javascript', done);
+      .expect('Content-Type', 'application/javascript; charset=utf-8', done);
     })
 
     it('should default to application/octet-stream', function(done){


### PR DESCRIPTION
> The mime-types module has a few small differences compared
> to mime:
> - mime-types API for getting charsets is slightly different
>   to mime
> - mime-types uses mime-db which has a comprehensive list of
>   charsets for mime types, whereas mime uses a simple rule:
>   UTF-8 for any type starting 'text/' and a caller-defined
>   fallback for anything else
> - mime-types will return false if it cannot find a particular
>   mime type in mime-db, whereas mime will default to
>   'application/octet-stream' if it does't find the mime type
>   in its types.json file
> 
> This commit makes the necessary changes to address these
> differences.
> 
> The mime module to use is now populated by
> require('mime-types') rather than reaching into the send
> module with require('send').mime.
> 
> One of the tests has been updated as a result of the charset
> lookup differences in mime-types, since mime-types gives
> UTF-8 as the charset for 'application/javascript' whereas
> mime returned the caller fallback (undefined in this case.)
> From what I can tell both the resulting values are valid in
> the Content-Type header (either 'Content-Type:
> application/javascript; charset=utf=8' or 'Content-Type:
> application/javascript') so I have updated the testcase to
> test for the former instead of the latter.

---

I have added mime-types as a dependency at `~2.1.10`, let me know if that is not the version we should take.

This PR is to address the item "Use `mime-types` instead of `mime`" from the [Release 5.0](https://github.com/expressjs/express/pull/2237) checklist.
