### PR TITLE
Remove direct http dependency

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -17,7 +17,6 @@ var finalhandler = require('finalhandler');
 var methods = require('methods');
 var debug = require('debug')('express:application');
 var View = require('./view');
-var http = require('http');
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
@@ -607,7 +606,7 @@ app.render = function render(name, options, callback) {
  */
 
 app.listen = function listen () {
-  var server = http.createServer(this)
+  var server = this.createServer(this)
   var args = Array.prototype.slice.call(arguments)
   if (typeof args[args.length - 1] === 'function') {
     var done = args[args.length - 1] = once(args[args.length - 1])

--- a/lib/express.js
+++ b/lib/express.js
@@ -21,6 +21,30 @@ var req = require('./request');
 var res = require('./response');
 
 /**
+ * Only reqire http when requested
+ */
+var http = {}
+var _http
+Object.defineProperty(http, 'IncomingMessage', {
+  get: function () {
+    _http = _http || require('http')
+    return _http.IncomingMessage
+  }
+})
+Object.defineProperty(http, 'ServerResponse', {
+  get: function () {
+    _http = _http || require('http')
+    return _http.ServerResponse
+  }
+})
+Object.defineProperty(http, 'createServer', {
+  get: function () {
+    _http = _http || require('http')
+    return _http.createServer
+  }
+})
+
+/**
  * Expose `createApplication()`.
  */
 
@@ -33,7 +57,12 @@ exports = module.exports = createApplication;
  * @api public
  */
 
-function createApplication() {
+function createApplication (opts) {
+  var options = opts || {}
+  options.reqProto = options.reqProto || http.IncomingMessage.prototype
+  options.resProto = options.resProto || http.ServerResponse.prototype
+  options.createServer = options.createServer || http.createServer
+
   var app = function(req, res, next) {
     app.handle(req, res, next);
   };
@@ -41,13 +70,13 @@ function createApplication() {
   mixin(app, EventEmitter.prototype, false);
   mixin(app, proto, false);
 
+  app.createServer = options.createServer
   // expose the prototype that will get set on requests
-  app.request = Object.create(req, {
+  app.request = Object.create(req(options.reqProto), {
     app: { configurable: true, enumerable: true, writable: true, value: app }
   })
-
   // expose the prototype that will get set on responses
-  app.response = Object.create(res, {
+  app.response = Object.create(res(options.resProto), {
     app: { configurable: true, enumerable: true, writable: true, value: app }
   })
 
@@ -60,8 +89,8 @@ function createApplication() {
  */
 
 exports.application = proto;
-exports.request = req;
-exports.response = res;
+exports.request = req.proto
+exports.response = res.proto
 
 /**
  * Expose constructors.

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,25 +16,25 @@
 var accepts = require('accepts');
 var isIP = require('net').isIP;
 var typeis = require('type-is');
-var http = require('http');
 var fresh = require('fresh');
 var parseRange = require('range-parser');
 var parse = require('parseurl');
 var proxyaddr = require('proxy-addr');
+var setPrototypeOf = require('setprototypeof')
 
 /**
  * Request prototype.
  * @public
  */
-
-var req = Object.create(http.IncomingMessage.prototype)
+exports = module.exports = function (proto) {
+  return setPrototypeOf(req, proto)
+}
 
 /**
  * Module exports.
  * @public
  */
-
-module.exports = req
+var req = module.exports.proto = {}
 
 /**
  * Return request header.

--- a/lib/response.js
+++ b/lib/response.js
@@ -18,7 +18,6 @@ var createError = require('http-errors')
 var deprecate = require('depd')('express');
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
-var http = require('http');
 var onFinished = require('on-finished');
 var mime = require('mime-types')
 var path = require('path');
@@ -34,20 +33,21 @@ var send = require('send');
 var extname = path.extname;
 var resolve = path.resolve;
 var vary = require('vary');
+var setPrototypeOf = require('setprototypeof')
 
 /**
  * Response prototype.
  * @public
  */
-
-var res = Object.create(http.ServerResponse.prototype)
+exports = module.exports = function (proto) {
+  return setPrototypeOf(res, proto)
+}
 
 /**
  * Module exports.
  * @public
  */
-
-module.exports = res
+var res = module.exports.proto = {}
 
 /**
  * Module variables.


### PR DESCRIPTION
I think this might resolve the issues brought up in #2812 and #3206, and also some of what we talked about at the most recent TC meeting for compat in the browser.  The goal here is that you can do:

```javascript
var express = require('express')
var uws = require('uws')
var app = express({
  reqProto: uws.http.getRequestPrototype(),
  resProto: uws.http.getResponsePrototype(),
  createServer: uws.http.createServer
})
```

In the long run, I think this is also what I need for my Nighthawk project as well, so IMO it is a good way forward.  But let me know your thoughts! 

CC: @dougwilson, @alexhultman, @blakeembrey