### PR TITLE
Call callback once on listen error

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -24,6 +24,7 @@ var compileTrust = require('./utils').compileTrust;
 var flatten = require('array-flatten').flatten
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
+var once = require('once')
 var Router = require('router');
 var setPrototypeOf = require('setprototypeof')
 
@@ -605,10 +606,15 @@ app.render = function render(name, options, callback) {
  * @public
  */
 
-app.listen = function listen() {
-  var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
-};
+app.listen = function listen () {
+  var server = http.createServer(this)
+  var args = Array.prototype.slice.call(arguments)
+  if (typeof args[args.length - 1] === 'function') {
+    var done = args[args.length - 1] = once(args[args.length - 1])
+    server.once('error', done)
+  }
+  return server.listen.apply(server, args)
+}
 
 /**
  * Log error using console.error.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "methods": "~1.1.2",
     "mime-types": "~2.1.34",
     "on-finished": "2.4.1",
+    "once": "1.4.0",
     "parseurl": "~1.3.3",
     "path-is-absolute": "1.0.1",
     "proxy-addr": "~2.0.7",

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var express = require('../')
+var assert = require('assert')
 
 describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
@@ -9,5 +10,18 @@ describe('app.listen()', function(){
     var server = app.listen(0, function () {
       server.close(done)
     });
+  })
+  it('should callback on HTTP server errors', function (done) {
+    var app1 = express()
+    var app2 = express()
+
+    var server1 = app1.listen(0, function (err) {
+      assert(!err)
+      app2.listen(server1.address().port, function (err) {
+        assert(err.code === 'EADDRINUSE')
+        server1.close()
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
This is a redo of #2623.  Probably didn't need a new PR, but I took a new direction by using the `once` module, and only binding to the error event.  I think this is slightly more elegant than the previous PR.  As discussed, this is a breaking change, so can only land in a 5.x branch.