### PR TITLE
Implementing classes using the new ES6 syntax (branch 5.0)

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -30,13 +30,6 @@ var join = path.join;
 var resolve = path.resolve;
 
 /**
- * Module exports.
- * @public
- */
-
-module.exports = View;
-
-/**
  * Initialize a new `View` with the given `name`.
  *
  * Options:
@@ -50,132 +43,112 @@ module.exports = View;
  * @public
  */
 
-function View(name, options) {
-  var opts = options || {};
+class View {
+  constructor(name, options) {
+    var opts = options || {};
 
-  this.defaultEngine = opts.defaultEngine;
-  this.ext = extname(name);
-  this.name = name;
-  this.root = opts.root;
+    this.defaultEngine = opts.defaultEngine;
+    this.ext = extname(name);
+    this.name = name;
+    this.root = opts.root;
 
-  if (!this.ext && !this.defaultEngine) {
-    throw new Error('No default engine was specified and no extension was provided.');
+    if (!this.ext && !this.defaultEngine) {
+      throw new Error('No default engine was specified and no extension was provided.');
+    }
+
+    var fileName = name;
+
+    if (!this.ext) {
+      // get extension from default engine name
+      this.ext = this.defaultEngine[0] !== '.'
+        ? '.' + this.defaultEngine
+        : this.defaultEngine;
+
+      fileName += this.ext;
+    }
+
+    if (!opts.engines[this.ext]) {
+      // load engine
+      opts.engines[this.ext] = require(this.ext.substr(1)).__express;
+    }
+
+    // store loaded engine
+    this.engine = opts.engines[this.ext];
+
+    // lookup path
+    this.path = this.lookup(fileName);
   }
 
-  var fileName = name;
+  /**
+   * Lookup view by the given `name`
+   *
+   * @param {string} name
+   * @private
+   */
 
-  if (!this.ext) {
-    // get extension from default engine name
-    this.ext = this.defaultEngine[0] !== '.'
-      ? '.' + this.defaultEngine
-      : this.defaultEngine;
+  lookup(name) {
+    var path;
+    var roots = [].concat(this.root);
 
-    fileName += this.ext;
+    debug('lookup "%s"', name);
+
+    for (var i = 0; i < roots.length && !path; i++) {
+      var root = roots[i];
+
+      // resolve the path
+      var loc = resolve(root, name);
+      var dir = dirname(loc);
+      var file = basename(loc);
+
+      // resolve the file
+      path = this.resolve(dir, file);
+    }
+
+    return path;
   }
 
-  if (!opts.engines[this.ext]) {
-    // load engine
-    opts.engines[this.ext] = require(this.ext.substr(1)).__express;
+  /**
+   * Render with the given options.
+   *
+   * @param {object} options
+   * @param {function} callback
+   * @private
+   */
+
+  render(options, callback) {
+    debug('render "%s"', this.path);
+    this.engine(this.path, options, callback);
   }
 
-  // store loaded engine
-  this.engine = opts.engines[this.ext];
+  /**
+   * Resolve the file within the given directory.
+   *
+   * @param {string} dir
+   * @param {string} file
+   * @private
+   */
 
-  // lookup path
-  this.path = this.lookup(fileName);
+  resolve(dir, file) {
+    var ext = this.ext;
+
+    // <path>.<ext>
+    var path = join(dir, file);
+    var stat = tryStat(path);
+
+    if (stat && stat.isFile()) {
+      return path;
+    }
+
+    // <path>/index.<ext>
+    path = join(dir, basename(file, ext), 'index' + ext);
+    stat = tryStat(path);
+
+    if (stat && stat.isFile()) {
+      return path;
+    }
+  }
+
 }
-
-/**
- * Lookup view by the given `name`
- *
- * @param {string} name
- * @private
- */
-
-View.prototype.lookup = function lookup(name) {
-  var path;
-  var roots = [].concat(this.root);
-
-  debug('lookup "%s"', name);
-
-  for (var i = 0; i < roots.length && !path; i++) {
-    var root = roots[i];
-
-    // resolve the path
-    var loc = resolve(root, name);
-    var dir = dirname(loc);
-    var file = basename(loc);
-
-    // resolve the file
-    path = this.resolve(dir, file);
-  }
-
-  return path;
-};
-
-/**
- * Render with the given options.
- *
- * @param {object} options
- * @param {function} callback
- * @private
- */
-
-View.prototype.render = function render(options, callback) {
-  var sync = true;
-
-  debug('render "%s"', this.path);
-
-  // render, normalizing sync callbacks
-  this.engine(this.path, options, function onRender() {
-    if (!sync) {
-      return callback.apply(this, arguments);
-    }
-
-    // copy arguments
-    var args = new Array(arguments.length);
-    var cntx = this;
-
-    for (var i = 0; i < arguments.length; i++) {
-      args[i] = arguments[i];
-    }
-
-    // force callback to be async
-    return process.nextTick(function renderTick() {
-      return callback.apply(cntx, args);
-    });
-  });
-
-  sync = false;
-};
-
-/**
- * Resolve the file within the given directory.
- *
- * @param {string} dir
- * @param {string} file
- * @private
- */
-
-View.prototype.resolve = function resolve(dir, file) {
-  var ext = this.ext;
-
-  // <path>.<ext>
-  var path = join(dir, file);
-  var stat = tryStat(path);
-
-  if (stat && stat.isFile()) {
-    return path;
-  }
-
-  // <path>/index.<ext>
-  path = join(dir, basename(file, ext), 'index' + ext);
-  stat = tryStat(path);
-
-  if (stat && stat.isFile()) {
-    return path;
-  }
-};
 
 /**
  * Return a stat, maybe.
@@ -194,3 +167,12 @@ function tryStat(path) {
     return undefined;
   }
 }
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = View;
+
+

--- a/lib/view.js
+++ b/lib/view.js
@@ -175,4 +175,3 @@ function tryStat(path) {
 
 module.exports = View;
 
-


### PR DESCRIPTION
I created a new PR to change the branches (5.0 -> 5.0).
Initial PR: https://github.com/expressjs/express/pull/3069

Original message: 
Hi, 

In my PhD research, I am using express in some experiments.

As a result, I detected the existence of at least 3 main "classes" in the current codebase (View, Route, Layer).

So, I decided to rewrite this code to follow the new syntax for classes provided by ECMAScript 2016, which I think is much more readable. All changes are just syntactical. I was also very careful to preserve the code style.
Finally, all tests are green in the migrated code.

Do you think it is worth to integrate these changes to the project?

Thank you
