### PR TITLE
Fix unnecessary semicolon.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -499,4 +499,4 @@ function defineGetter(obj, name, getter) {
     enumerable: true,
     get: getter
   });
-};
+}


### PR DESCRIPTION
At the end of `/lib/request.js` I found an unnecessary semicolon which does not exist in other files.
There is no effect on the operation in particular.
However, in order to unify the format, I deleted it.