### PR TITLE
Release 4.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "2.5"
   - "3.3"
   - "4.4"
+  - "5.11"
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "3.3"
   - "4.4"
   - "5.11"
+  - "6.2"
 sudo: false
 cache:
   directories:

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix Windows absolute path check using forward slashes
   * Improve performance for `res.json`/`res.jsonp` in most cases
   * deps: accepts@~1.3.3
     - Fix including type extensions in parameters in `Accept` parsing

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Improve performance for `res.json`/`res.jsonp` in most cases
   * deps: accepts@~1.3.3
     - Fix including type extensions in parameters in `Accept` parsing
     - Fix parsing `Accept` parameters with quoted equals

--- a/History.md
+++ b/History.md
@@ -1,3 +1,14 @@
+unreleased
+==========
+
+  * deps: accepts@~1.3.3
+    - Fix including type extensions in parameters in `Accept` parsing
+    - Fix parsing `Accept` parameters with quoted equals
+    - Fix parsing `Accept` parameters with quoted semicolons
+    - Many performance improvments
+    - deps: mime-types@~2.1.11
+    - deps: negotiator@0.6.1
+
 4.13.4 / 2016-01-21
 ===================
 

--- a/History.md
+++ b/History.md
@@ -31,6 +31,10 @@ unreleased
     - deps: ipaddr.js@1.1.1
   * deps: qs@6.2.0
     - Add `decoder` option in `parse` function
+  * deps: range-parser@~1.2.0
+    - Add `combine` option to combine overlapping ranges
+    - Fix incorrectly returning -1 when there is at least one valid range
+    - perf: remove internal function
   * deps: type-is@~1.6.13
     - Fix type error when given invalid type to match against
     - deps: mime-types@~2.1.11

--- a/History.md
+++ b/History.md
@@ -21,6 +21,12 @@ unreleased
     - perf: hoist regular expression
     - perf: use for loop in parse
     - perf: use string concatination for serialization
+  * deps: proxy-addr@~1.1.2
+    - Fix accepting various invalid netmasks
+    - Fix IPv6-mapped IPv4 validation edge cases
+    - IPv4 netmasks must be contingous
+    - IPv6 addresses cannot be used as a netmask
+    - deps: ipaddr.js@1.1.1
   * deps: vary@~1.1.0
     - Only accept valid field names in the `field` argument
 

--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
   * Add `cacheControl` option to `res.sendFile`/`res.sendfile`
   * Add `options` argument to `req.range`
     - Includes the `combine` option
+  * Encode URL in `res.location`/`res.redirect` if not already encoded
   * Fix some redirect handling in `res.sendFile`/`res.sendfile`
   * Fix Windows absolute path check using forward slashes
   * Improve error with invalid arguments to `req.get()`

--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 unreleased
 ==========
 
+  * Add `options` argument to `req.range`
+    - Includes the `combine` option
   * Fix Windows absolute path check using forward slashes
   * Improve performance for `res.json`/`res.jsonp` in most cases
   * deps: accepts@~1.3.3

--- a/History.md
+++ b/History.md
@@ -56,6 +56,14 @@ unreleased
     - deps: range-parser@~1.2.0
     - deps: statuses@~1.3.0
     - perf: remove argument reassignment
+  * deps: serve-static@~1.11.1
+    - Add `acceptRanges` option
+    - Add `cacheControl` option
+    - Attempt to combine multiple ranges into single range
+    - Fix redirect error when `req.url` contains raw non-URL characters
+    - Ignore non-byte `Range` headers
+    - Use status code 301 for redirects
+    - deps: send@0.14.1
   * deps: type-is@~1.6.13
     - Fix type error when given invalid type to match against
     - deps: mime-types@~2.1.11

--- a/History.md
+++ b/History.md
@@ -10,6 +10,17 @@ unreleased
     - deps: negotiator@0.6.1
   * deps: content-type@~1.0.2
     - perf: enable strict mode
