### PR TITLE
Using let instead of var to declare the counter in the for loop.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -321,7 +321,7 @@ app.param = function param(name, fn) {
   this.lazyrouter();
 
   if (Array.isArray(name)) {
-    for (var i = 0; i < name.length; i++) {
+    for (let i = 0; i < name.length; i++) {
       this.param(name[i], fn);
     }
 
@@ -499,7 +499,7 @@ app.all = function all(path) {
   var route = this._router.route(path);
   var args = slice.call(arguments, 1);
 
-  for (var i = 0; i < methods.length; i++) {
+  for (let i = 0; i < methods.length; i++) {
     route[methods[i]].apply(route, args);
   }
 


### PR DESCRIPTION
Using let instead of var to declare the counter in the for loop in order to keep the counter local to the loop.