### PR TITLE
Issue #3129 : few typos fixes

### DIFF
--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('../..');
+var path = require('path');
 var logger = require('morgan');
 var app = express();
 
@@ -16,7 +17,7 @@ app.use(logger('dev'));
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // if you wanted to "prefix" you may use
 // the mounting feature of Connect, for example
@@ -24,13 +25,13 @@ app.use(express.static(__dirname + '/public'));
 // The mount-path "/static" is simply removed before
 // passing control to the express.static() middleware,
 // thus it serves the file correctly by ignoring "/static"
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 // if for some reason you want to serve files from
 // several directories, you can use express.static()
 // multiple times! Here we're passing "./public/css",
 // this will allow "GET /style.css" instead of "GET /css/style.css":
-app.use(express.static(__dirname + '/public/css'));
+app.use(express.static(path.join(__dirname, 'public', 'css')));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/test/app.options.js
+++ b/test/app.options.js
@@ -72,7 +72,7 @@ describe('OPTIONS', function(){
     .expect(200, 'GET,HEAD', done);
   })
 
-  describe('when error occurs in respone handler', function () {
+  describe('when error occurs in response handler', function () {
     it('should pass error to callback', function (done) {
       var app = express();
       var router = express.Router();

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -757,7 +757,7 @@ describe('app.router', function(){
       .expect('editing tj (old)', cb);
     })
 
-    it('should work inside literal paranthesis', function(done){
+    it('should work inside literal parenthesis', function(done){
       var app = express();
 
       app.get('/:user\\(:op\\)', function(req, res){

--- a/test/req.acceptsEncoding.js
+++ b/test/req.acceptsEncoding.js
@@ -4,7 +4,7 @@ var express = require('../')
 
 describe('req', function(){
   describe('.acceptsEncoding', function(){
-    it('should be true if encoding accpeted', function(done){
+    it('should be true if encoding accepted', function(done){
       var app = express();
 
       app.use(function(req, res){
@@ -19,7 +19,7 @@ describe('req', function(){
       .expect(200, done);
     })
 
-    it('should be false if encoding not accpeted', function(done){
+    it('should be false if encoding not accepted', function(done){
       var app = express();
 
       app.use(function(req, res){

--- a/test/req.acceptsEncodings.js
+++ b/test/req.acceptsEncodings.js
@@ -4,7 +4,7 @@ var express = require('../')
 
 describe('req', function(){
   describe('.acceptsEncodingss', function(){
-    it('should be true if encoding accpeted', function(done){
+    it('should be true if encoding accepted', function(done){
       var app = express();
 
       app.use(function(req, res){
@@ -19,7 +19,7 @@ describe('req', function(){
       .expect(200, done);
     })
 
-    it('should be false if encoding not accpeted', function(done){
+    it('should be false if encoding not accepted', function(done){
       var app = express();
 
       app.use(function(req, res){

--- a/test/req.acceptsLanguage.js
+++ b/test/req.acceptsLanguage.js
@@ -4,7 +4,7 @@ var express = require('../')
 
 describe('req', function(){
   describe('.acceptsLanguage', function(){
-    it('should be true if language accpeted', function(done){
+    it('should be true if language accepted', function(done){
       var app = express();
 
       app.use(function(req, res){
@@ -19,7 +19,7 @@ describe('req', function(){
       .expect(200, done);
     })
 
-    it('should be false if language not accpeted', function(done){
+    it('should be false if language not accepted', function(done){
       var app = express();
 
       app.use(function(req, res){

--- a/test/req.acceptsLanguages.js
+++ b/test/req.acceptsLanguages.js
@@ -4,7 +4,7 @@ var express = require('../')
 
 describe('req', function(){
   describe('.acceptsLanguages', function(){
-    it('should be true if language accpeted', function(done){
+    it('should be true if language accepted', function(done){
       var app = express();
 
       app.use(function(req, res){
@@ -19,7 +19,7 @@ describe('req', function(){
       .expect(200, done);
     })
 
-    it('should be false if language not accpeted', function(done){
+    it('should be false if language not accepted', function(done){
       var app = express();
 
       app.use(function(req, res){


### PR DESCRIPTION
test/app.options.js
`respone`  => `response `

test/app.router.js
`paranthesis` => `paranthesis `

test/req.acceptsEncoding.js, test/req.acceptsEncodings.js, test/req.acceptsLanguage.js, test/req.acceptsLanguages.js
`accpeted` => `accepted` 