### PR TITLE
Add test coverage for res.sendFile's "cacheControl" option and for various examples

### DIFF
--- a/examples/expose-data-to-client/index.js
+++ b/examples/expose-data-to-client/index.js
@@ -1,7 +1,13 @@
+/**
+ * Module dependencies.
+ */
 
-var express = require('../..');
+var express = require('../../');
 var logger = require('morgan');
-var app = express();
+var app = module.exports = express();
+var test = app.get('env') == 'test';
+
+if (!test) app.use(logger('dev'));
 
 app.set('view engine', 'jade');
 app.set('views', __dirname + '/views');
@@ -23,8 +29,6 @@ User.prototype.toJSON = function(){
     name: this.name
   };
 };
-
-app.use(logger('dev'));
 
 // earlier on expose an object
 // that we can tack properties on.

--- a/examples/jade/index.js
+++ b/examples/jade/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var express = require('../../lib/express');
+var express = require('../../');
 
 // Path to our public directory
 
@@ -10,7 +10,7 @@ var pub = __dirname + '/public';
 
 // setup middleware
 
-var app = express();
+var app = module.exports = express();
 app.use(express.static(pub));
 
 // Optional since express defaults to CWD/views

--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('../..');
+var path = require('path');
 var logger = require('morgan');
 var app = express();
 
@@ -16,7 +17,7 @@ app.use(logger('dev'));
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // if you wanted to "prefix" you may use
 // the mounting feature of Connect, for example
@@ -24,13 +25,13 @@ app.use(express.static(__dirname + '/public'));
 // The mount-path "/static" is simply removed before
 // passing control to the express.static() middleware,
 // thus it serves the file correctly by ignoring "/static"
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 // if for some reason you want to serve files from
 // several directories, you can use express.static()
 // multiple times! Here we're passing "./public/css",
 // this will allow "GET /style.css" instead of "GET /css/style.css":
-app.use(express.static(__dirname + '/public/css'));
+app.use(express.static(path.join(__dirname, 'public', 'css')));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/test/acceptance/expose-data-to-client.js
+++ b/test/acceptance/expose-data-to-client.js
@@ -1,0 +1,24 @@
+
+var app = require('../../examples/expose-data-to-client')
+  , request = require('supertest');
+
+describe('expose-data-to-client', function(){
+  describe('GET /',function(){
+    it('should redirect to /user', function(done){
+      request(app)
+        .get('/')
+        .expect('Location', '/user')
+        .expect(302, done)
+    })
+  })
+
+  describe('GET /user', function(){
+    it('should display the exposed data', function(done){
+      request(app)
+        .get('/user')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(/{"user":{"id":123,"name":"Tobi"}/)
+        .expect(200, done)
+    })
+  })
+})

--- a/test/acceptance/jade.js
+++ b/test/acceptance/jade.js
@@ -1,0 +1,17 @@
+
+var app = require('../../examples/jade')
+  , request = require('supertest');
+
+describe('jade', function(){
+  describe('GET /', function(){
+    it('should respond with html', function(done){
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(/<div class="email">tj@vision-media.ca<\/div>/)
+      .expect(/<div class="email">ciaranj@gmail\.com<\/div>/)
+      .expect(/<div class="email">aaron\.heckmann\+github@gmail\.com<\/div>/)
+      .expect(200, done)
+    })
+  })
+})

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -185,6 +185,26 @@ describe('res', function(){
         .expect(403, done);
       })
     })
+
+    describe('with "cacheControl" option', function () {
+      it('should enable cacheControl by default', function (done) {
+        var app = createApp(path.resolve(__dirname, 'fixtures/name.txt'));
+
+        request(app)
+        .get('/')
+        .expect('cache-control', 'public, max-age=0')
+        .expect(200, done);
+      })
+
+      it('should accept cacheControl option', function(done){
+        var app = createApp(path.resolve(__dirname, 'fixtures/name.txt'), { cacheControl: false });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('cache-control'))
+        .expect(200, done);
+      })
+    })
   })
 
   describe('.sendFile(path, fn)', function () {


### PR DESCRIPTION
This also required that I export both examples' `app` object and make the jade's examples use of morgan dependent on `env`.