+  * deps: cookie@0.3.1
+    - Add `sameSite` option
+    - Fix cookie `Max-Age` to never be a floating point number
+    - Improve error message when `encode` is not a function
+    - Improve error message when `expires` is not a `Date`
+    - Throw better error for invalid argument to parse
+    - Throw on invalid values provided to `serialize`
+    - perf: enable strict mode
+    - perf: hoist regular expression
+    - perf: use for loop in parse
+    - perf: use string concatination for serialization
   * deps: vary@~1.1.0
     - Only accept valid field names in the `field` argument
 

--- a/History.md
+++ b/History.md
@@ -10,6 +10,8 @@ unreleased
     - deps: negotiator@0.6.1
   * deps: content-type@~1.0.2
     - perf: enable strict mode
+  * deps: vary@~1.1.0
+    - Only accept valid field names in the `field` argument
 
 4.13.4 / 2016-01-21
 ===================

--- a/History.md
+++ b/History.md
@@ -31,6 +31,12 @@ unreleased
     - perf: hoist regular expression
     - perf: use for loop in parse
     - perf: use string concatination for serialization
+  * deps: finalhandler@0.5.0
+    - Change invalid or non-numeric status code to 500
+    - Overwrite status message to match set status code
+    - Prefer `err.statusCode` if `err.status` is invalid
+    - Set response headers from `err.headers` object
+    - Use `statuses` instead of `http` module for status messages
   * deps: proxy-addr@~1.1.2
     - Fix accepting various invalid netmasks
     - Fix IPv6-mapped IPv4 validation edge cases

--- a/History.md
+++ b/History.md
@@ -8,6 +8,8 @@ unreleased
     - Many performance improvments
     - deps: mime-types@~2.1.11
     - deps: negotiator@0.6.1
+  * deps: content-type@~1.0.2
+    - perf: enable strict mode
 
 4.13.4 / 2016-01-21
 ===================

--- a/History.md
+++ b/History.md
@@ -28,6 +28,8 @@ unreleased
     - IPv4 netmasks must be contingous
     - IPv6 addresses cannot be used as a netmask
     - deps: ipaddr.js@1.1.1
+  * deps: qs@6.2.0
+    - Add `decoder` option in `parse` function
   * deps: type-is@~1.6.13
     - Fix type error when given invalid type to match against
     - deps: mime-types@~2.1.11

--- a/History.md
+++ b/History.md
@@ -29,6 +29,7 @@ unreleased
     - deps: ipaddr.js@1.1.1
   * deps: vary@~1.1.0
     - Only accept valid field names in the `field` argument
+  * perf: use strict equality when possible
 
 4.13.4 / 2016-01-21
 ===================

--- a/History.md
+++ b/History.md
@@ -28,6 +28,9 @@ unreleased
     - IPv4 netmasks must be contingous
     - IPv6 addresses cannot be used as a netmask
     - deps: ipaddr.js@1.1.1
+  * deps: type-is@~1.6.13
+    - Fix type error when given invalid type to match against
+    - deps: mime-types@~2.1.11
   * deps: vary@~1.1.0
     - Only accept valid field names in the `field` argument
   * perf: use strict equality when possible

--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ unreleased
   * Add `options` argument to `req.range`
     - Includes the `combine` option
   * Fix Windows absolute path check using forward slashes
+  * Improve error with invalid arguments to `req.get()`
   * Improve performance for `res.json`/`res.jsonp` in most cases
   * deps: accepts@~1.3.3
     - Fix including type extensions in parameters in `Accept` parsing

--- a/History.md
+++ b/History.md
@@ -1,11 +1,15 @@
 unreleased
 ==========
 
+  * Add `acceptRanges` option to `res.sendFile`/`res.sendfile`
+  * Add `cacheControl` option to `res.sendFile`/`res.sendfile`
   * Add `options` argument to `req.range`
     - Includes the `combine` option
+  * Fix some redirect handling in `res.sendFile`/`res.sendfile`
   * Fix Windows absolute path check using forward slashes
   * Improve error with invalid arguments to `req.get()`
   * Improve performance for `res.json`/`res.jsonp` in most cases
