### PR TITLE
Use node's `path.join` in examples (#3046)

### DIFF
--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('../..');
+var path = require('path');
 var logger = require('morgan');
 var app = express();
 
@@ -16,7 +17,7 @@ app.use(logger('dev'));
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // if you wanted to "prefix" you may use
 // the mounting feature of Connect, for example
@@ -24,13 +25,13 @@ app.use(express.static(__dirname + '/public'));
 // The mount-path "/static" is simply removed before
 // passing control to the express.static() middleware,
 // thus it serves the file correctly by ignoring "/static"
-app.use('/static', express.static(__dirname + '/public'));
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 // if for some reason you want to serve files from
 // several directories, you can use express.static()
 // multiple times! Here we're passing "./public/css",
 // this will allow "GET /style.css" instead of "GET /css/style.css":
-app.use(express.static(__dirname + '/public/css'));
+app.use(express.static(path.join(__dirname, 'public', 'css')));
 
 app.listen(3000);
 console.log('listening on port 3000');


### PR DESCRIPTION
closes #3046