### PR TITLE
location: back override option + tests

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -72,6 +72,7 @@ app.defaultConfiguration = function defaultConfiguration() {
 
   // default settings
   this.enable('x-powered-by');
+  this.enable('location back-referrer');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');

--- a/lib/response.js
+++ b/lib/response.js
@@ -834,7 +834,7 @@ res.location = function location(url) {
   var loc = url;
 
   // "back" is an alias for the referrer
-  if (url === 'back') {
+  if (url === 'back' && this.app.enabled('location back-referrer')) {
     loc = this.req.get('Referrer') || '/';
   }
 

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -99,6 +99,21 @@ describe('res', function(){
         .expect('Location', '/')
         .expect(200, done)
       })
+
+      it('should set the header to "back" on back', function (done) {
+        var app = express()
+
+        app.disable("location back-referrer")
+
+        app.use(function (req, res) {
+          res.location('back').end()
+        })
+
+        request(app)
+        .get('/')
+        .expect('Location', 'back')
+        .expect(200, done)
+      })
     })
   })
 })


### PR DESCRIPTION
Make option for setting back as location to override built in behavior. To redirect to page "back", default behavior is to use referrer or navigate to root of domain and not the intended relative path. This can be compensated for with "./back" but when dealing with third party responses, you would need to test for "back" on every call to replace.

Added tests for location('back')