### PR TITLE
Throw TypeError if argument passed to res.status is null or undefined

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -39,7 +39,7 @@ var res = module.exports = {
  */
 
 res.status = function(code){
-  if (code === undefined || code === null) {
+  if (code == null) {
     throw new TypeError('Invalid status code.');
   }
   this.statusCode = code;

--- a/lib/response.js
+++ b/lib/response.js
@@ -39,6 +39,9 @@ var res = module.exports = {
  */
 
 res.status = function(code){
+  if (code === undefined || code === null) {
+    throw new TypeError('Invalid status code.');
+  }
   this.statusCode = code;
   return this;
 };

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -16,5 +16,16 @@ describe('res', function(){
       .expect('Created')
       .expect(201, done);
     })
+
+    it('should throw a TypeError if code is null or undefined', function(done){
+     var app = express();
+     app.use(function(req, res){
+         res.status(null).end('Created');
+     });
+
+     request(app)
+       .get('/')
+       .expect(500, done);
+    })
   })
-})
+});


### PR DESCRIPTION
It's fix for #2795 
