### PR TITLE
Removed link to expired domain

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,6 @@ $ npm install express
   * Visit the [Wiki](https://github.com/expressjs/express/wiki)
   * [Google Group](https://groups.google.com/group/express-js) for discussion
   * [Gitter](https://gitter.im/expressjs/express) for support and discussion
-  * [Русскоязычная документация](http://jsman.ru/express/)
 
 **PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/expressjs/express/wiki/New-features-in-4.x).
 


### PR DESCRIPTION
The link in which Русскоязычная документация links to has expired.

Maybe there is an up to date link someone else is aware of we can replace it with or remove this.

/OCD