### PR TITLE
Update debug module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "content-type": "~1.0.2",
     "cookie": "0.3.1",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.3",
+    "debug": "2.6.4",
     "depd": "~1.1.0",
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
This version fixes the issue described here https://github.com/visionmedia/debug/issues/443
> If process.env.DEBUG is set to a value other than a string a TypeError occurs. This can easily happen when using webpack to build a project.