### PR TITLE
Options for Engines

### DIFF
--- a/examples/view-constructor/github-view.js
+++ b/examples/view-constructor/github-view.js
@@ -21,7 +21,7 @@ module.exports = GithubView;
 function GithubView(name, options){
   this.name = name;
   options = options || {};
-  this.engine = options.engines[extname(name)];
+  this.engine = options.engines[extname(name)].callback;
   // "root" is the app.set('views') setting, however
   // in your own implementation you could ignore this
   this.path = '/' + options.root + '/master/' + name;

--- a/lib/application.js
+++ b/lib/application.js
@@ -285,7 +285,7 @@ app.route = function route(path) {
  * @public
  */
 
-app.engine = function engine(ext, fn) {
+app.engine = function engine(ext, fn, options) {
   if (typeof fn !== 'function') {
     throw new Error('callback function required');
   }
@@ -296,7 +296,10 @@ app.engine = function engine(ext, fn) {
     : ext;
 
   // store engine
-  this.engines[extension] = fn;
+  this.engines[extension] = {
+    callback: fn,
+    options: options || this.get('view engine options') || {}
+  };
 
   return this;
 };
@@ -554,6 +557,7 @@ app.render = function render(name, options, callback) {
 
     view = new View(name, {
       defaultEngine: this.get('view engine'),
+      defaultEngineOptions: this.get('view engine options') || {},
       root: this.get('views'),
       engines: engines
     });

--- a/lib/view.js
+++ b/lib/view.js
@@ -54,6 +54,7 @@ function View(name, options) {
   var opts = options || {};
 
   this.defaultEngine = opts.defaultEngine;
+  this.defaultEngineOptions = opts.defaultEngineOptions;
   this.ext = extname(name);
   this.name = name;
   this.root = opts.root;
@@ -75,14 +76,18 @@ function View(name, options) {
 
   if (!opts.engines[this.ext]) {
     // load engine
-    opts.engines[this.ext] = require(this.ext.substr(1)).__express;
+    opts.engines[this.ext] = {
+      callback: require(this.ext.substr(1)).__express,
+      options: this.defaultEngineOptions
+    };
   }
 
   // store loaded engine
-  this.engine = opts.engines[this.ext];
+  var engine = opts.engines[this.ext];
+  this.engine = engine.callback;
 
   // lookup path
-  this.path = this.lookup(fileName);
+  this.path = engine.options.noFileSystem ? name : this.lookup(fileName);
 }
 
 /**

--- a/test/app.engine.js
+++ b/test/app.engine.js
@@ -11,7 +11,7 @@ function render(path, options, fn) {
 }
 
 describe('app', function(){
-  describe('.engine(ext, fn)', function(){
+  describe('.engine(ext, fn, options)', function(){
     it('should map a template engine', function(done){
       var app = express();
 
@@ -73,6 +73,49 @@ describe('app', function(){
       app.render('user', function(err, str){
         if (err) return done(err);
         str.should.equal('<p>tobi</p>');
+        done();
+      })
+    })
+    
+    it('should throw when no options are specified and the file does not exist', function(done){
+      var app = express();
+
+      app.set('views', __dirname + '/fixtures');
+      app.engine('.html', render);
+      app.set('view engine', '.html');
+
+      app.render('nonexistent', function(err, str){
+        if (err) return done();
+        done(new Error('No Error was thrown despite missing file'));
+      })
+    })
+
+    it('should throw when noFileSystem is explicitly set to false and the file does not exist', function(done){
+      var app = express();
+
+      app.set('views', __dirname + '/fixtures');
+      app.engine('.html', render, { noFileSystem: false });
+      app.set('view engine', '.html');
+
+      app.render('nonexistent', function(err, str){
+        if (err) return done();
+        done(new Error('No Error was thrown despite missing file'));
+      })
+    })
+
+    it('should work when noFileSystem is set to true and the file does not exist', function(done){
+      var app = express();
+      var fileName = 'nonexistent';
+
+      app.set('views', __dirname + '/fixtures');
+      app.engine('.html', function(name, options, fn) {
+        name.should.equal(fileName);
+        done();
+      }, { noFileSystem: true });
+      app.set('view engine', '.html');
+
+      app.render(fileName, function(err, str){
+        if (err) return done(err);
         done();
       })
     })


### PR DESCRIPTION
This is inspired by #2982. It adds an option object to engines, and adds an option for bypassing the filesystem mapping and checks done in view.js.

Alternatively, this option could be used to bypass the `if (!view.path) {` check in application.js:565, or even to assign `view.path = name` somewhere around there.

Either way, I think it'd be a good idea to have options for engines. 
Put into the 5.0 branch because it's a breaking change.
