### PR TITLE
tests: use supertest to check response header values

### DIFF
--- a/test/acceptance/cookies.js
+++ b/test/acceptance/cookies.js
@@ -1,6 +1,7 @@
 
 var app = require('../../examples/cookies')
   , request = require('supertest');
+var utils = require('../support/utils');
 
 describe('cookies', function(){
   describe('GET /', function(){
@@ -13,10 +14,8 @@ describe('cookies', function(){
     it('should respond with no cookies', function(done){
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.not.have.property('set-cookie')
-        done()
-      })
+      .expect(utils.shouldNotHaveHeader('Set-Cookie'))
+      .expect(200, done)
     })
 
     it('should respond to cookie', function(done){
@@ -57,20 +56,16 @@ describe('cookies', function(){
       .post('/')
       .type('urlencoded')
       .send({ remember: 1 })
-      .expect(302, function(err, res){
-        res.headers.should.have.property('set-cookie')
-        done()
-      })
+      .expect('Set-Cookie', /remember=1/)
+      .expect(302, done)
     })
 
     it('should no set cookie w/o reminder', function(done){
       request(app)
       .post('/')
       .send({})
-      .expect(302, function(err, res){
-        res.headers.should.not.have.property('set-cookie')
-        done()
-      })
+      .expect(utils.shouldNotHaveHeader('Set-Cookie'))
+      .expect(302, done)
     })
   })
 })

--- a/test/acceptance/downloads.js
+++ b/test/acceptance/downloads.js
@@ -15,11 +15,8 @@ describe('downloads', function(){
     it('should have a download header', function(done){
       request(app)
       .get('/files/amazing.txt')
-      .end(function(err, res){
-        res.status.should.equal(200);
-        res.headers.should.have.property('content-disposition', 'attachment; filename="amazing.txt"')
-        done()
-      })
+      .expect('Content-Disposition', 'attachment; filename="amazing.txt"')
+      .expect(200, done)
     })
   })
 

--- a/test/middleware.basic.js
+++ b/test/middleware.basic.js
@@ -32,13 +32,8 @@ describe('middleware', function(){
       .get('/')
       .set('Content-Type', 'application/json')
       .send('{"foo":"bar"}')
-      .end(function(err, res){
-        if (err) return done(err);
-        res.headers.should.have.property('content-type', 'application/json');
-        res.statusCode.should.equal(200);
-        res.text.should.equal('{"foo":"bar"}');
-        done();
-      })
+      .expect('Content-Type', 'application/json')
+      .expect(200, '{"foo":"bar"}', done)
     })
   })
 })

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -2,6 +2,7 @@
 var express = require('../')
   , request = require('supertest')
   , assert = require('assert');
+var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.jsonp(object)', function(){
@@ -136,11 +137,8 @@ describe('res', function(){
       request(app)
       .get('/')
       .expect('Content-Type', 'application/vnd.example+json; charset=utf-8')
-      .expect(200, '{"hello":"world"}', function (err, res) {
-        if (err) return done(err);
-        res.headers.should.not.have.property('x-content-type-options');
-        done();
-      });
+      .expect(utils.shouldNotHaveHeader('X-Content-Type-Options'))
+      .expect(200, '{"hello":"world"}', done);
     })
 
     it('should override previous Content-Types with callback', function(done){

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -13,10 +13,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.have.property('location', 'http://google.com');
-        done();
-      })
+      .expect('Location', 'http://google.com')
+      .expect(200, done)
     })
   })
 })

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -2,6 +2,7 @@
 var http = require('http');
 var express = require('..');
 var request = require('supertest');
+var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.redirect(url)', function(){
@@ -29,11 +30,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.statusCode.should.equal(303);
-        res.headers.should.have.property('location', 'http://google.com');
-        done();
-      })
+      .expect('Location', 'http://google.com')
+      .expect(303, done)
     })
   })
 
@@ -47,11 +45,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.statusCode.should.equal(303);
-        res.headers.should.have.property('location', 'http://google.com');
-        done();
-      })
+      .expect('Location', 'http://google.com')
+      .expect(303, done)
     })
   })
 
@@ -65,11 +60,8 @@ describe('res', function(){
 
       request(app)
       .head('/')
-      .end(function(err, res){
-        res.headers.should.have.property('location', 'http://google.com');
-        res.text.should.equal('');
-        done();
-      })
+      .expect('Location', 'http://google.com')
+      .expect(302, '', done)
     })
   })
 
@@ -182,11 +174,8 @@ describe('res', function(){
       .set('Accept', 'application/octet-stream')
       .expect('location', 'http://google.com')
       .expect('content-length', '0')
-      .expect(302, '', function(err, res){
-        if (err) return done(err)
-        res.headers.should.not.have.property('content-type');
-        done();
-      })
+      .expect(utils.shouldNotHaveHeader('Content-Type'))
+      .expect(302, '', done)
     })
   })
 })

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var express = require('..');
 var methods = require('methods');
 var request = require('supertest');
+var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.send()', function(){
@@ -118,12 +119,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.have.property('content-type', 'text/html; charset=utf-8');
-        res.text.should.equal('<p>hey</p>');
-        res.statusCode.should.equal(200);
-        done();
-      })
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200, '<p>hey</p>', done);
     })
 
     it('should set ETag', function (done) {
@@ -190,12 +187,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.have.property('content-type', 'application/octet-stream');
-        res.text.should.equal('hello');
-        res.statusCode.should.equal(200);
-        done();
-      })
+      .expect('Content-Type', 'application/octet-stream')
+      .expect(200, 'hello', done);
     })
 
     it('should set ETag', function (done) {
@@ -221,12 +214,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.have.property('content-type', 'text/plain; charset=utf-8');
-        res.text.should.equal('hey');
-        res.statusCode.should.equal(200);
-        done();
-      })
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(200, 'hey', done);
     })
   })
 