+  * Improve `Range` header handling in `res.sendFile`/`res.sendfile`
   * deps: accepts@~1.3.3
     - Fix including type extensions in parameters in `Accept` parsing
     - Fix parsing `Accept` parameters with quoted equals
@@ -38,6 +42,20 @@ unreleased
     - Add `combine` option to combine overlapping ranges
     - Fix incorrectly returning -1 when there is at least one valid range
     - perf: remove internal function
+  * deps: send@0.14.1
+    - Add `acceptRanges` option
+    - Add `cacheControl` option
+    - Attempt to combine multiple ranges into single range
+    - Correctly inherit from `Stream` class
+    - Fix `Content-Range` header in 416 responses when using `start`/`end` options
+    - Fix `Content-Range` header missing from default 416 responses
+    - Fix redirect error when `path` contains raw non-URL characters
+    - Fix redirect when `path` starts with multiple forward slashes
+    - Ignore non-byte `Range` headers
+    - deps: http-errors@~1.5.0
+    - deps: range-parser@~1.2.0
+    - deps: statuses@~1.3.0
+    - perf: remove argument reassignment
   * deps: type-is@~1.6.13
     - Fix type error when given invalid type to match against
     - deps: mime-types@~2.1.11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - nodejs_version: "3.3"
     - nodejs_version: "4.4"
     - nodejs_version: "5.11"
+    - nodejs_version: "6.2"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "2.5"
     - nodejs_version: "3.3"
     - nodejs_version: "4.4"
+    - nodejs_version: "5.11"
 cache:
   - node_modules
 install:

--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -30,14 +30,9 @@ module.exports = function query(options) {
     opts = undefined;
   }
 
