### PR TITLE
Remove unused err argument

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -609,7 +609,7 @@ function restore(fn, obj) {
     vals[i] = obj[props[i]];
   }
 
-  return function(err){
+  return function(){
     // restore vals
     for (var i = 0; i < props.length; i++) {
       obj[props[i]] = vals[i];


### PR DESCRIPTION
restore() function in lib/router/index.js does not use it's err argument at all. 

All tests passed.