### PR TITLE
Make router.use warn about probably unintended usage

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -458,6 +458,13 @@ proto.use = function use(fn) {
       throw new TypeError('Router.use() requires middleware function but got a ' + gettype(fn));
     }
 
+    // log a warning if the function doesn't look middleware-like
+    var argCount = fn.length;
+    if ((argCount < 2 || argCount > 3) && !process.env.DISABLE_WARNINGS) {
+      console.trace('A non-middleware-like function was passed to `.use()` – '
+      + 'this is probably unintended.');
+    }
+
     // add the middleware
     debug('use %s %s', path, fn.name || '<anonymous>');
 


### PR DESCRIPTION
This will help people avoid wasting some hours debugging.

When using `router#use`, you most likely always want to pass in a valid middleware function – with `(req, res [, next])` signature – or a router to mount on top of the path.

I've seen people waste hours because their code had bugs and they weren't passing in a random function (that didn't look like middleware, it had no arguments) and express didn't complain.

Having some kind of check / warning for this most common use of `router#use` would make the library more user friendly, and potentially save up wasted hours, frustration, and demotivation – specially for beginners and first time users.

Code is just a proof-of-concept to get a feel of the new warning behaviour. Using the following example:

``` js
var express = require('express')
var app = express()
var userRouter = express()

app.use('/hi', function (req, res, next) {})
app.use('/hi', function (req, res) {})
app.use('/hi', function () {}) // <-- random function passed in
app.get('/hi', function (req, res) {
  res.send('Hello World!')
})
app.use('/users', userRouter)

app.listen(3000, function () {
  console.log('up and running!')
})
```

The output would be:

```
➜  temp node app.js
Trace: A non-middleware-like function was passed to `.use()` – this is probably unintended.
    at Function.use (/Users/dasilvacontin/GitHub/expressjs/express/lib/router/index.js:464:15)
    at EventEmitter.<anonymous> (/Users/dasilvacontin/GitHub/expressjs/express/lib/application.js:219:21)
    at Array.forEach (native)
    at EventEmitter.use (/Users/dasilvacontin/GitHub/expressjs/express/lib/application.js:216:7)
    at Object.<anonymous> (/Users/dasilvacontin/temp/app.js:7:5)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
up and running!
```

(feel free to edit my example, I don't know conventions for using express)
