### PR TITLE
test: rename 'decode querystring' to 'decode params'

### DIFF
--- a/test/app.router.js
+++ b/test/app.router.js
@@ -90,7 +90,7 @@ describe('app.router', function(){
     });
   })
 
-  describe('decode querystring', function(){
+  describe('decode params', function(){
     it('should decode correct params', function(done){
       var app = express();
 


### PR DESCRIPTION
Rename 'decode querystring' to 'decode params' in test/app.router.js

This is a fix for https://github.com/expressjs/express/issues/3194