### PR TITLE
Fixing current benchmark script errors

### DIFF
--- a/benchmarks/run
+++ b/benchmarks/run
@@ -6,7 +6,7 @@ pid=$!
 
 sleep 2
 
-wrk 'http://localhost:3333/?foo[bar]=baz' \
+../node_modules/.bin/wrk 'http://localhost:3333/?foo[bar]=baz' \
   -d 3 \
   -c 50 \
   -t 8 \

--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('../..');
+var path = require('path');
 var logger = require('morgan');
 var app = express();
 
@@ -16,7 +17,7 @@ app.use(logger('dev'));
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // if you wanted to "prefix" you may use
 // the mounting feature of Connect, for example
@@ -24,13 +25,13 @@ app.use(express.static(__dirname + '/public'));
 // The mount-path "/static" is simply removed before
 // passing control to the express.static() middleware,
 // thus it serves the file correctly by ignoring "/static"
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 // if for some reason you want to serve files from
 // several directories, you can use express.static()
 // multiple times! Here we're passing "./public/css",
 // this will allow "GET /style.css" instead of "GET /css/style.css":
-app.use(express.static(__dirname + '/public/css'));
+app.use(express.static(path.join(__dirname, 'public', 'css')));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "express-session": "~1.13.0",
     "jade": "~1.11.0",
     "multiparty": "~4.1.2",
-    "vhost": "~3.0.2"
+    "vhost": "~3.0.2",
+    "wrk-node": "~0.1.4"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -87,6 +88,7 @@
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
     "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
-    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+    "benchmark": "make --directory=benchmarks"
   }
 }


### PR DESCRIPTION
This PR is in response to #2108. I agree with @dougwilson on `benchmarks that do not use non-Node.js dependencies`. 

The current benchmarking script was not touched for 3 years and has a dependency on [wrk](https://github.com/wg/wrk). No reference of this in the docs. If you run the script, you'll get errors.

I submit this PR as a first step in fixing the current script and then moving towards using alternative/better benchmarking tools.
(Prefer to keep the Master branch clean without errors).
