### PR TITLE
Gracefully handle invalid status codes

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -57,7 +57,11 @@ var charsetRegExp = /;\s*charset\s*=/;
  */
 
 res.status = function status(code) {
-  this.statusCode = code;
+  var statusCode = parseInt(code, 10);
+  if (statusCode < 100 || statusCode > 999) {
+    statusCode = 500;
+  }
+  this.statusCode = statusCode;
   return this;
 };
 
@@ -112,10 +116,10 @@ res.send = function send(body) {
     // res.send(body, status) backwards compat
     if (typeof arguments[0] !== 'number' && typeof arguments[1] === 'number') {
       deprecate('res.send(body, status): Use res.status(status).send(body) instead');
-      this.statusCode = arguments[1];
+      this.status(arguments[1]);
     } else {
       deprecate('res.send(status, body): Use res.status(status).send(body) instead');
-      this.statusCode = arguments[0];
+      this.status(arguments[0]);
       chunk = arguments[1];
     }
   }
@@ -128,8 +132,8 @@ res.send = function send(body) {
     }
 
     deprecate('res.send(status): Use res.sendStatus(status) instead');
-    this.statusCode = chunk;
-    chunk = statusCodes[chunk];
+    this.status(chunk);
+    chunk = statusCodes[this.statusCode] || String(this.statusCode);
   }
 
   switch (typeof chunk) {
@@ -228,10 +232,10 @@ res.json = function json(obj) {
     // res.json(body, status) backwards compat
     if (typeof arguments[1] === 'number') {
       deprecate('res.json(obj, status): Use res.status(status).json(obj) instead');
-      this.statusCode = arguments[1];
+      this.status(arguments[1]);
     } else {
       deprecate('res.json(status, obj): Use res.status(status).json(obj) instead');
-      this.statusCode = arguments[0];
+      this.status(arguments[0]);
       val = arguments[1];
     }
   }
@@ -270,10 +274,10 @@ res.jsonp = function jsonp(obj) {
     // res.json(body, status) backwards compat
     if (typeof arguments[1] === 'number') {
       deprecate('res.jsonp(obj, status): Use res.status(status).json(obj) instead');
-      this.statusCode = arguments[1];
+      this.status(arguments[1]);
     } else {
       deprecate('res.jsonp(status, obj): Use res.status(status).jsonp(obj) instead');
-      this.statusCode = arguments[0];
+      this.status(arguments[0]);
       val = arguments[1];
     }
   }
@@ -334,11 +338,10 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
-  var body = statusCodes[statusCode] || String(statusCode);
-
-  this.statusCode = statusCode;
+  this.status(statusCode);
   this.type('txt');
-
+  
+  var body = statusCodes[this.statusCode] || String(this.statusCode);
   return this.send(body);
 };
 
@@ -890,7 +893,7 @@ res.redirect = function redirect(url) {
   });
 
   // Respond
-  this.statusCode = status;
+  this.status(status);
   this.set('Content-Length', Buffer.byteLength(body));
 
   if (this.req.method === 'HEAD') {

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -16,5 +16,41 @@ describe('res', function(){
       .expect('Created')
       .expect(201, done);
     })
+    
+    it('should set the status to 500 if invalid', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.status(10000).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done);
+    })
+    
+    it('should handle numeric strings', function(done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.status('400').end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(400, done);
+    })
+    
+    it('should handle floats as integers', function(done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.status(404.04).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect(404, done);
+    })
   })
 })


### PR DESCRIPTION
Currently if an invalid status code is sent in the response, node throws an exception on `writeHead` that afaik can't be handled in express. Instead it just leads to a hanging request. I realize that it's best practice for people to only send valid status codes, but I have seen:

```if (err) res.sendStatus(err.code || 500)```

far too many times.

This change is similar to https://github.com/expressjs/express/pull/2797, which I think is ultimately a better solution. But this fix should be non breaking.