-  if (opts !== undefined) {
-    if (opts.allowDots === undefined) {
-      opts.allowDots = false;
-    }
-
-    if (opts.allowPrototypes === undefined) {
-      opts.allowPrototypes = true;
-    }
+  if (opts !== undefined && opts.allowPrototypes === undefined) {
+    // back-compat for qs module
+    opts.allowPrototypes = true;
   }
 
   return function query(req, res, next){

--- a/lib/request.js
+++ b/lib/request.js
@@ -182,18 +182,23 @@ req.acceptsLanguage = deprecate.function(req.acceptsLanguages,
  * range that is required (most commonly, "bytes"). Each array element is an object
  * with a "start" and "end" property for the portion of the range.
  *
+ * The "combine" option can be set to `true` and overlapping & adjacent ranges
+ * will be combined into a single range.
+ *
  * NOTE: remember that ranges are inclusive, so for example "Range: users=0-3"
  * should respond with 4 users when available, not 3.
  *
  * @param {number} size
+ * @param {object} [options]
+ * @param {boolean} [options.combine=false]
  * @return {number|array}
  * @public
  */
 
-req.range = function range(size) {
+req.range = function range(size, options) {
   var range = this.get('Range');
   if (!range) return;
-  return parseRange(size, range);
+  return parseRange(size, range, options);
 };
 
 /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -303,7 +303,7 @@ defineGetter(req, 'protocol', function protocol(){
 /**
  * Short-hand for:
  *
- *    req.protocol == 'https'
+ *    req.protocol === 'https'
  *
  * @return {Boolean}
  * @public
@@ -437,10 +437,10 @@ defineGetter(req, 'fresh', function(){
   var s = this.res.statusCode;
 
   // GET or HEAD for weak freshness validation only
-  if ('GET' != method && 'HEAD' != method) return false;
+  if ('GET' !== method && 'HEAD' !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
-  if ((s >= 200 && s < 300) || 304 == s) {
+  if ((s >= 200 && s < 300) || 304 === s) {
     return fresh(this.headers, (this.res._headers || {}));
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -171,26 +171,26 @@ req.acceptsLanguage = deprecate.function(req.acceptsLanguages,
   'req.acceptsLanguage: Use acceptsLanguages instead');
 
 /**
- * Parse Range header field,
- * capping to the given `size`.
+ * Parse Range header field, capping to the given `size`.
  *
- * Unspecified ranges such as "0-" require
- * knowledge of your resource length. In
- * the case of a byte range this is of course
- * the total number of bytes. If the Range
- * header field is not given `null` is returned,
- * `-1` when unsatisfiable, `-2` when syntactically invalid.
+ * Unspecified ranges such as "0-" require knowledge of your resource length. In
+ * the case of a byte range this is of course the total number of bytes. If the
+ * Range header field is not given `undefined` is returned, `-1` when unsatisfiable,
+ * and `-2` when syntactically invalid.
  *
- * NOTE: remember that ranges are inclusive, so
- * for example "Range: users=0-3" should respond
- * with 4 users when available, not 3.
+ * When ranges are returned, the array has a "type" property which is the type of
+ * range that is required (most commonly, "bytes"). Each array element is an object
+ * with a "start" and "end" property for the portion of the range.
  *
- * @param {Number} size
- * @return {Array}
+ * NOTE: remember that ranges are inclusive, so for example "Range: users=0-3"
+ * should respond with 4 users when available, not 3.
+ *
+ * @param {number} size
+ * @return {number|array}
  * @public
  */
 
-req.range = function(size){
+req.range = function range(size) {
   var range = this.get('Range');
   if (!range) return;
   return parseRange(size, range);

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,6 +57,14 @@ var req = exports = module.exports = {
 
 req.get =
 req.header = function header(name) {
+  if (!name) {
+    throw new TypeError('name argument is required to req.get');
+  }
+
+  if (typeof name !== 'string') {
+    throw new TypeError('name must be a string to req.get');
+  }
+
   var lc = name.toLowerCase();
 
   switch (lc) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -239,7 +239,7 @@ res.json = function json(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body = stringify(val, replacer, spaces);
 
   // content-type
   if (!this.get('Content-Type')) {
@@ -281,7 +281,7 @@ res.jsonp = function jsonp(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body = stringify(val, replacer, spaces);
   var callback = this.req.query[app.get('jsonp callback name')];
 
   // content-type
@@ -1050,4 +1050,17 @@ function sendfile(res, file, options, callback) {
 
   // pipe
   file.pipe(res);
+}
+
+/**
+ * Stringify JSON, like JSON.stringify, but v8 optimized.
+ * @private
+ */
+
+function stringify(value, replacer, spaces) {
+  // v8 checks arguments.length for optimizing simple call
+  // https://bugs.chromium.org/p/v8/issues/detail?id=4730
+  return replacer || spaces
+    ? JSON.stringify(value, replacer, spaces)
+    : JSON.stringify(value);
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,6 +14,7 @@
 
 var contentDisposition = require('content-disposition');
 var deprecate = require('depd')('express');
+var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
 var http = require('http');
 var isAbsolute = require('./utils').isAbsolute;
@@ -832,8 +833,7 @@ res.location = function location(url) {
   }
 
   // set location
-  this.set('Location', loc);
-  return this;
+  return this.set('Location', encodeUrl(loc));
 };
 
 /**
@@ -871,13 +871,12 @@ res.redirect = function redirect(url) {
   }
 
   // Set location header
-  this.location(address);
-  address = this.get('Location');
+  address = this.location(address).get('Location');
 
   // Support text/{plain,html} by default
   this.format({
     text: function(){
-      body = statusCodes[status] + '. Redirecting to ' + encodeURI(address);
+      body = statusCodes[status] + '. Redirecting to ' + address;
     },
 
     html: function(){

--- a/lib/response.js
+++ b/lib/response.js
@@ -189,7 +189,7 @@ res.send = function send(body) {
   if (req.fresh) this.statusCode = 304;
 
   // strip irrelevant headers
-  if (204 == this.statusCode || 304 == this.statusCode) {
+  if (204 === this.statusCode || 304 === this.statusCode) {
     this.removeHeader('Content-Type');
     this.removeHeader('Content-Length');
     this.removeHeader('Transfer-Encoding');

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -119,7 +119,7 @@ proto.param = function param(name, fn) {
 
   // ensure we end up with a
   // middleware function
-  if ('function' != typeof fn) {
+  if ('function' !== typeof fn) {
     throw new Error('invalid param() call for ' + name + ', got ' + fn);
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -283,7 +283,6 @@ exports.setCharset = function setCharset(type, charset) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowDots: false,
     allowPrototypes: true
   });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ exports.wetag = function wetag(body, encoding){
 
 exports.isAbsolute = function(path){
   if ('/' === path[0]) return true;
-  if (':' === path[1] && '\\' === path[2]) return true;
+  if (':' === path[1] && ('\\' === path[2] || '/' === path[2])) return true; // Windows device path
   if ('\\\\' === path.substring(0, 2)) return true; // Microsoft Azure absolute path
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,9 +66,9 @@ exports.wetag = function wetag(body, encoding){
  */
 
 exports.isAbsolute = function(path){
-  if ('/' == path[0]) return true;
-  if (':' == path[1] && '\\' == path[2]) return true;
-  if ('\\\\' == path.substring(0, 2)) return true; // Microsoft Azure absolute path
+  if ('/' === path[0]) return true;
+  if (':' === path[1] && '\\' === path[2]) return true;
+  if ('\\\\' === path.substring(0, 2)) return true; // Microsoft Azure absolute path
 };
 
 /**
@@ -142,7 +142,7 @@ function acceptParams(str, index) {
 
   for (var i = 1; i < parts.length; ++i) {
     var pms = parts[i].split(/ *= */);
-    if ('q' == pms[0]) {
+    if ('q' === pms[0]) {
       ret.quality = parseFloat(pms[1]);
     } else {
       ret.params[pms[0]] = pms[1];

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "istanbul": "0.4.3",
     "marked": "0.3.5",
     "mocha": "2.5.3",
-    "should": "8.4.0",
+    "should": "9.0.0",
     "supertest": "1.1.0",
     "body-parser": "~1.14.2",
     "connect-redis": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.1",
     "path-to-regexp": "0.1.7",
-    "proxy-addr": "~1.0.10",
+    "proxy-addr": "~1.1.2",
     "qs": "4.0.0",
     "range-parser": "~1.0.3",
     "send": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "qs": "6.2.0",
     "range-parser": "~1.2.0",
     "send": "0.14.1",
-    "serve-static": "~1.10.2",
+    "serve-static": "~1.11.1",
     "type-is": "~1.6.13",
     "utils-merge": "1.0.0",
     "vary": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "range-parser": "~1.0.3",
     "send": "0.13.1",
     "serve-static": "~1.10.2",
-    "type-is": "~1.6.6",
+    "type-is": "~1.6.13",
     "utils-merge": "1.0.0",
     "vary": "~1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
     "etag": "~1.7.0",
-    "finalhandler": "0.4.1",
+    "finalhandler": "0.5.0",
     "fresh": "0.3.0",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ejs": "2.4.2",
     "istanbul": "0.4.3",
     "marked": "0.3.5",
-    "mocha": "2.5.1",
+    "mocha": "2.5.3",
     "should": "8.4.0",
     "supertest": "1.1.0",
     "body-parser": "~1.14.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "path-to-regexp": "0.1.7",
     "proxy-addr": "~1.1.2",
     "qs": "6.2.0",
-    "range-parser": "~1.0.3",
+    "range-parser": "~1.2.0",
     "send": "0.13.1",
     "serve-static": "~1.10.2",
     "type-is": "~1.6.13",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "array-flatten": "1.1.1",
     "content-disposition": "0.5.1",
     "content-type": "~1.0.2",
-    "cookie": "0.1.5",
+    "cookie": "0.3.1",
     "cookie-signature": "1.0.6",
     "debug": "~2.2.0",
     "depd": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "accepts": "~1.3.3",
     "array-flatten": "1.1.1",
     "content-disposition": "0.5.1",
-    "content-type": "~1.0.1",
+    "content-type": "~1.0.2",
     "cookie": "0.1.5",
     "cookie-signature": "1.0.6",
     "debug": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cookie-signature": "1.0.6",
     "debug": "~2.2.0",
     "depd": "~1.1.0",
+    "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
     "etag": "~1.7.0",
     "finalhandler": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "marked": "0.3.5",
     "mocha": "2.5.3",
     "should": "9.0.0",
-    "supertest": "1.1.0",
+    "supertest": "1.2.0",
     "body-parser": "~1.14.2",
     "connect-redis": "~2.4.1",
     "cookie-parser": "~1.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "api"
   ],
   "dependencies": {
-    "accepts": "~1.2.12",
+    "accepts": "~1.3.3",
     "array-flatten": "1.1.1",
     "content-disposition": "0.5.1",
     "content-type": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "serve-static": "~1.10.2",
     "type-is": "~1.6.6",
     "utils-merge": "1.0.0",
-    "vary": "~1.0.1"
+    "vary": "~1.1.0"
   },
   "devDependencies": {
     "after": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -56,22 +56,22 @@
   },
   "devDependencies": {
     "after": "0.8.1",
+    "body-parser": "~1.15.1",
+    "cookie-parser": "~1.4.3",
     "ejs": "2.4.2",
     "istanbul": "0.4.3",
     "marked": "0.3.5",
+    "method-override": "~2.3.6",
     "mocha": "2.5.3",
+    "morgan": "~1.7.0",
     "should": "9.0.2",
     "supertest": "1.2.0",
-    "body-parser": "~1.14.2",
     "connect-redis": "~2.4.1",
-    "cookie-parser": "~1.4.1",
     "cookie-session": "~1.2.0",
     "express-session": "~1.13.0",
     "jade": "~1.11.0",
-    "method-override": "~2.3.5",
-    "morgan": "~1.6.1",
     "multiparty": "~4.1.2",
-    "vhost": "~3.0.1"
+    "vhost": "~3.0.2"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parseurl": "~1.3.1",
     "path-to-regexp": "0.1.7",
     "proxy-addr": "~1.1.2",
-    "qs": "4.0.0",
+    "qs": "6.2.0",
     "range-parser": "~1.0.3",
     "send": "0.13.1",
     "serve-static": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "proxy-addr": "~1.1.2",
     "qs": "6.2.0",
     "range-parser": "~1.2.0",
-    "send": "0.13.1",
+    "send": "0.14.1",
     "serve-static": "~1.10.2",
     "type-is": "~1.6.13",
     "utils-merge": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "after": "0.8.1",
-    "ejs": "2.4.1",
+    "ejs": "2.4.2",
     "istanbul": "0.4.3",
     "marked": "0.3.5",
     "mocha": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "istanbul": "0.4.3",
     "marked": "0.3.5",
     "mocha": "2.5.3",
-    "should": "9.0.0",
+    "should": "9.0.2",
     "supertest": "1.2.0",
     "body-parser": "~1.14.2",
     "connect-redis": "~2.4.1",

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -31,5 +31,29 @@ describe('req', function(){
       .set('Referrer', 'http://foobar.com')
       .expect('http://foobar.com', done);
     })
+
+    it('should throw missing header name', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.end(req.get())
+      })
+
+      request(app)
+      .get('/')
+      .expect(500, /TypeError: name argument is required to req.get/, done)
+    })
+
+    it('should throw for non-string header name', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.end(req.get(42))
+      })
+
+      request(app)
+      .get('/')
+      .expect(500, /TypeError: name must be a string to req.get/, done)
+    })
   })
 })

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -43,7 +43,7 @@ describe('req', function(){
         var app = createApp('simple');
 
         request(app)
-        .get('/?user[name]=tj')
+        .get('/?user%5Bname%5D=tj')
         .expect(200, '{"user[name]":"tj"}', done);
       });
     });
@@ -55,7 +55,7 @@ describe('req', function(){
         });
 
         request(app)
-        .get('/?user[name]=tj')
+        .get('/?user%5Bname%5D=tj')
         .expect(200, '{"length":17}', done);
       });
     });
