### PR TITLE
Settings functionality moved out of core

### DIFF
--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -11,8 +11,8 @@ var app = module.exports = express();
 
 // config
 
-app.set('view engine', 'ejs');
-app.set('views', __dirname + '/views');
+app.settings.set('view engine', 'ejs');
+app.settings.set('views', __dirname + '/views');
 
 // middleware
 

--- a/examples/ejs/index.js
+++ b/examples/ejs/index.js
@@ -21,12 +21,12 @@ app.engine('.html', require('ejs').__express);
 
 // Optional since express defaults to CWD/views
 
-app.set('views', __dirname + '/views');
+app.settings.set('views', __dirname + '/views');
 
 // Without this you would need to
 // supply the extension to res.render()
 // ex: res.render('users.html').
-app.set('view engine', 'html');
+app.settings.set('view engine', 'html');
 
 // Dummy users
 var users = [

--- a/examples/error-pages/index.js
+++ b/examples/error-pages/index.js
@@ -8,17 +8,17 @@ var logger = require('morgan');
 var silent = 'test' == process.env.NODE_ENV;
 
 // general config
-app.set('views', __dirname + '/views');
-app.set('view engine', 'ejs');
+app.settings.set('views', __dirname + '/views');
+app.settings.set('view engine', 'ejs');
 
 // our custom "verbose errors" setting
 // which we can use in the templates
 // via settings['verbose errors']
-app.enable('verbose errors');
+app.settings.enable('verbose errors');
 
 // disable them in production
 // use $ NODE_ENV=production node examples/error-pages
-if ('production' == app.settings.env) app.disable('verbose errors');
+if ('production' == app.settings.get('env')) app.settings.disable('verbose errors');
 
 silent || app.use(logger('dev'));
 

--- a/examples/error/index.js
+++ b/examples/error/index.js
@@ -5,7 +5,7 @@
 var express = require('../../');
 var logger = require('morgan');
 var app = module.exports = express();
-var test = app.get('env') == 'test';
+var test = app.settings.get('env') == 'test';
 
 if (!test) app.use(logger('dev'));
 

--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -21,10 +21,10 @@ app.engine('md', function(path, options, fn){
   });
 });
 
-app.set('views', __dirname + '/views');
+app.settings.set('views', __dirname + '/views');
 
 // make it the default so we dont need .md
