### PR TITLE
examples: fix pbkdf2 invocation

### DIFF
--- a/examples/auth/pass.js
+++ b/examples/auth/pass.js
@@ -31,7 +31,7 @@ var iterations = 12000;
 
 exports.hash = function (pwd, salt, fn) {
   if (3 == arguments.length) {
-    crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+    crypto.pbkdf2(pwd, salt, iterations, len, 'sha256', function(err, hash){
       fn(err, hash.toString('base64'));
     });
   } else {
@@ -39,7 +39,7 @@ exports.hash = function (pwd, salt, fn) {
     crypto.randomBytes(len, function(err, salt){
       if (err) return fn(err);
       salt = salt.toString('base64');
-      crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+      crypto.pbkdf2(pwd, salt, iterations, len, 'sha256', function(err, hash){
         if (err) return fn(err);
         fn(null, salt, hash.toString('base64'));
       });


### PR DESCRIPTION
Calling `crypto.pbkdf2()` without a digest has been deprecated in Node and is scheduled to be broken in Node 8.

Fix this by actually passing a digest.

ref: https://github.com/nodejs/node/pull/11305

**Note**: `npm test` still fails with Node master for me, but I’m on it :S