### PR TITLE
Fix Issue #2652 concerning V8 decodeURIComponent().

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -3,6 +3,7 @@
  * Copyright(c) 2009-2013 TJ Holowaychuk
  * Copyright(c) 2013 Roman Shtylman
  * Copyright(c) 2014-2015 Douglas Christopher Wilson
+ * Copyright(c) 2016 Michael Vergoz
  * MIT Licensed
  */
 
@@ -15,6 +16,7 @@
 
 var pathRegexp = require('path-to-regexp');
 var debug = require('debug')('express:router:layer');
+var url = require('url');
 
 /**
  * Module variables.
@@ -163,14 +165,10 @@ function decode_param(val) {
     return val;
   }
 
-  try {
-    return decodeURIComponent(val);
-  } catch (err) {
-    if (err instanceof URIError) {
-      err.message = 'Failed to decode param \'' + val + '\'';
-      err.status = err.statusCode = 400;
-    }
+  /* parse URL using nodejs framework */
+  var r = url.parse(val);
+  if(!r)
+    return(null);
 
-    throw err;
-  }
+  return(r.path);
 }


### PR DESCRIPTION
Hi,

This Error throwed by V8 Engine using decodeURIComponent() Was Very Disturbing To Me. 
It is easy to reproduce. Just send an URI with gt/lt like (/un/known/route/<%= this what i used %>) in an unknown route and you will get the issue.
This Could also lead to a DoS issue because I was not able to catch the throwed error then the process goes down and that why i made the modification. 
I Replaced the decoding by the Native Nodejs URL Parser.

Cheers
Michael
