### PR TITLE
Improve performace of response.json and jsonp.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -239,7 +239,13 @@ res.json = function json(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body;
+  if (replacer || spaces) {
+    body = JSON.stringify(val, replacer, spaces);
+  } else {
+    // avoid performance penalty in the default path
+    body = JSON.stringify(val);
+  }
 
   // content-type
   if (!this.get('Content-Type')) {
@@ -281,7 +287,13 @@ res.jsonp = function jsonp(obj) {
   var app = this.app;
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = JSON.stringify(val, replacer, spaces);
+  var body;
+  if (replacer || spaces) {
+    body = JSON.stringify(val, replacer, spaces);
+  } else {
+    // avoid performance penalty in the default path
+    body = JSON.stringify(val);
+  }
   var callback = this.req.query[app.get('jsonp callback name')];
 
   // content-type


### PR DESCRIPTION
Use single arity overload of JSON.stringify in the default case for response.json(). Faster by 20x-30x for my workload.

Not sure why it works.
