### PR TITLE
BugFixed: prevent toLowerCase crash the App.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/app.js",
+			"stopOnEntry": false,
+			"args": [],
+			"cwd": "${workspaceRoot}",
+			"preLaunchTask": null,
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"externalConsole": false,
+			"sourceMaps": false,
+			"outDir": null
+		},
+		{
+			"name": "Attach",
+			"type": "node",
+			"request": "attach",
+			"port": 5858,
+			"address": "localhost",
+			"restart": false,
+			"sourceMaps": false,
+			"outDir": null,
+			"localRoot": "${workspaceRoot}",
+			"remoteRoot": null
+		}
+	]
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,8 +57,9 @@ var req = exports = module.exports = {
 
 req.get =
 req.header = function header(name) {
-  var lc = name.toLowerCase();
-
+  var lc = null;
+  if(typeof name === 'string') lc = name.toLowerCase();
+  
   switch (lc) {
     case 'referer':
     case 'referrer':

--- a/lib/request.js
+++ b/lib/request.js
@@ -61,7 +61,7 @@ req.header = function header(name) {
   
   // If name wasn't a string, it will crash
   if(typeof name !== 'string') { 
-    new TypeError('Parameter "name" needs to be a String but got a ' + (typeof name));
+    return new TypeError('Parameter "name" needs to be a String but got a ' + (typeof name));
   }
   
   lc = name.toLowerCase();

--- a/lib/request.js
+++ b/lib/request.js
@@ -58,7 +58,13 @@ var req = exports = module.exports = {
 req.get =
 req.header = function header(name) {
   var lc = null;
-  if(typeof name === 'string') lc = name.toLowerCase();
+  
+  // If name wasn't a string, it will crash
+  if(typeof name !== 'string') { 
+    new TypeError('Parameter "name" needs to be a String but got a ' + (typeof name));
+  }
+  
+  lc = name.toLowerCase();
   
   switch (lc) {
     case 'referer':

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -23,12 +23,13 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        res.end(req.get(['Referer']));
-      });
-
+        assert(req.get(['Something-Else']) == '[TypeError: Parameter "name" needs to be a String but got a object]' );
+        res.end(req.get('Content-Type'));
+      })
+      
       request(app)
       .post('/')
-      .set(['Referrer'], 'http://foobar.com')
+      .set('Content-Type', 'application/json')
       .expect(500, done);
     })
 

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -3,10 +3,6 @@ var express = require('../')
   , request = require('supertest')
   , assert = require('assert');
 
-function typeThrowError(name) {
-    new TypeError('Parameter "name" needs to be a String but got a ' + (typeof name));
-}
-
 describe('req', function(){
   describe('.get(field)', function(){
     it('should return the header field value', function(done){
@@ -16,17 +12,24 @@ describe('req', function(){
         assert(req.get('Something-Else') === undefined);
         res.end(req.get('Content-Type'));
       });
-      
-      app.use(function(req, res){
-        var name = ['something'];
-        assert.throws(typeThrowError(name), TypeError, "Error thrown");
-        res.end(req.get('Content-Type'));
-      });
 
       request(app)
       .post('/')
       .set('Content-Type', 'application/json')
       .expect('application/json', done);
+    })
+    
+    it('should handle render error throws', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.end(req.get(['Referer']));
+      });
+
+      request(app)
+      .post('/')
+      .set(['Referrer'], 'http://foobar.com')
+      .expect(500, done);
     })
 
     it('should special-case Referer', function(done){

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -3,6 +3,10 @@ var express = require('../')
   , request = require('supertest')
   , assert = require('assert');
 
+function typeThrowError(name) {
+    new TypeError('Parameter "name" needs to be a String but got a ' + (typeof name));
+}
+
 describe('req', function(){
   describe('.get(field)', function(){
     it('should return the header field value', function(done){
@@ -10,6 +14,12 @@ describe('req', function(){
 
       app.use(function(req, res){
         assert(req.get('Something-Else') === undefined);
+        res.end(req.get('Content-Type'));
+      });
+      
+      app.use(function(req, res){
+        var name = ['something'];
+        assert.throws(typeThrowError(name), TypeError, "Error thrown");
         res.end(req.get('Content-Type'));
       });
 


### PR DESCRIPTION
I caught this bug in development. When a user accidentaly ran a non string parameter to get on request, the App crashes.
I fixed this.
