### PR TITLE
Catches errors from Promises / Async functions

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -68,7 +68,10 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    var result = fn(error, req, res, next);
+    if (isPromise(result)) {
+      result.then(null, next);
+    }
   } catch (err) {
     next(err);
   }
@@ -92,7 +95,10 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    var result = fn(req, res, next);
+    if (isPromise(result)) {
+      result.then(null, next);
+    }
   } catch (err) {
     next(err);
   }
@@ -173,4 +179,16 @@ function decode_param(val) {
 
     throw err;
   }
+}
+
+/**
+ * Returns true if the val is a Promise.
+ *
+ * @param {any} val
+ * @return {boolean}
+ * @private
+ */
+
+function isPromise(val) {
+  return val && typeof val === 'object' && typeof val.then === 'function';
 }

--- a/test/app.promise.js
+++ b/test/app.promise.js
@@ -1,0 +1,59 @@
+
+var express = require('../')
+  , request = require('supertest');
+
+describe('app', function(){
+  describe('.VERB()', function(){
+    it('should handle a rejected promise', function(done) {
+      // Only run this test in environments where Promise is defined.
+      if (!global.Promise) {
+        return done();
+      }
+
+      var app = express();
+
+      var a = false;
+      var b = false;
+      var c = false;
+      var d = false;
+
+      app.get('/', function(req, res, next){
+        return new Promise(function(){
+          throw new Error('boom!');
+        });
+      }, function(req, res, next) {
+        return new Promise(function(){
+          a = true;
+          next();
+        });
+      }, function(err, req, res, next){
+        return new Promise(function(){
+          b = true;
+          err.message.should.equal('boom!');
+          throw err;
+        });
+      }, function(err, req, res, next){
+        return new Promise(function(){
+          c = true;
+          err.message.should.equal('boom!');
+          next();
+        });
+      }, function(err, req, res, next){
+        return new Promise(function(){
+          d = true;
+          next();
+        });
+      }, function(req, res){
+        a.should.be.false;
+        b.should.be.true;
+        c.should.be.true;
+        d.should.be.false;
+        res.send(204);
+      });
+
+      request(app)
+      .get('/')
+      .expect(204, done);
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for catching errors from rejected promises (perhaps in the form of an async function) that matches the existing try/catch behavior for synchronous returning functions.

[Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) have now been part of the JavaScript specification for over a year and are popularly used for modeling asynchronous behavior (such as rendering a webpage). They're even mentioned in an express [article about best practices](https://expressjs.com/en/advanced/best-practice-performance.html#use-promises).

However one of the pitfalls of using Promises is being aware of error behavior and not forgetting to call `.catch()`. This is a prominent note in that same article. However a common behavior is to "chain" Promises and allow for the top-most Promise to handle the error. For libraries where error-handling is critical, like webservers or test harnesses, being Promise-aware and allowing functions to return Promises can help isolate error behavior from the library user. Mocha is a [great example of this done well](http://paulsalaets.com/testing-with-promises-in-mocha). Users of Express may inadvertently expect this behavior, return a Promise from their routing functions, and then be surprised when errors are swallowed during debugging.

Support for Promises will become more critical as [Async functions](https://tc39.github.io/ecmascript-asyncawait/) enters the language, giving first-class language syntax for creating and operating on promises. This proposal is expected to be ratified soon, is already implemented in Chakra-node, is implemented behind a flag in Chrome, is expected to arrive in node v7, and is already used by many via transpilers like Babel. This makes proper error handling for Promises imminent as this use case is about to become far more common. It would be great for Express to get ahead of this sooner rather than later.

Example of code where Express error handling will work just fine:

``` js
app.get('/', (req, res) => {
  throw new Error('Oh crap!')
})
```

And a minor syntax modification leads to swallowed errors:

``` js
app.get('/', async (req, res) => {
  throw new Error('Oh crap!')
})
```

This PR approaches a solution to the problem as minimally-invasive as possible. It does not presume anything about the host environment, and it detects and supports the [Promise A](http://wiki.commonjs.org/wiki/Promises/A) subset of the Promise specification, which many older Promise libraries only support.
