### PR TITLE
Support "Accept" header content preference in error page example

### DIFF
--- a/examples/error-pages/index.js
+++ b/examples/error-pages/index.js
@@ -60,20 +60,20 @@ app.get('/500', function(req, res, next){
 app.use(function(req, res, next){
   res.status(404);
 
-  // respond with html page
-  if (req.accepts('html')) {
-    res.render('404', { url: req.url });
-    return;
-  }
+  switch (req.accepts(['html', 'json'])) {
+    case "html":
+      // respond with html page
+      res.render('404', { url: req.url });
+      break;
+    case "json":
+      // respond with json
+      res.send({ error: 'Not found' });
+      break;
+    default:
+      // default to plain-text. send()
+      res.type('txt').send('Not found');
 
-  // respond with json
-  if (req.accepts('json')) {
-    res.send({ error: 'Not found' });
-    return;
   }
-
-  // default to plain-text. send()
-  res.type('txt').send('Not found');
 });
 
 // error-handling middleware, take the same form

--- a/examples/error-pages/index.js
+++ b/examples/error-pages/index.js
@@ -60,20 +60,17 @@ app.get('/500', function(req, res, next){
 app.use(function(req, res, next){
   res.status(404);
 
-  switch (req.accepts(['html', 'json'])) {
-    case "html":
-      // respond with html page
-      res.render('404', { url: req.url });
-      break;
-    case "json":
-      // respond with json
-      res.send({ error: 'Not found' });
-      break;
-    default:
-      // default to plain-text. send()
+  res.format({
+    text: function() {
       res.type('txt').send('Not found');
-
-  }
+    },
+    html: function() {
+      res.render('404', { url: req.url });
+    },
+    json: function() {
+      res.send({ error: 'Not found' });
+    }
+  });
 });
 
 // error-handling middleware, take the same form


### PR DESCRIPTION
I experienced this confusion when testing the 404 example with Backbone.js (which internally uses jquery).  

When Backbone calls `$.getJSON`, the `Accept` header is set to `application/json, text/javascript, */*; q=0.01`.  However, an HTML response is returned rather than a JSON response.

To prevent confusion for others it would be preferable to use the array argument type, which will  select the best match for media type, properly returning a JSON response if `application/json` is first in the "Accept" request-header list. 