-app.set('view engine', 'md');
+app.settings.set('view engine', 'md');
 
 app.get('/', function(req, res){
   res.render('index', { title: 'Markdown Example' });

--- a/examples/mvc/index.js
+++ b/examples/mvc/index.js
@@ -14,10 +14,10 @@ var app = module.exports = express();
 
 // set our default template engine to "jade"
 // which prevents the need for extensions
-app.set('view engine', 'jade');
+app.settings.set('view engine', 'jade');
 
 // set views for error and 404 pages
-app.set('views', __dirname + '/views');
+app.settings.set('views', __dirname + '/views');
 
 // define a custom res.message() method
 // which stores messages in the session

--- a/examples/mvc/lib/boot.js
+++ b/examples/mvc/lib/boot.js
@@ -19,8 +19,8 @@ module.exports = function(parent, options){
     var path;
 
     // allow specifying the view engine
-    if (obj.engine) app.set('view engine', obj.engine);
-    app.set('views', __dirname + '/../controllers/' + name + '/views');
+    if (obj.engine) app.settings.set('view engine', obj.engine);
+    app.settings.set('views', __dirname + '/../controllers/' + name + '/views');
 
     // generate routes based
     // on the exported methods

--- a/examples/route-separation/index.js
+++ b/examples/route-separation/index.js
@@ -16,8 +16,8 @@ module.exports = app;
 
 // Config
 
-app.set('view engine', 'jade');
-app.set('views', __dirname + '/views');
+app.settings.set('view engine', 'jade');
+app.settings.set('views', __dirname + '/views');
 
 /* istanbul ignore next */
 if (!module.parent) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -25,6 +25,7 @@ var flatten = require('array-flatten');
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var Router = require('router');
+var StoreSettings = require('store-settings');
 var slice = Array.prototype.slice;
 
 /**
@@ -55,7 +56,21 @@ app.init = function init() {
 
   this.cache = {};
   this.engines = {};
-  this.settings = {};
+  this.settings = new StoreSettings({
+    setters: {
+      'etag': function (val) {
+        this.set('etag fn', compileETag(val));
+	  },
+      'query parser': function (val) {
+        this.set('query parser fn', compileQueryParser(val));
+      },
+      'trust proxy': function (val) {
+        this.set('trust proxy fn', compileTrust(val));
+        // trust proxy inherit back-compat
+        this.set(trustProxyDefaultSymbol, false)
+      }
+    }
+  })
 
   this.defaultConfiguration();
 
@@ -66,8 +81,8 @@ app.init = function init() {
     get: function getrouter() {
       if (router === null) {
         router = new Router({
-          caseSensitive: this.enabled('case sensitive routing'),
-          strict: this.enabled('strict routing')
+          caseSensitive: this.settings.enabled('case sensitive routing'),
+          strict: this.settings.enabled('strict routing')
         });
       }
 
@@ -85,34 +100,31 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this.enable('x-powered-by');
-  this.set('etag', 'weak');
-  this.set('env', env);
-  this.set('query parser', 'extended');
-  this.set('subdomain offset', 2);
-  this.set('trust proxy', false);
+  this.settings.enable('x-powered-by');
+  this.settings.set('etag', 'weak');
+  this.settings.set('env', env);
+  this.settings.set('query parser', 'extended');
+  this.settings.set('subdomain offset', 2);
+  this.settings.set('trust proxy', false);
 
   // trust proxy inherit back-compat
-  Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
-    configurable: true,
-    value: true
-  });
+  this.settings.set(trustProxyDefaultSymbol, true);
 
   debug('booting in %s mode', env);
 
   this.on('mount', function onmount(parent) {
     // inherit trust proxy
-    if (this.settings[trustProxyDefaultSymbol] === true
-      && typeof parent.settings['trust proxy fn'] === 'function') {
-      delete this.settings['trust proxy'];
-      delete this.settings['trust proxy fn'];
+    if (this.settings.get(trustProxyDefaultSymbol) === true
+      && typeof parent.settings.get('trust proxy fn') === 'function') {
+      this.settings.set('trust proxy', undefined);
+      this.settings.set('trust proxy fn', undefined);
     }
 
     // inherit protos
     this.request.__proto__ = parent.request;
     this.response.__proto__ = parent.response;
     this.engines.__proto__ = parent.engines;
-    this.settings.__proto__ = parent.settings;
+    this.settings.inheritFrom(parent.settings)
   });
 
   // setup locals
@@ -122,15 +134,15 @@ app.defaultConfiguration = function defaultConfiguration() {
   this.mountpath = '/';
 
   // default locals
-  this.locals.settings = this.settings;
+  this.locals.settings = this.settings.settings;
 
   // default configuration
-  this.set('view', View);
-  this.set('views', resolve('views'));
-  this.set('jsonp callback name', 'callback');
+  this.settings.set('view', View);
+  this.settings.set('views', resolve('views'));
+  this.settings.set('jsonp callback name', 'callback');
 
   if (env === 'production') {
-    this.enable('view cache');
+    this.settings.enable('view cache');
   }
 };
 
@@ -146,12 +158,12 @@ app.defaultConfiguration = function defaultConfiguration() {
 app.handle = function handle(req, res, callback) {
   // final handler
   var done = callback || finalhandler(req, res, {
-    env: this.get('env'),
+    env: this.settings.get('env'),
     onerror: logerror.bind(this)
   });
 
   // set powered by header
-  if (this.enabled('x-powered-by')) {
+  if (this.settings.enabled('x-powered-by')) {
     res.setHeader('X-Powered-By', 'Express');
   }
 
@@ -212,7 +224,7 @@ app.use = function use(fn) {
 
   fns.forEach(function (fn) {
     // non-express app
-    if (!fn || !fn.handle || !fn.set) {
+    if (!fn || !fn.handle || !fn.settings) {
       return router.use(path, fn);
     }
 
@@ -328,55 +340,6 @@ app.param = function param(name, fn) {
 };
 
 /**
- * Assign `setting` to `val`, or return `setting`'s value.
- *
- *    app.set('foo', 'bar');
- *    app.get('foo');
- *    // => "bar"
- *
- * Mounted servers inherit their parent server's settings.
- *
- * @param {String} setting
- * @param {*} [val]
- * @return {Server} for chaining
- * @public
- */
-
-app.set = function set(setting, val) {
-  if (arguments.length === 1) {
-    // app.get(setting)
-    return this.settings[setting];
-  }
-
-  debug('set "%s" to %o', setting, val);
-
-  // set value
-  this.settings[setting] = val;
-
-  // trigger matched settings
-  switch (setting) {
-    case 'etag':
-      this.set('etag fn', compileETag(val));
-      break;
-    case 'query parser':
-      this.set('query parser fn', compileQueryParser(val));
-      break;
-    case 'trust proxy':
-      this.set('trust proxy fn', compileTrust(val));
-
-      // trust proxy inherit back-compat
-      Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
-        configurable: true,
-        value: false
-      });
-
-      break;
-  }
-
-  return this;
-};
-
-/**
  * Return the app's absolute pathname
  * based on the parent(s) that have
  * mounted it.
@@ -397,78 +360,11 @@ app.path = function path() {
 };
 
 /**
- * Check if `setting` is enabled (truthy).
- *
- *    app.enabled('foo')
- *    // => false
- *
- *    app.enable('foo')
- *    app.enabled('foo')
- *    // => true
- *
- * @param {String} setting
- * @return {Boolean}
- * @public
- */
-
-app.enabled = function enabled(setting) {
-  return Boolean(this.set(setting));
-};
-
-/**
- * Check if `setting` is disabled.
- *
- *    app.disabled('foo')
- *    // => true
- *
- *    app.enable('foo')
- *    app.disabled('foo')
- *    // => false
- *
- * @param {String} setting
- * @return {Boolean}
- * @public
- */
-
-app.disabled = function disabled(setting) {
-  return !this.set(setting);
-};
-
-/**
- * Enable `setting`.
- *
- * @param {String} setting
- * @return {app} for chaining
- * @public
- */
-
-app.enable = function enable(setting) {
-  return this.set(setting, true);
-};
-
-/**
- * Disable `setting`.
- *
- * @param {String} setting
- * @return {app} for chaining
- * @public
- */
-
-app.disable = function disable(setting) {
-  return this.set(setting, false);
-};
-
-/**
  * Delegate `.VERB(...)` calls to `router.VERB(...)`.
  */
 
 methods.forEach(function(method){
   app[method] = function(path){
-    if (method === 'get' && arguments.length === 1) {
-      // app.get(setting)
-      return this.set(path);
-    }
-
     var route = this.route(path);
     route[method].apply(route, slice.call(arguments, 1));
     return this;
@@ -540,7 +436,7 @@ app.render = function render(name, options, callback) {
 
   // set .cache unless explicitly provided
   if (renderOptions.cache == null) {
-    renderOptions.cache = this.enabled('view cache');
+    renderOptions.cache = this.settings.enabled('view cache');
   }
 
   // primed cache
@@ -550,11 +446,11 @@ app.render = function render(name, options, callback) {
 
   // view
   if (!view) {
-    var View = this.get('view');
+    var View = this.settings.get('view');
 
     view = new View(name, {
-      defaultEngine: this.get('view engine'),
-      root: this.get('views'),
+      defaultEngine: this.settings.get('view engine'),
+      root: this.settings.get('views'),
       engines: engines
     });
 
@@ -612,7 +508,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.settings.get('env') !== 'test') console.error(err.stack || err.toString());
 }
 
 /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -210,7 +210,7 @@ req.range = function range(size, options) {
  */
 
 defineGetter(req, 'query', function query(){
-  var queryparse = this.app.get('query parser fn');
+  var queryparse = this.app.settings.get('query parser fn');
 
   if (!queryparse) {
     // parsing is disabled
@@ -280,7 +280,7 @@ defineGetter(req, 'protocol', function protocol(){
   var proto = this.connection.encrypted
     ? 'https'
     : 'http';
-  var trust = this.app.get('trust proxy fn');
+  var trust = this.app.settings.get('trust proxy fn');
 
   if (!trust(this.connection.remoteAddress, 0)) {
     return proto;
@@ -316,7 +316,7 @@ defineGetter(req, 'secure', function secure(){
  */
 
 defineGetter(req, 'ip', function ip(){
-  var trust = this.app.get('trust proxy fn');
+  var trust = this.app.settings.get('trust proxy fn');
   return proxyaddr(this, trust);
 });
 
@@ -333,7 +333,7 @@ defineGetter(req, 'ip', function ip(){
  */
 
 defineGetter(req, 'ips', function ips() {
-  var trust = this.app.get('trust proxy fn');
+  var trust = this.app.settings.get('trust proxy fn');
   var addrs = proxyaddr.all(this, trust);
   return addrs.slice(1).reverse();
 });
@@ -358,7 +358,7 @@ defineGetter(req, 'subdomains', function subdomains() {
 
   if (!hostname) return [];
 
-  var offset = this.app.get('subdomain offset');
+  var offset = this.app.settings.get('subdomain offset');
   var subdomains = !isIP(hostname)
     ? hostname.split('.').reverse()
     : [hostname];
@@ -389,7 +389,7 @@ defineGetter(req, 'path', function path() {
  */
 
 defineGetter(req, 'host', function host(){
-  var trust = this.app.get('trust proxy fn');
+  var trust = this.app.settings.get('trust proxy fn');
   var val = this.get('X-Forwarded-Host');
 
   if (!val || !trust(this.connection.remoteAddress, 0)) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -161,7 +161,7 @@ res.send = function send(body) {
 
   // populate ETag
   var etag;
-  var generateETag = len !== undefined && app.get('etag fn');
+  var generateETag = len !== undefined && app.settings.get('etag fn');
   if (typeof generateETag === 'function' && !this.get('ETag')) {
     if ((etag = generateETag(chunk, encoding))) {
       this.set('ETag', etag);
@@ -205,8 +205,8 @@ res.send = function send(body) {
 res.json = function json(obj) {
   // settings
   var app = this.app;
-  var replacer = app.get('json replacer');
-  var spaces = app.get('json spaces');
+  var replacer = app.settings.get('json replacer');
+  var spaces = app.settings.get('json spaces');
   var body = stringify(obj, replacer, spaces);
 
   // content-type
@@ -232,10 +232,10 @@ res.json = function json(obj) {
 res.jsonp = function jsonp(obj) {
   // settings
   var app = this.app;
-  var replacer = app.get('json replacer');
-  var spaces = app.get('json spaces');
+  var replacer = app.settings.get('json replacer');
+  var spaces = app.settings.get('json spaces');
   var body = stringify(obj, replacer, spaces);
-  var callback = this.req.query[app.get('jsonp callback name')];
+  var callback = this.req.query[app.settings.get('jsonp callback name')];
 
   // content-type
   if (!this.get('Content-Type')) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "router": "~1.1.5",
     "send": "0.14.2",
     "serve-static": "~1.11.2",
+    "store-settings": "^1.2.0",
     "type-is": "~1.6.14",
     "utils-merge": "1.0.0",
     "vary": "~1.1.0"

--- a/test/app.engine.js
+++ b/test/app.engine.js
@@ -15,7 +15,7 @@ describe('app', function(){
     it('should map a template engine', function(done){
       var app = express();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.engine('.html', render);
       app.locals.user = { name: 'tobi' };
 
@@ -36,7 +36,7 @@ describe('app', function(){
     it('should work without leading "."', function(done){
       var app = express();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.engine('html', render);
       app.locals.user = { name: 'tobi' };
 
@@ -50,9 +50,9 @@ describe('app', function(){
     it('should work "view engine" setting', function(done){
       var app = express();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.engine('html', render);
-      app.set('view engine', 'html');
+      app.settings.set('view engine', 'html');
       app.locals.user = { name: 'tobi' };
 
       app.render('user', function(err, str){
@@ -65,9 +65,9 @@ describe('app', function(){
     it('should work "view engine" with leading "."', function(done){
       var app = express();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.engine('.html', render);
-      app.set('view engine', '.html');
+      app.settings.set('view engine', '.html');
       app.locals.user = { name: 'tobi' };
 
       app.render('user', function(err, str){

--- a/test/app.js
+++ b/test/app.js
@@ -74,7 +74,7 @@ describe('in development', function(){
   it('should disable "view cache"', function(){
     process.env.NODE_ENV = 'development';
     var app = express();
-    app.enabled('view cache').should.be.false;
+    app.settings.enabled('view cache').should.be.false;
     process.env.NODE_ENV = 'test';
   })
 })
@@ -83,7 +83,7 @@ describe('in production', function(){
   it('should enable "view cache"', function(){
     process.env.NODE_ENV = 'production';
     var app = express();
-    app.enabled('view cache').should.be.true;
+    app.settings.enabled('view cache').should.be.true;
     process.env.NODE_ENV = 'test';
   })
 })
@@ -92,7 +92,7 @@ describe('without NODE_ENV', function(){
   it('should default to development', function(){
     process.env.NODE_ENV = '';
     var app = express();
-    app.get('env').should.equal('development');
+    app.settings.get('env').should.equal('development');
     process.env.NODE_ENV = 'test';
   })
 })

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -18,7 +18,7 @@ describe('app', function(){
   describe('.locals.settings', function(){
     it('should expose app settings', function(){
       var app = express();
-      app.set('title', 'House of Manny');
+      app.settings.set('title', 'House of Manny');
       var obj = app.locals.settings;
       obj.should.have.property('env', 'test');
       obj.should.have.property('title', 'House of Manny');

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -19,7 +19,7 @@ describe('app', function(){
     it('should support absolute paths with "view engine"', function(done){
       var app = createApp();
 
-      app.set('view engine', 'tmpl');
+      app.settings.set('view engine', 'tmpl');
       app.locals.user = { name: 'tobi' };
 
       app.render(__dirname + '/fixtures/user', function(err, str){
@@ -32,7 +32,7 @@ describe('app', function(){
     it('should expose app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.render('user.tmpl', function (err, str) {
@@ -45,8 +45,8 @@ describe('app', function(){
     it('should support index.<engine>', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
-      app.set('view engine', 'tmpl');
+      app.settings.set('views', __dirname + '/fixtures');
+      app.settings.set('view engine', 'tmpl');
 
       app.render('blog/post', function (err, str) {
         if (err) return done(err);
@@ -67,7 +67,7 @@ describe('app', function(){
         throw new Error('err!');
       };
 
-      app.set('view', View);
+      app.settings.set('view', View);
 
       app.render('something', function(err, str){
         err.should.be.ok;
@@ -80,7 +80,7 @@ describe('app', function(){
       it('should provide a helpful error', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('views', __dirname + '/fixtures');
         app.render('rawr.tmpl', function (err) {
           err.message.should.equal('Failed to lookup view "rawr.tmpl" in views directory "' + __dirname + '/fixtures"');
           done();
@@ -92,7 +92,7 @@ describe('app', function(){
       it('should invoke the callback', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.render('user.tmpl', function (err, str) {
           // nextTick to prevent cyclic
@@ -108,7 +108,7 @@ describe('app', function(){
       it('should render the template', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.render('email.tmpl', function (err, str) {
           if (err) return done(err);
@@ -122,8 +122,8 @@ describe('app', function(){
       it('should render the template', function(done){
         var app = createApp();
 
-        app.set('view engine', 'tmpl');
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('view engine', 'tmpl');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.render('email', function(err, str){
           if (err) return done(err);
@@ -137,7 +137,7 @@ describe('app', function(){
       it('should lookup the file in the path', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures/default_layout');
+        app.settings.set('views', __dirname + '/fixtures/default_layout');
         app.locals.user = { name: 'tobi' };
 
         app.render('user.tmpl', function (err, str) {
@@ -152,7 +152,7 @@ describe('app', function(){
           var app = createApp();
           var views = [__dirname + '/fixtures/local_layout', __dirname + '/fixtures/default_layout'];
 
-          app.set('views', views);
+          app.settings.set('views', views);
           app.locals.user = { name: 'tobi' };
 
           app.render('user.tmpl', function (err, str) {
@@ -166,7 +166,7 @@ describe('app', function(){
           var app = createApp();
           var views = [__dirname + '/fixtures/local_layout', __dirname + '/fixtures/default_layout'];
 
-          app.set('views', views);
+          app.settings.set('views', views);
           app.locals.name = 'tobi';
 
           app.render('name.tmpl', function (err, str) {
@@ -180,7 +180,7 @@ describe('app', function(){
           var app = createApp();
           var views = [__dirname + '/fixtures/local_layout', __dirname + '/fixtures/default_layout'];
 
-          app.set('views', views);
+          app.settings.set('views', views);
           app.locals.name = 'tobi';
 
           app.render('pet.tmpl', function (err, str) {
@@ -204,7 +204,7 @@ describe('app', function(){
           fn(null, 'abstract engine');
         };
 
-        app.set('view', View);
+        app.settings.set('view', View);
 
         app.render('something', function(err, str){
           if (err) return done(err);
@@ -229,8 +229,8 @@ describe('app', function(){
           fn(null, 'abstract engine');
         };
 
-        app.set('view cache', false);
-        app.set('view', View);
+        app.settings.set('view cache', false);
+        app.settings.set('view', View);
 
         app.render('something', function(err, str){
           if (err) return done(err);
@@ -259,8 +259,8 @@ describe('app', function(){
           fn(null, 'abstract engine');
         };
 
-        app.set('view cache', true);
-        app.set('view', View);
+        app.settings.set('view cache', true);
+        app.settings.set('view', View);
 
         app.render('something', function(err, str){
           if (err) return done(err);
@@ -281,7 +281,7 @@ describe('app', function(){
     it('should render the template', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
 
       var user = { name: 'tobi' };
 
@@ -295,7 +295,7 @@ describe('app', function(){
     it('should expose app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.render('user.tmpl', {}, function (err, str) {
@@ -308,7 +308,7 @@ describe('app', function(){
     it('should give precedence to app.render() locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
       var jane = { name: 'jane' };
 
@@ -334,8 +334,8 @@ describe('app', function(){
           fn(null, 'abstract engine');
         };
 
-        app.set('view cache', false);
-        app.set('view', View);
+        app.settings.set('view cache', false);
+        app.settings.set('view', View);
 
         app.render('something', {cache: true}, function(err, str){
           if (err) return done(err);

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -213,7 +213,7 @@ describe('app.router', function(){
       it('should match identical casing', function(done){
         var app = express();
 
-        app.enable('case sensitive routing');
+        app.settings.enable('case sensitive routing');
 
         app.get('/uSer', function(req, res){
           res.end('tj');
@@ -227,7 +227,7 @@ describe('app.router', function(){
       it('should not match otherwise', function(done){
         var app = express();
 
-        app.enable('case sensitive routing');
+        app.settings.enable('case sensitive routing');
 
         app.get('/uSer', function(req, res){
           res.end('tj');
@@ -393,7 +393,7 @@ describe('app.router', function(){
       it('should match trailing slashes', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.get('/user/', function(req, res){
           res.end('tj');
@@ -407,7 +407,7 @@ describe('app.router', function(){
       it('should pass-though middleware', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.use(function (req, res, next) {
           res.setHeader('x-middleware', 'true');
@@ -427,7 +427,7 @@ describe('app.router', function(){
       it('should pass-though mounted middleware', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.use('/user/', function (req, res, next) {
           res.setHeader('x-middleware', 'true');
@@ -447,7 +447,7 @@ describe('app.router', function(){
       it('should match no slashes', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.get('/user', function(req, res){
           res.end('tj');
@@ -461,7 +461,7 @@ describe('app.router', function(){
       it('should match middleware when omitting the trailing slash', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.use('/user/', function(req, res){
           res.end('tj');
@@ -475,7 +475,7 @@ describe('app.router', function(){
       it('should match middleware', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.use('/user', function(req, res){
           res.end('tj');
@@ -489,7 +489,7 @@ describe('app.router', function(){
       it('should match middleware when adding the trailing slash', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.use('/user', function(req, res){
           res.end('tj');
@@ -503,7 +503,7 @@ describe('app.router', function(){
       it('should fail when omitting the trailing slash', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.get('/user/', function(req, res){
           res.end('tj');
@@ -517,7 +517,7 @@ describe('app.router', function(){
       it('should fail when adding the trailing slash', function(done){
         var app = express();
 
-        app.enable('strict routing');
+        app.settings.enable('strict routing');
 
         app.get('/user', function(req, res){
           res.end('tj');

--- a/test/config.js
+++ b/test/config.js
@@ -6,31 +6,31 @@ describe('config', function () {
   describe('.set()', function () {
     it('should set a value', function () {
       var app = express();
-      app.set('foo', 'bar');
-      assert.equal(app.get('foo'), 'bar');
+      app.settings.set('foo', 'bar');
+      assert.equal(app.settings.get('foo'), 'bar');
     })
 
     it('should return the app', function () {
       var app = express();
-      assert.equal(app.set('foo', 'bar'), app);
+      assert.equal(app.settings.set('foo', 'bar'), app.settings);
     })
 
     it('should return the app when undefined', function () {
       var app = express();
-      assert.equal(app.set('foo', undefined), app);
+      assert.equal(app.settings.set('foo', undefined), app.settings);
     })
 
     describe('"etag"', function(){
       it('should throw on bad value', function(){
         var app = express();
-        assert.throws(app.set.bind(app, 'etag', 42), /unknown value/);
+        assert.throws(app.settings.set.bind(app.settings, 'etag', 42), /unknown value/);
       })
 
       it('should set "etag fn"', function(){
         var app = express()
         var fn = function(){}
-        app.set('etag', fn)
-        assert.equal(app.get('etag fn'), fn)
+        app.settings.set('etag', fn)
+        assert.equal(app.settings.get('etag fn'), fn)
       })
     })
 
@@ -38,8 +38,8 @@ describe('config', function () {
       it('should set "trust proxy fn"', function(){
         var app = express()
         var fn = function(){}
-        app.set('trust proxy', fn)
-        assert.equal(app.get('trust proxy fn'), fn)
+        app.settings.set('trust proxy', fn)
+        assert.equal(app.settings.get('trust proxy fn'), fn)
       })
     })
   })
@@ -47,13 +47,13 @@ describe('config', function () {
   describe('.get()', function(){
     it('should return undefined when unset', function(){
       var app = express();
-      assert.strictEqual(app.get('foo'), undefined);
+      assert.strictEqual(app.settings.get('foo'), undefined);
     })
     
     it('should otherwise return the value', function(){
       var app = express();
-      app.set('foo', 'bar');
-      assert.equal(app.get('foo'), 'bar');
+      app.settings.set('foo', 'bar');
+      assert.equal(app.settings.get('foo'), 'bar');
     })
 
     describe('when mounted', function(){
@@ -61,9 +61,9 @@ describe('config', function () {
         var app = express();
         var blog = express();
 
-        app.set('title', 'Express');
+        app.settings.set('title', 'Express');
         app.use(blog);
-        assert.equal(blog.get('title'), 'Express');
+        assert.equal(blog.settings.get('title'), 'Express');
       })
 
       it('should given precedence to the child', function(){
@@ -71,10 +71,10 @@ describe('config', function () {
         var blog = express();
 
         app.use(blog);
-        app.set('title', 'Express');
-        blog.set('title', 'Some Blog');
+        app.settings.set('title', 'Express');
+        blog.settings.set('title', 'Some Blog');
 
-        assert.equal(blog.get('title'), 'Some Blog');
+        assert.equal(blog.settings.get('title'), 'Some Blog');
       })
 
       it('should inherit "trust proxy" setting', function () {
@@ -83,14 +83,14 @@ describe('config', function () {
 
         function fn() { return false }
 
-        app.set('trust proxy', fn);
-        assert.equal(app.get('trust proxy'), fn);
-        assert.equal(app.get('trust proxy fn'), fn);
+        app.settings.set('trust proxy', fn);
+        assert.equal(app.settings.get('trust proxy'), fn);
+        assert.equal(app.settings.get('trust proxy fn'), fn);
 
         app.use(blog);
 
-        assert.equal(blog.get('trust proxy'), fn);
-        assert.equal(blog.get('trust proxy fn'), fn);
+        assert.equal(blog.settings.get('trust proxy'), fn);
+        assert.equal(blog.settings.get('trust proxy fn'), fn);
       })
 
       it('should prefer child "trust proxy" setting', function () {
@@ -100,20 +100,20 @@ describe('config', function () {
         function fn1() { return false }
         function fn2() { return true }
 
-        app.set('trust proxy', fn1);
-        assert.equal(app.get('trust proxy'), fn1);
-        assert.equal(app.get('trust proxy fn'), fn1);
+        app.settings.set('trust proxy', fn1);
+        assert.equal(app.settings.get('trust proxy'), fn1);
+        assert.equal(app.settings.get('trust proxy fn'), fn1);
 
-        blog.set('trust proxy', fn2);
-        assert.equal(blog.get('trust proxy'), fn2);
-        assert.equal(blog.get('trust proxy fn'), fn2);
+        blog.settings.set('trust proxy', fn2);
+        assert.equal(blog.settings.get('trust proxy'), fn2);
+        assert.equal(blog.settings.get('trust proxy fn'), fn2);
 
         app.use(blog);
 
-        assert.equal(app.get('trust proxy'), fn1);
-        assert.equal(app.get('trust proxy fn'), fn1);
-        assert.equal(blog.get('trust proxy'), fn2);
-        assert.equal(blog.get('trust proxy fn'), fn2);
+        assert.equal(app.settings.get('trust proxy'), fn1);
+        assert.equal(app.settings.get('trust proxy fn'), fn1);
+        assert.equal(blog.settings.get('trust proxy'), fn2);
+        assert.equal(blog.settings.get('trust proxy fn'), fn2);
       })
     })
   })
@@ -121,42 +121,42 @@ describe('config', function () {
   describe('.enable()', function(){
     it('should set the value to true', function(){
       var app = express();
-      assert.equal(app.enable('tobi'), app);
-      assert.strictEqual(app.get('tobi'), true);
+      assert.equal(app.settings.enable('tobi'), app.settings);
+      assert.strictEqual(app.settings.get('tobi'), true);
     })
   })
   
   describe('.disable()', function(){
     it('should set the value to false', function(){
       var app = express();
-      assert.equal(app.disable('tobi'), app);
-      assert.strictEqual(app.get('tobi'), false);
+      assert.equal(app.settings.disable('tobi'), app.settings);
+      assert.strictEqual(app.settings.get('tobi'), false);
     })
   })
   
   describe('.enabled()', function(){
     it('should default to false', function(){
       var app = express();
-      assert.strictEqual(app.enabled('foo'), false);
+      assert.strictEqual(app.settings.enabled('foo'), false);
     })
     
     it('should return true when set', function(){
       var app = express();
-      app.set('foo', 'bar');
-      assert.strictEqual(app.enabled('foo'), true);
+      app.settings.set('foo', 'bar');
+      assert.strictEqual(app.settings.enabled('foo'), true);
     })
   })
   
   describe('.disabled()', function(){
     it('should default to true', function(){
       var app = express();
-      assert.strictEqual(app.disabled('foo'), true);
+      assert.strictEqual(app.settings.disabled('foo'), true);
     })
     
     it('should return false when set', function(){
       var app = express();
-      app.set('foo', 'bar');
-      assert.strictEqual(app.disabled('foo'), false);
+      app.settings.set('foo', 'bar');
+      assert.strictEqual(app.settings.disabled('foo'), false);
     })
   })
 })

--- a/test/exports.js
+++ b/test/exports.js
@@ -9,7 +9,7 @@ describe('exports', function(){
   })
 
   it('should expose the application prototype', function(){
-    express.application.set.should.be.a.Function;
+    express.application.defaultConfiguration.should.be.a.Function;
   })
 
   it('should expose the request prototype', function(){

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -74,7 +74,7 @@ describe('req', function(){
       it('should respect X-Forwarded-Host', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.host);
@@ -90,7 +90,7 @@ describe('req', function(){
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){
         var app = express();
 
-        app.set('trust proxy', '10.0.0.1');
+        app.settings.set('trust proxy', '10.0.0.1');
 
         app.use(function(req, res){
           res.end(req.host);
@@ -106,7 +106,7 @@ describe('req', function(){
       it('should default to Host', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.host);
@@ -122,7 +122,7 @@ describe('req', function(){
         it('should respect X-Forwarded-Host', function (done) {
           var app = express();
 
-          app.set('trust proxy', 1);
+          app.settings.set('trust proxy', 1);
 
           app.use(function (req, res) {
             res.end(req.host);

--- a/test/req.hostname.js
+++ b/test/req.hostname.js
@@ -74,7 +74,7 @@ describe('req', function(){
       it('should respect X-Forwarded-Host', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.hostname);
@@ -90,7 +90,7 @@ describe('req', function(){
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){
         var app = express();
 
-        app.set('trust proxy', '10.0.0.1');
+        app.settings.set('trust proxy', '10.0.0.1');
 
         app.use(function(req, res){
           res.end(req.hostname);
@@ -106,7 +106,7 @@ describe('req', function(){
       it('should default to Host', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.hostname);

--- a/test/req.ip.js
+++ b/test/req.ip.js
@@ -9,7 +9,7 @@ describe('req', function(){
         it('should return the client addr', function(done){
           var app = express();
 
-          app.enable('trust proxy');
+          app.settings.enable('trust proxy');
 
           app.use(function(req, res, next){
             res.send(req.ip);
@@ -24,7 +24,7 @@ describe('req', function(){
         it('should return the addr after trusted proxy', function(done){
           var app = express();
 
-          app.set('trust proxy', 2);
+          app.settings.set('trust proxy', 2);
 
           app.use(function(req, res, next){
             res.send(req.ip);
@@ -40,7 +40,7 @@ describe('req', function(){
           var app = express();
           var sub = express();
 
-          app.set('trust proxy', 2);
+          app.settings.set('trust proxy', 2);
           app.use(sub);
 
           sub.use(function (req, res, next) {
@@ -73,7 +73,7 @@ describe('req', function(){
       it('should return the remote address', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res, next){
           res.send(req.ip);

--- a/test/req.ips.js
+++ b/test/req.ips.js
@@ -9,7 +9,7 @@ describe('req', function(){
         it('should return an array of the specified addresses', function(done){
           var app = express();
 
-          app.enable('trust proxy');
+          app.settings.enable('trust proxy');
 
           app.use(function(req, res, next){
             res.send(req.ips);
@@ -24,7 +24,7 @@ describe('req', function(){
         it('should stop at first untrusted', function(done){
           var app = express();
 
-          app.set('trust proxy', 2);
+          app.settings.set('trust proxy', 2);
 
           app.use(function(req, res, next){
             res.send(req.ips);

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -20,7 +20,7 @@ describe('req', function(){
       it('should respect X-Forwarded-Proto', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.protocol);
@@ -35,7 +35,7 @@ describe('req', function(){
       it('should default to the socket addr if X-Forwarded-Proto not present', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           req.connection.encrypted = true;
@@ -50,7 +50,7 @@ describe('req', function(){
       it('should ignore X-Forwarded-Proto if socket addr not trusted', function(done){
         var app = express();
 
-        app.set('trust proxy', '10.0.0.1');
+        app.settings.set('trust proxy', '10.0.0.1');
 
         app.use(function(req, res){
           res.end(req.protocol);
@@ -65,7 +65,7 @@ describe('req', function(){
       it('should default to http', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.use(function(req, res){
           res.end(req.protocol);
@@ -80,7 +80,7 @@ describe('req', function(){
         it('should respect X-Forwarded-Proto', function (done) {
           var app = express();
 
-          app.set('trust proxy', 1);
+          app.settings.set('trust proxy', 1);
 
           app.use(function (req, res) {
             res.end(req.protocol);

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -92,7 +92,7 @@ function createApp(setting) {
   var app = express();
 
   if (setting !== undefined) {
-    app.set('query parser', setting);
+    app.settings.set('query parser', setting);
   }
 
   app.use(function (req, res) {

--- a/test/req.secure.js
+++ b/test/req.secure.js
@@ -37,7 +37,7 @@ describe('req', function(){
       it('should return true when "trust proxy" is enabled', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.get('/', function(req, res){
           res.send(req.secure ? 'yes' : 'no');
@@ -52,7 +52,7 @@ describe('req', function(){
       it('should return false when initial proxy is http', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.get('/', function(req, res){
           res.send(req.secure ? 'yes' : 'no');
@@ -67,7 +67,7 @@ describe('req', function(){
       it('should return true when initial proxy is https', function(done){
         var app = express();
 
-        app.enable('trust proxy');
+        app.settings.enable('trust proxy');
 
         app.get('/', function(req, res){
           res.send(req.secure ? 'yes' : 'no');
@@ -83,7 +83,7 @@ describe('req', function(){
         it('should respect X-Forwarded-Proto', function (done) {
           var app = express();
 
-          app.set('trust proxy', 1);
+          app.settings.set('trust proxy', 1);
 
           app.get('/', function (req, res) {
             res.send(req.secure ? 'yes' : 'no');

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -79,7 +79,7 @@ describe('req', function(){
       it('should return an array', function (done) {
         var app = express();
 
-        app.set('trust proxy', true);
+        app.settings.set('trust proxy', true);
         app.use(function (req, res) {
           res.send(req.subdomains);
         });
@@ -95,7 +95,7 @@ describe('req', function(){
       describe('when subdomain offset is zero', function(){
         it('should return an array with the whole domain', function(done){
           var app = express();
-          app.set('subdomain offset', 0);
+          app.settings.set('subdomain offset', 0);
 
           app.use(function(req, res){
             res.send(req.subdomains);
@@ -109,7 +109,7 @@ describe('req', function(){
 
         it('should return an array with the whole IPv4', function (done) {
           var app = express();
-          app.set('subdomain offset', 0);
+          app.settings.set('subdomain offset', 0);
 
           app.use(function(req, res){
             res.send(req.subdomains);
@@ -123,7 +123,7 @@ describe('req', function(){
 
         it('should return an array with the whole IPv6', function (done) {
           var app = express();
-          app.set('subdomain offset', 0);
+          app.settings.set('subdomain offset', 0);
 
           app.use(function(req, res){
             res.send(req.subdomains);
@@ -139,7 +139,7 @@ describe('req', function(){
       describe('when present', function(){
         it('should return an array', function(done){
           var app = express();
-          app.set('subdomain offset', 3);
+          app.settings.set('subdomain offset', 3);
 
           app.use(function(req, res){
             res.send(req.subdomains);
@@ -155,7 +155,7 @@ describe('req', function(){
       describe('otherwise', function(){
         it('should return an empty array', function(done){
           var app = express();
-          app.set('subdomain offset', 3);
+          app.settings.set('subdomain offset', 3);
 
           app.use(function(req, res){
             res.send(req.subdomains);

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -106,7 +106,7 @@ describe('res', function(){
       it('should be passed to JSON.stringify()', function(done){
         var app = express();
 
-        app.set('json replacer', function(key, val){
+        app.settings.set('json replacer', function(key, val){
           return '_' == key[0]
             ? undefined
             : val;
@@ -126,13 +126,13 @@ describe('res', function(){
     describe('"json spaces" setting', function(){
       it('should be undefined by default', function(){
         var app = express();
-        assert(undefined === app.get('json spaces'));
+        assert(undefined === app.settings.get('json spaces'));
       })
 
       it('should be passed to JSON.stringify()', function(done){
         var app = express();
 
-        app.set('json spaces', 2);
+        app.settings.set('json spaces', 2);
 
         app.use(function(req, res){
           res.json({ name: 'tobi', age: 2 });

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -48,7 +48,7 @@ describe('res', function(){
     it('should allow renaming callback', function(done){
       var app = express();
 
-      app.set('jsonp callback name', 'clb');
+      app.settings.set('jsonp callback name', 'clb');
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -246,7 +246,7 @@ describe('res', function(){
       it('should be passed to JSON.stringify()', function(done){
         var app = express();
 
-        app.set('json replacer', function(key, val){
+        app.settings.set('json replacer', function(key, val){
           return '_' == key[0]
             ? undefined
             : val;
@@ -266,13 +266,13 @@ describe('res', function(){
     describe('"json spaces" setting', function(){
       it('should be undefined by default', function(){
         var app = express();
-        assert(undefined === app.get('json spaces'));
+        assert(undefined === app.settings.get('json spaces'));
       })
 
       it('should be passed to JSON.stringify()', function(done){
         var app = express();
 
-        app.set('json spaces', 2);
+        app.settings.set('json spaces', 2);
 
         app.use(function(req, res){
           res.jsonp({ name: 'tobi', age: 2 });

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -23,7 +23,7 @@ describe('res', function(){
       var app = createApp();
 
       app.locals.user = { name: 'tobi' };
-      app.set('view engine', 'tmpl');
+      app.settings.set('view engine', 'tmpl');
 
       app.use(function(req, res){
         res.render(__dirname + '/fixtures/user');
@@ -51,7 +51,7 @@ describe('res', function(){
     it('should expose app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.use(function(req, res){
@@ -66,7 +66,7 @@ describe('res', function(){
     it('should expose app.locals with `name` property', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.name = 'tobi';
 
       app.use(function(req, res){
@@ -81,8 +81,8 @@ describe('res', function(){
     it('should support index.<engine>', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
-      app.set('view engine', 'tmpl');
+      app.settings.set('views', __dirname + '/fixtures');
+      app.settings.set('view engine', 'tmpl');
 
       app.use(function(req, res){
         res.render('blog/post');
@@ -97,7 +97,7 @@ describe('res', function(){
       it('should next(err)', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.use(function(req, res){
           res.render('user.tmpl');
@@ -117,8 +117,8 @@ describe('res', function(){
       it('should render the template', function(done){
         var app = createApp();
 
-        app.set('view engine', 'tmpl');
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('view engine', 'tmpl');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.use(function(req, res){
           res.render('email');
@@ -134,7 +134,7 @@ describe('res', function(){
       it('should lookup the file in the path', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures/default_layout');
+        app.settings.set('views', __dirname + '/fixtures/default_layout');
 
         app.use(function(req, res){
           res.render('user.tmpl', { user: { name: 'tobi' } });
@@ -150,7 +150,7 @@ describe('res', function(){
           var app = createApp();
           var views = [__dirname + '/fixtures/local_layout', __dirname + '/fixtures/default_layout'];
 
-          app.set('views', views);
+          app.settings.set('views', views);
 
           app.use(function(req, res){
             res.render('user.tmpl', { user: { name: 'tobi' } });
@@ -165,7 +165,7 @@ describe('res', function(){
           var app = createApp();
           var views = [__dirname + '/fixtures/local_layout', __dirname + '/fixtures/default_layout'];
 
-          app.set('views', views);
+          app.settings.set('views', views);
 
           app.use(function(req, res){
             res.render('name.tmpl', { name: 'tobi' });
@@ -183,7 +183,7 @@ describe('res', function(){
     it('should render the template', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
 
       var user = { name: 'tobi' };
 
@@ -199,7 +199,7 @@ describe('res', function(){
     it('should expose app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.use(function(req, res){
@@ -214,7 +214,7 @@ describe('res', function(){
     it('should expose res.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
         res.locals.user = { name: 'tobi' };
@@ -229,7 +229,7 @@ describe('res', function(){
     it('should give precedence to res.locals over app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
 
       app.use(function(req, res){
@@ -245,7 +245,7 @@ describe('res', function(){
     it('should give precedence to res.render() locals over res.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       var jane = { name: 'jane' };
 
       app.use(function(req, res){
@@ -261,7 +261,7 @@ describe('res', function(){
     it('should give precedence to res.render() locals over app.locals', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
       app.locals.user = { name: 'tobi' };
       var jane = { name: 'jane' };
 
@@ -279,7 +279,7 @@ describe('res', function(){
     it('should pass the resulting string', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
         var tobi = { name: 'tobi' };
@@ -299,7 +299,7 @@ describe('res', function(){
     it('should pass the resulting string', function(done){
       var app = createApp();
 
-      app.set('views', __dirname + '/fixtures');
+      app.settings.set('views', __dirname + '/fixtures');
 
       app.use(function(req, res){
         res.locals.user = { name: 'tobi' };
@@ -318,7 +318,7 @@ describe('res', function(){
       it('should pass it to the callback', function(done){
         var app = createApp();
 
-        app.set('views', __dirname + '/fixtures');
+        app.settings.set('views', __dirname + '/fixtures');
 
         app.use(function(req, res){
           res.render('user.tmpl', function (err) {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -336,7 +336,7 @@ describe('res', function(){
           res.send('kajdslfkasdf');
         });
 
-        app.enable('etag');
+        app.settings.enable('etag');
 
         request(app)
         .get('/')
@@ -368,7 +368,7 @@ describe('res', function(){
           res.send('');
         });
 
-        app.enable('etag');
+        app.settings.enable('etag');
 
         request(app)
         .get('/')
@@ -384,7 +384,7 @@ describe('res', function(){
           res.send(str);
         });
 
-        app.enable('etag');
+        app.settings.enable('etag');
 
         request(app)
         .get('/')
@@ -400,7 +400,7 @@ describe('res', function(){
           res.send('hello!');
         });
 
-        app.enable('etag');
+        app.settings.enable('etag');
 
         request(app)
         .get('/')
@@ -415,7 +415,7 @@ describe('res', function(){
           res.send();
         });
 
-        app.enable('etag');
+        app.settings.enable('etag');
 
         request(app)
         .get('/')
@@ -433,7 +433,7 @@ describe('res', function(){
           res.send(str);
         });
 
-        app.disable('etag');
+        app.settings.disable('etag');
 
         request(app)
         .get('/')
@@ -444,7 +444,7 @@ describe('res', function(){
       it('should send ETag when manually set', function (done) {
         var app = express();
 
-        app.disable('etag');
+        app.settings.disable('etag');
 
         app.use(function (req, res) {
           res.set('etag', '"asdf"');
@@ -462,7 +462,7 @@ describe('res', function(){
       it('should send strong ETag', function (done) {
         var app = express();
 
-        app.set('etag', 'strong');
+        app.settings.set('etag', 'strong');
 
         app.use(function (req, res) {
           res.send('hello, world!');
@@ -479,7 +479,7 @@ describe('res', function(){
       it('should send weak ETag', function (done) {
         var app = express();
 
-        app.set('etag', 'weak');
+        app.settings.set('etag', 'weak');
 
         app.use(function (req, res) {
           res.send('hello, world!');
@@ -496,7 +496,7 @@ describe('res', function(){
       it('should send custom ETag', function (done) {
         var app = express();
 
-        app.set('etag', function (body, encoding) {
+        app.settings.set('etag', function (body, encoding) {
           var chunk = !Buffer.isBuffer(body)
             ? new Buffer(body, encoding)
             : body;
@@ -517,7 +517,7 @@ describe('res', function(){
       it('should not send falsy ETag', function (done) {
         var app = express();
 
-        app.set('etag', function (body, encoding) {
+        app.settings.set('etag', function (body, encoding) {
           return undefined;
         });
 


### PR DESCRIPTION
This is based on what was discussed at the last TC meeting for a good "first step" in abstracting out parts of core than can be shared.  The changes here are rather far reaching, but they basically mean the following:

```
app.set()
app.get()
app.enable()
app.disable()
app.enabled()
app.disabled()
```

Become:

```
app.settings.set()
app.settings.get()
app.settings.enable()
app.settings.disable()
app.settings.enabled()
app.settings.disabled()
```

I think there are a bunch of points for discussion here:

1. I opted to move it all under `.settings`, mainly to resolves the weird behavior from `app.get` being multi purpose.  But it could also be done so that the methods remain the same, either via mixing them in, or explicitly calling into `.settings` as getter methods.
2. If we are already breaking the api, should we also add other changes, like removing the `enabled`/`disabled` shorthands to minimize the api surface.
3. Do people like the "setters" type functionality?  It is used to keep the features like setting `etag` but it actually setting `etag fn`.  Not sure, but it seems to me we could get rid of the whole thing but just using `etag` directly.

EDIT: standardjs compliance pending :) 
**Dont feel like doing all that busy work tonight if the whole PR might get shut down...