@@ -65,7 +65,7 @@ describe('req', function(){
         var app = createApp(false);
 
         request(app)
-        .get('/?user[name]=tj')
+        .get('/?user%5Bname%5D=tj')
         .expect(200, '{}', done);
       });
     });
@@ -75,7 +75,7 @@ describe('req', function(){
         var app = createApp(true);
 
         request(app)
-        .get('/?user[name]=tj')
+        .get('/?user%5Bname%5D=tj')
         .expect(200, '{"user[name]":"tj"}', done);
       });
     });

--- a/test/req.range.js
+++ b/test/req.range.js
@@ -12,9 +12,9 @@ function req(ret) {
 describe('req', function(){
   describe('.range(size)', function(){
     it('should return parsed ranges', function(){
-      var ret = [{ start: 0, end: 50 }, { start: 60, end: 100 }];
-      ret.type = 'bytes';
-      req('bytes=0-50,60-100').range(120).should.eql(ret);
+      var ranges = [{ start: 0, end: 50 }, { start: 51, end: 100 }]
+      ranges.type = 'bytes'
+      assert.deepEqual(req('bytes=0-50,51-100').range(120), ranges)
     })
 
     it('should cap to the given size', function(){
@@ -33,6 +33,16 @@ describe('req', function(){
       var ret = [{ start: 0, end: 50 }, { start: 60, end: 100 }];
       ret.type = 'bytes';
       assert(req('').range(120) === undefined);
+    })
+  })
+
+  describe('.range(size, options)', function(){
+    describe('with "combine: true" option', function(){
+      it('should return combined ranges', function(){
+        var ranges = [{ start: 0, end: 100 }]
+        ranges.type = 'bytes'
+        assert.deepEqual(req('bytes=0-50,51-100').range(120, { combine: true }), ranges)
+      })
     })
   })
 })

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -16,5 +16,31 @@ describe('res', function(){
       .expect('Location', 'http://google.com')
       .expect(200, done)
     })
+
+    it('should encode "url"', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.location('https://google.com?q=\u2603 §10').end()
+      })
+
+      request(app)
+      .get('/')
+      .expect('Location', 'https://google.com?q=%E2%98%83%20%C2%A710')
+      .expect(200, done)
+    })
+
+    it('should not touch already-encoded sequences in "url"', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.location('https://google.com?q=%A710').end()
+      })
+
+      request(app)
+      .get('/')
+      .expect('Location', 'https://google.com?q=%A710')
+      .expect(200, done)
+    })
   })
 })

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -18,6 +18,32 @@ describe('res', function(){
       .expect('location', 'http://google.com')
       .expect(302, done)
     })