@@ -269,13 +258,10 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.not.have.property('content-type');
-        res.headers.should.not.have.property('content-length');
-        res.headers.should.not.have.property('transfer-encoding');
-        res.text.should.equal('');
-        done();
-      })
+      .expect(utils.shouldNotHaveHeader('Content-Type'))
+      .expect(utils.shouldNotHaveHeader('Content-Length'))
+      .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
+      .expect(204, '', done);
     })
   })
 
@@ -289,13 +275,10 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .end(function(err, res){
-        res.headers.should.not.have.property('content-type');
-        res.headers.should.not.have.property('content-length');
-        res.headers.should.not.have.property('transfer-encoding');
-        res.text.should.equal('');
-        done();
-      })
+      .expect(utils.shouldNotHaveHeader('Content-Type'))
+      .expect(utils.shouldNotHaveHeader('Content-Length'))
+      .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
+      .expect(304, '', done);
     })
   })
 
@@ -451,7 +434,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect(shouldNotHaveHeader('ETag'))
+        .expect(utils.shouldNotHaveHeader('ETag'))
         .expect(200, done);
       })
     });
@@ -469,7 +452,7 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect(shouldNotHaveHeader('ETag'))
+        .expect(utils.shouldNotHaveHeader('ETag'))
         .expect(200, done);
       });
 
@@ -559,15 +542,9 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect(shouldNotHaveHeader('ETag'))
+        .expect(utils.shouldNotHaveHeader('ETag'))
         .expect(200, done);
       })
     })
   })
 })
-
-function shouldNotHaveHeader(header) {
-  return function (res) {
-    assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header)
-  }
-}

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -7,6 +7,7 @@ var onFinished = require('on-finished');
 var path = require('path');
 var should = require('should');
 var fixtures = path.join(__dirname, 'fixtures');
+var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.sendFile(path)', function () {
@@ -154,11 +155,8 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .expect(404, function (err, res) {
-          if (err) return done(err);
-          res.headers.should.not.have.property('x-success');
-          done();
-        });
+        .expect(utils.shouldNotHaveHeader('X-Success'))
+        .expect(404, done);
       });
     });
 
@@ -509,11 +507,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect(404, function (err, res) {
-        if (err) return done(err);
-        res.headers.should.not.have.property('x-success');
-        done();
-      });
+      .expect(utils.shouldNotHaveHeader('X-Success'))
+      .expect(404, done);
     })
 
     it('should transfer a file', function (done) {
@@ -595,11 +590,8 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .end(function(err, res){
-          res.text.should.equal('<p>{{user.name}}</p>');
-          res.headers.should.have.property('content-type', 'text/html; charset=UTF-8');
-          done();
-        });
+        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect(200, '<p>{{user.name}}</p>', done);
       })
     })
 
@@ -613,11 +605,8 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .end(function(err, res){
-          res.text.should.equal('<p>{{user.name}}</p>');
-          res.headers.should.have.property('content-type', 'text/html; charset=UTF-8');
-          done();
-        });
+        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect(200, '<p>{{user.name}}</p>', done);
       })
 
       it('should serve relative to "root"', function(done){
@@ -629,11 +618,8 @@ describe('res', function(){
 
         request(app)
         .get('/')
-        .end(function(err, res){
-          res.text.should.equal('<p>{{user.name}}</p>');
-          res.headers.should.have.property('content-type', 'text/html; charset=UTF-8');
-          done();
-        });
+        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect(200, '<p>{{user.name}}</p>', done);
       })
 
       it('should consider ../ malicious when "root" is not set', function(done){

--- a/test/res.vary.js
+++ b/test/res.vary.js
@@ -2,6 +2,7 @@
 var assert = require('assert');
 var express = require('..');
 var request = require('supertest');
+var utils = require('./support/utils');
 
 describe('res.vary()', function(){
   describe('with no arguments', function(){
@@ -15,7 +16,7 @@ describe('res.vary()', function(){
 
       request(app)
       .get('/')
-      .expect(shouldNotHaveHeader('Vary'))
+      .expect(utils.shouldNotHaveHeader('Vary'))
       .expect(200, done);
     })
   })
@@ -31,7 +32,7 @@ describe('res.vary()', function(){
 
       request(app)
       .get('/')
-      .expect(shouldNotHaveHeader('Vary'))
+      .expect(utils.shouldNotHaveHeader('Vary'))
       .expect(200, done);
     })
   })
@@ -88,9 +89,3 @@ describe('res.vary()', function(){
     })
   })
 })
-
-function shouldNotHaveHeader(header) {
-  return function (res) {
-    assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header);
-  };
-}

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -1,0 +1,24 @@
+
+/**
+ * Module dependencies.
+ * @private
+ */
+var assert = require('assert');
+
+/**
+ * Module exports.
+ * @public
+ */
+exports.shouldNotHaveHeader = shouldNotHaveHeader;
+
+/**
+ * Assert that a supertest response does not have a header.
+ *
+ * @param {string} header Header name to check
+ * @returns {function}
+ */
+function shouldNotHaveHeader(header) {
+  return function (res) {
+    assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header);
+  };
+}


### PR DESCRIPTION
This is an alternative pull request for #2983 converting the usages to use `supertest` rather than continuing to use `supertest`. This helps align with goals like removing the `should` module from tests eventually, since there are no less `should` usages (plus, `supertest` provides these features).

The cause for these two pull requests is that there is discussion going on currently to change the prototype of the `headers` object from `Object` to `null`, which would remove global extension properties like `.should`.
