### PR TITLE
Don't reply with Content-Length when Transfer-Encoding === 'chunked'

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -172,8 +172,10 @@ res.send = function send(body) {
       encoding = undefined;
     }
 
-    len = chunk.length;
-    this.set('Content-Length', len);
+    if (this.get('Transfer-Encoding') !== 'chunked') {
+      len = chunk.length;
+      this.set('Content-Length', len);
+    }
   }
 
   // populate ETag

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -299,6 +299,24 @@ describe('res', function(){
     })
   })
 
+  describe('when Transfer-Encoding is chunked', function() {
+    it('should strip the Content-Length field', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.status(200).set('Transfer-Encoding', 'chunked').send();
+      });
+
+      request(app)
+      .get('/')
+      .end(function(err, res){
+        res.headers.should.not.have.property('content-length');
+        res.headers.should.have.property('transfer-encoding');
+        done();
+      })
+    })
+  })
+
   it('should always check regardless of length', function(done){
     var app = express();
     var etag = '"asdf"';


### PR DESCRIPTION
According to latest changes in Node (v0.10.42, 0.12.10, 4.3.0 and 5.6.0) to comply more with HTTP 1.1, it's prohibited to apply a `Content-Length` when `Transfer-Encoding` is set to `chunked`.

See discussions such as the following about this issue: https://github.com/request/request/issues/2091