+
+    it('should encode "url"', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect('https://google.com?q=\u2603 §10')
+      })
+
+      request(app)
+      .get('/')
+      .expect('Location', 'https://google.com?q=%E2%98%83%20%C2%A710')
+      .expect(302, done)
+    })
+
+    it('should not touch already-encoded sequences in "url"', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect('https://google.com?q=%A710')
+      })
+
+      request(app)
+      .get('/')
+      .expect('Location', 'https://google.com?q=%A710')
+      .expect(302, done)
+    })
   })
 
   describe('.redirect(status, url)', function(){
@@ -85,7 +111,7 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        res.redirect('<lame>');
+        res.redirect('<la\'me>');
       });
 
       request(app)
@@ -93,8 +119,8 @@ describe('res', function(){
       .set('Host', 'http://example.com')
       .set('Accept', 'text/html')
       .expect('Content-Type', /html/)
-      .expect('Location', '<lame>')
-      .expect(302, '<p>' + http.STATUS_CODES[302] + '. Redirecting to <a href="&lt;lame&gt;">&lt;lame&gt;</a></p>', done);
+      .expect('Location', '%3Cla\'me%3E')
+      .expect(302, '<p>' + http.STATUS_CODES[302] + '. Redirecting to <a href="%3Cla&#39;me%3E">%3Cla&#39;me%3E</a></p>', done)
     })
 
     it('should include the redirect type', function(done){
@@ -141,8 +167,8 @@ describe('res', function(){
       .set('Host', 'http://example.com')
       .set('Accept', 'text/plain, */*')
       .expect('Content-Type', /plain/)
-      .expect('Location', 'http://example.com/?param=<script>alert("hax");</script>')
-      .expect(302, http.STATUS_CODES[302] + '. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E', done);
+      .expect('Location', 'http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E')
+      .expect(302, http.STATUS_CODES[302] + '. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E', done)
     })
 
     it('should include the redirect type', function(done){

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -286,6 +286,14 @@ describe('res', function(){
     })
   })
 
+  describe('.sendFile(path, options)', function () {
+    it('should pass options to send module', function (done) {
+      request(createApp(path.resolve(fixtures, 'name.txt'), { start: 0, end: 1 }))
+      .get('/')
+      .expect(200, 'to', done)
+    })
+  })
+
   describe('.sendfile(path, fn)', function(){
     it('should invoke the callback when complete', function(done){
       var app = express();
@@ -701,6 +709,20 @@ describe('res', function(){
     })
   })
 })
+
+  describe('.sendfile(path, options)', function () {
+    it('should pass options to send module', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.sendfile(path.resolve(fixtures, 'name.txt'), { start: 0, end: 1 })
+      })
+
+      request(app)
+      .get('/')
+      .expect(200, 'to', done)
+    })
+  })
 
 function createApp(path, options, fn) {
   var app = express();

--- a/test/utils.js
+++ b/test/utils.js
@@ -73,6 +73,7 @@ describe('utils.wetag(body, encoding)', function(){
 describe('utils.isAbsolute()', function(){
   it('should support windows', function(){
     assert(utils.isAbsolute('c:\\'));
+    assert(utils.isAbsolute('c:/'));
     assert(!utils.isAbsolute(':\\'));
   })
 


### PR DESCRIPTION
This is a tracking issue for release 4.14.

**Please keep feature requests in their own issues**

If you want to make a comment on a particular change, please make the comment in the "Files changed" tab so comments are not lost during a rebase.

List of changes for release:
- [x] Encode URL in `res.location`/`res.redirect` if not already encoded #2897 #3003
- [x] Fix Windows absolute path check using forward slashes #3017
- [x] Improve `res.json`/`res.jsonp` performance in Node.js < 6 #2900
- [x] Improve error when given non-string to `res.header` #2993
- [x] Use strict compares #2722
- [x] Upgrade `accepts` module to 1.3.3 which brings in lots of `negotiator` improvements
- [x] Upgrade `content-type` module to 1.0.2
- [x] Upgrade `cookie` module to 0.3.1 which brings new `sameSite` option
- [x] Upgrade `finalhandler` module to 0.5.0 which brings `err.headers` support
- [x] Upgrade `proxy-addr` module to 1.1.2
- [x] Upgrade `qs` module to 6.2.0 which brings the `encode` option to `query` middleware
- [x] Upgrade `range-parser` module to 1.2.0 which brings options like `combine`
- [x] Upgrade `send` module to 0.14.1 which brings `Range` & redirect fixes and new options
- [x] Upgrade `serve-static` module to 1.11.1 which brings `Range` & redirect fixes and new options
- [x] Upgrade `type-is` module to 1.6.13
- [x] Upgrade `vary` module to 1.1.0 which brings field name validation

**Testing this release**

If you want to try out this release, you can install it with the following commands:

``` bash
$ npm cache clean express
$ npm install strongloop/express#4.14
```

Owners/collaborators: please do not merge this PR :)
