### PR TITLE
test: convert var to es6 const

### DIFF
--- a/test/app.all.js
+++ b/test/app.all.js
@@ -1,10 +1,10 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app.all()', function(){
   it('should add a router per method', function(done){
-    var app = express();
+    const app = express();
 
     app.all('/tobi', function(req, res){
       res.end(req.method);
@@ -20,8 +20,8 @@ describe('app.all()', function(){
   })
 
   it('should run the callback for a method just once', function(done){
-    var app = express()
-      , n = 0;
+    const app = express()
+    var n = 0;
 
     app.all('/*', function(req, res, next){
       if (n++) return done(new Error('DELETE called several times'));

--- a/test/app.del.js
+++ b/test/app.del.js
@@ -1,10 +1,10 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app.del()', function(){
   it('should alias app.delete()', function(done){
-    var app = express();
+    const app = express();
 
     app.del('/tobi', function(req, res){
       res.end('deleted tobi!');

--- a/test/app.head.js
+++ b/test/app.head.js
@@ -1,11 +1,11 @@
 
-var express = require('../');
-var request = require('supertest');
-var assert = require('assert');
+const express = require('../');
+const request = require('supertest');
+const assert = require('assert');
 
 describe('HEAD', function(){
   it('should default to GET', function(done){
-    var app = express();
+    const app = express();
 
     app.get('/tobi', function(req, res){
       // send() detects HEAD
@@ -45,8 +45,8 @@ describe('HEAD', function(){
 
 describe('app.head()', function(){
   it('should override', function(done){
-    var app = express()
-      , called;
+    const app = express()
+    var called;
 
     app.head('/tobi', function(req, res){
       called = true;

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -1,16 +1,16 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const equest = require('supertest');
 
 describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
-    var app = express();
+    const app = express();
 
     app.del('/tobi', function(req, res){
       res.end('deleted tobi!');
     });
 
-    var server = app.listen(9999, function(){
+    const server = app.listen(9999, function(){
       server.close();
       done();
     });

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app', function(){
   describe('.locals(obj)', function(){
     it('should merge locals', function(){
-      var app = express();
+      const app = express();
       Object.keys(app.locals).should.eql(['settings']);
       app.locals.user = 'tobi';
       app.locals.age = 2;

--- a/test/app.request.js
+++ b/test/app.request.js
@@ -1,6 +1,6 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app', function(){
   describe('.request', function(){

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,6 +1,6 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('throw after .end()', function(){
   it('should fail gracefully', function(done){

--- a/test/req.stale.js
+++ b/test/req.stale.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.stale', function(){
     it('should return false when the resource is not modified', function(done){
-      var app = express();
-      var etag = '"12345"';
+      const app = express();
+      const etag = '"12345"';
 
       app.use(function(req, res){
         res.set('ETag', etag);
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should return true when the resource is modified', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('ETag', '"123"');
@@ -34,7 +34,7 @@ describe('req', function(){
     })
 
     it('should return true without response headers', function(done){
-      var app = express();
+      const app = express();
 
       app.disable('x-powered-by')
       app.use(function(req, res){

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.clearCookie(name)', function(){
     it('should set a cookie passed expiry', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.clearCookie('sid').end();
@@ -20,7 +20,7 @@ describe('res', function(){
 
   describe('.clearCookie(name, options)', function(){
     it('should set the given params', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.clearCookie('sid', { path: '/admin' }).end();

--- a/test/res.get.js
+++ b/test/res.get.js
@@ -1,11 +1,11 @@
 
-var express = require('..');
-var request = require('supertest');
+const express = require('..');
+const request = require('supertest');
 
 describe('res', function(){
   describe('.get(field)', function(){
     it('should get the response header field', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.setHeader('Content-Type', 'text/x-foo');

--- a/test/res.links.js
+++ b/test/res.links.js
@@ -1,11 +1,11 @@
 
-var express = require('..');
-var request = require('supertest');
+const express = require('..');
+const request = require('supertest');
 
 describe('res', function(){
   describe('.links(obj)', function(){
     it('should set Link header field', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.links({
@@ -22,7 +22,7 @@ describe('res', function(){
     })
 
     it('should set Link header field for multiple calls', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.links({

--- a/test/res.locals.js
+++ b/test/res.locals.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.locals', function(){
     it('should be empty by default', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         Object.keys(res.locals).should.eql([]);
@@ -19,8 +19,8 @@ describe('res', function(){
   })
 
   it('should work when mounted', function(done){
-    var app = express();
-    var blog = express();
+    const app = express();
+    const blog = express();
 
     app.use(blog);
 

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.location(url)', function(){
     it('should set the header', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.location('http://google.com').end();
@@ -18,7 +18,7 @@ describe('res', function(){
     })
 
     it('should encode "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.location('https://google.com?q=\u2603 §10').end()
@@ -31,7 +31,7 @@ describe('res', function(){
     })
 
     it('should not touch already-encoded sequences in "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.location('https://google.com?q=%A710').end()

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -1,12 +1,12 @@
 
-var assert = require('assert')
-var express = require('..')
-var request = require('supertest')
+const assert = require('assert')
+const express = require('..')
+const request = require('supertest')
 
 describe('res', function () {
   describe('.sendStatus(statusCode)', function () {
     it('should send the status code and message as body', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendStatus(201);
@@ -18,7 +18,7 @@ describe('res', function () {
     })
 
     it('should work with unknown code', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendStatus(599);

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.status(code)', function(){
     it('should set the response .statusCode', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.status(201).end('Created');


### PR DESCRIPTION
Convert var in some test cases to const. Changed some const
assignment statements that used the form `const var
\n , var` to `const var \n const var` to match style used
in some of the other test files.

- [x] all tests passing