### PR TITLE
debug require engine

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -75,6 +75,7 @@ function View(name, options) {
 
   if (!opts.engines[this.ext]) {
     // load engine
+    debug('require "%s"', this.ext.substr(1));
     opts.engines[this.ext] = require(this.ext.substr(1)).__express;
   }
 


### PR DESCRIPTION
Requiring new engine can take more than 300ms, it make sense to include it in debug to inform developers whence the delays comes from.