### PR TITLE
Explicitly remove headers from 204 and 304 responses when using .end()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -209,6 +209,36 @@ res.send = function send(body) {
 };
 
 /**
+ * Ends the response process.
+ *
+ * Method comes from Node core, but we need to define it here
+ * so we can strip headers for 204 and 304 status codes.
+ *
+ * Examples:
+ *
+ *     res.end();
+ *
+ * @public
+ */
+
+res.end = function end() {
+  if (204 === this.statusCode || 304 === this.statusCode) {
+    this.removeHeader('Content-Type');
+    this.removeHeader('Content-Length');
+    this.removeHeader('Transfer-Encoding');
+  }
+
+  // we need to get original .end()
+  Object.getPrototypeOf(
+    Object.getPrototypeOf(
+      Object.getPrototypeOf(
+        Object.getPrototypeOf(this)
+      )
+    )
+  ).end.apply(this, arguments);
+}
+
+/**
  * Send JSON response.
  *
  * Examples:

--- a/test/res.end.js
+++ b/test/res.end.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var express = require('..');
+var methods = require('methods');
+var request = require('supertest');
+var utils = require('./support/utils');
+
+describe('res', function(){
+  describe('.end()', function(){
+    describe('when .statusCode is 204', function(){
+      it('should strip Content-* fields, Transfer-Encoding field, and body', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.status(204).set('Transfer-Encoding', 'chunked').end();
+        });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('Content-Type'))
+        .expect(utils.shouldNotHaveHeader('Content-Length'))
+        .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
+        .expect(204, '', done);
+      })
+    })
+
+    describe('when .statusCode is 304', function(){
+      it('should strip Content-* fields, Transfer-Encoding field, and body)', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.status(304).set('Transfer-Encoding', 'chunked').end();
+        });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('Content-Type'))
+        .expect(utils.shouldNotHaveHeader('Content-Length'))
+        .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
+        .expect(304, '', done);
+      })
+    })
+  })
+})


### PR DESCRIPTION
We need to remove that headers for requests issued with .end() like we do with .send().
