### PR TITLE
Replace http.STATUS_CODES with the statuses module

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -25,7 +25,7 @@ var sign = require('cookie-signature').sign;
 var normalizeType = require('./utils').normalizeType;
 var normalizeTypes = require('./utils').normalizeTypes;
 var setCharset = require('./utils').setCharset;
-var statusCodes = http.STATUS_CODES;
+var statuses = require('statuses')
 var cookie = require('cookie');
 var send = require('send');
 var extname = path.extname;
@@ -129,7 +129,7 @@ res.send = function send(body) {
 
     deprecate('res.send(status): Use res.sendStatus(status) instead');
     this.statusCode = chunk;
-    chunk = statusCodes[chunk];
+    chunk = statuses[chunk];
   }
 
   switch (typeof chunk) {
@@ -334,7 +334,7 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
-  var body = statusCodes[statusCode] || String(statusCode);
+  var body = statuses[statusCode] || String(statusCode)
 
   this.statusCode = statusCode;
   this.type('txt');
@@ -876,12 +876,12 @@ res.redirect = function redirect(url) {
   // Support text/{plain,html} by default
   this.format({
     text: function(){
-      body = statusCodes[status] + '. Redirecting to ' + address;
+      body = statuses[status] + '. Redirecting to ' + address
     },
 
     html: function(){
       var u = escapeHtml(address);
-      body = '<p>' + statusCodes[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>';
+      body = '<p>' + statuses[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>'
     },
 
     default: function(){

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "range-parser": "~1.2.0",
     "send": "0.14.2",
     "serve-static": "~1.11.2",
+    "statuses": "~1.3.1",
     "type-is": "~1.6.14",
     "utils-merge": "1.0.0",
     "vary": "~1.1.0"

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -1,5 +1,4 @@
 
-var http = require('http');
 var express = require('..');
 var request = require('supertest');
 var utils = require('./support/utils');
@@ -104,7 +103,7 @@ describe('res', function(){
       .set('Accept', 'text/html')
       .expect('Content-Type', /html/)
       .expect('Location', 'http://google.com')
-      .expect(302, '<p>' + http.STATUS_CODES[302] + '. Redirecting to <a href="http://google.com">http://google.com</a></p>', done);
+      .expect(302, '<p>Found. Redirecting to <a href="http://google.com">http://google.com</a></p>', done)
     })
 
     it('should escape the url', function(done){
@@ -120,7 +119,7 @@ describe('res', function(){
       .set('Accept', 'text/html')
       .expect('Content-Type', /html/)
       .expect('Location', '%3Cla\'me%3E')
-      .expect(302, '<p>' + http.STATUS_CODES[302] + '. Redirecting to <a href="%3Cla&#39;me%3E">%3Cla&#39;me%3E</a></p>', done)
+      .expect(302, '<p>Found. Redirecting to <a href="%3Cla&#39;me%3E">%3Cla&#39;me%3E</a></p>', done)
     })
 
     it('should include the redirect type', function(done){
@@ -152,7 +151,7 @@ describe('res', function(){
       .set('Accept', 'text/plain, */*')
       .expect('Content-Type', /plain/)
       .expect('Location', 'http://google.com')
-      .expect(302, http.STATUS_CODES[302] + '. Redirecting to http://google.com', done);
+      .expect(302, 'Found. Redirecting to http://google.com', done)
     })
 
     it('should encode the url', function(done){
@@ -168,7 +167,7 @@ describe('res', function(){
       .set('Accept', 'text/plain, */*')
       .expect('Content-Type', /plain/)
       .expect('Location', 'http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E')
-      .expect(302, http.STATUS_CODES[302] + '. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E', done)
+      .expect(302, 'Found. Redirecting to http://example.com/?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E', done)
     })
 
     it('should include the redirect type', function(done){


### PR DESCRIPTION
Replaced usage of core `http.STATUS_CODES` with the list from the `statuses` module.  This was pulled out from #3213 as recommended by @dougwilson in a side conversation.  For posterity, it is known that it might be considered a "breaking" change because it changes the response text, which is why the tests were breaking.

@dougwilson I couldn't remember if you said to make the PR against 5.0 and backport it, or against 4.0 and cherry-pick it forward, I know we mentioned both ways.  Let me know if I did this the wrong way and I can fix it.