### PR TITLE
expose the matched routes for a request

### DIFF
--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('../..');
+var path = require('path');
 var logger = require('morgan');
 var app = express();
 
@@ -16,7 +17,7 @@ app.use(logger('dev'));
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // if you wanted to "prefix" you may use
 // the mounting feature of Connect, for example
@@ -24,13 +25,13 @@ app.use(express.static(__dirname + '/public'));
 // The mount-path "/static" is simply removed before
 // passing control to the express.static() middleware,
 // thus it serves the file correctly by ignoring "/static"
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 // if for some reason you want to serve files from
 // several directories, you can use express.static()
 // multiple times! Here we're passing "./public/css",
 // this will allow "GET /style.css" instead of "GET /css/style.css":
-app.use(express.static(__dirname + '/public/css'));
+app.use(express.static(path.join(__dirname, 'public', 'css')));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -267,6 +267,9 @@ proto.handle = function handle(req, res, out) {
       : layer.params;
     var layerPath = layer.path;
 
+    // Expose the definition of the route that was hit
+    req.matchedRoute = generateMatchedRoute(req.matchedRoute, layer.pathDefinition);
+
     // this should be done for the layer
     self.process_params(layer, paramcalled, req, res, function (err) {
       if (err) {
@@ -279,6 +282,16 @@ proto.handle = function handle(req, res, out) {
 
       trim_prefix(layer, layerError, layerPath, path);
     });
+  }
+
+  function generateMatchedRoute (prevMatch, curMatch) {
+    if (!prevMatch) {
+      return curMatch;
+    } else if (prevMatch === '/') {
+      return curMatch;
+    } else {
+      return prevMatch + curMatch;
+    }
   }
 
   function trim_prefix(layer, layerError, layerPath, path) {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -268,7 +268,8 @@ proto.handle = function handle(req, res, out) {
     var layerPath = layer.path;
 
     // Expose the definition of the route that was hit
-    req.matchedRoute = generateMatchedRoute(req.matchedRoute, layer.pathDefinition);
+    req.matchedRoutes = req.matchedRoutes ?
+      req.matchedRoutes.concat([layer.pathDefinition]) : [layer.pathDefinition];
 
     // this should be done for the layer
     self.process_params(layer, paramcalled, req, res, function (err) {
@@ -282,16 +283,6 @@ proto.handle = function handle(req, res, out) {
 
       trim_prefix(layer, layerError, layerPath, path);
     });
-  }
-
-  function generateMatchedRoute (prevMatch, curMatch) {
-    if (!prevMatch) {
-      return curMatch;
-    } else if (prevMatch === '/') {
-      return curMatch;
-    } else {
-      return prevMatch + curMatch;
-    }
   }
 
   function trim_prefix(layer, layerError, layerPath, path) {

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -42,6 +42,7 @@ function Layer(path, options, fn) {
   this.name = fn.name || '<anonymous>';
   this.params = undefined;
   this.path = undefined;
+  this.pathDefinition = path;
   this.regexp = pathRegexp(path, this.keys = [], opts);
 
   if (path === '/' && opts.end === false) {

--- a/test/Router.js
+++ b/test/Router.js
@@ -68,33 +68,33 @@ describe('Router', function(){
     router.handle({ url: '/', method: 'GET' }, { end: done });
   });
 
-  it('should expose the matched route on the req object', function (done) {
+  it('should expose the matched routes on the req object', function (done) {
     var router = new Router();
     var path = '/foo/:num';
 
     router.use(path, function (req, res) {
-      assert(req.matchedRoute);
-      assert.equal(req.matchedRoute, path);
+      assert(req.matchedRoutes);
+      assert.deepEqual(req.matchedRoutes, [path]);
       res.end();
     });
 
     router.handle({ url: '/foo/123', method: 'GET' }, {end: done});
   });
 
-  it('should expose the nested matched route on the req object', function (done) {
+  it('should expose the nested matched routes on the req object', function (done) {
     var layer1 = new Router();
     var layer2 = new Router();
     var layer3 = new Router();
 
     layer1.use(layer2);
     layer2.use('/foo/:num', layer3);
-    layer3.get('/bar/:num', function (req, res) {
-      assert.equal(req.matchedRoute, '/foo/:num/bar/:num');
+    layer3.get(/[0-9]/, function (req, res) {
+      assert.deepEqual(req.matchedRoutes, ['/', '/foo/:num', /[0-9]/]);
       res.end();
     });
 
     // Simulate request entering "app" or "base" later
-    layer1.handle({ url: '/foo/123/bar/321', method: 'GET' }, {end: done});
+    layer1.handle({ url: '/foo/123/321', method: 'GET' }, {end: done});
   });
 
   describe('.handle', function(){

--- a/test/Router.js
+++ b/test/Router.js
@@ -68,6 +68,35 @@ describe('Router', function(){
     router.handle({ url: '/', method: 'GET' }, { end: done });
   });
 
+  it('should expose the matched route on the req object', function (done) {
+    var router = new Router();
+    var path = '/foo/:num';
+
+    router.use(path, function (req, res) {
+      assert(req.matchedRoute);
+      assert.equal(req.matchedRoute, path);
+      res.end();
+    });
+
+    router.handle({ url: '/foo/123', method: 'GET' }, {end: done});
+  });
+
+  it('should expose the nested matched route on the req object', function (done) {
+    var layer1 = new Router();
+    var layer2 = new Router();
+    var layer3 = new Router();
+
+    layer1.use(layer2);
+    layer2.use('/foo/:num', layer3);
+    layer3.get('/bar/:num', function (req, res) {
+      assert.equal(req.matchedRoute, '/foo/:num/bar/:num');
+      res.end();
+    });
+
+    // Simulate request entering "app" or "base" later
+    layer1.handle({ url: '/foo/123/bar/321', method: 'GET' }, {end: done});
+  });
+
   describe('.handle', function(){
     it('should dispatch', function(done){
       var router = new Router();


### PR DESCRIPTION
I'm open to suggestions on improving this one. Basically if a route is "/foo/:num/bar/:num" and a client requests "/foo/12/bar/32" I would like to be able to see that they hit "/foo/:num/bar/:num":

Here's how this PR does that:

``` js
app.get('/foo/:num/bar/:num', function (req, res) {
  var matched = req.matchedRoute; // "/foo/:num/bar/:num"
  var originalUrl = req.originalUrl; // "/foo/12/bar/32"
});
```

It works for nested routes also. This can be seen in the new tests added.

It would also be possible to expose an Array instead if desirable, e.g `['/foo/:num/bar/:num']` with each matched layer/router inside.
