### PR TITLE
Replace Jade ref with EJS within engine "how to" comments

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -261,9 +261,9 @@ app.route = function route(path) {
  *
  * By default will `require()` the engine based on the
  * file extension. For example if you try to render
- * a "foo.jade" file Express will invoke the following internally:
+ * a "foo.ejs" file Express will invoke the following internally:
  *
- *     app.engine('jade', require('jade').__express);
+ *     app.engine('ejs', require('ejs').__express);
  *
  * For engines that do not provide `.__express` out of the box,
  * or if you wish to "map" a different extension to the template engine


### PR DESCRIPTION
It's probably best we reference `ejs` within the engine howto comments as that is a dependency we're not trying to remove.

Further discussion at #3181