### PR TITLE
test: convert var to const

### DIFF
--- a/test/app.all.js
+++ b/test/app.all.js
@@ -1,10 +1,10 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app.all()', function(){
   it('should add a router per method', function(done){
-    var app = express();
+    const app = express();
 
     app.all('/tobi', function(req, res){
       res.end(req.method);
@@ -20,8 +20,8 @@ describe('app.all()', function(){
   })
 
   it('should run the callback for a method just once', function(done){
-    var app = express()
-      , n = 0;
+    const app = express()
+    var n = 0;
 
     app.all('/*', function(req, res, next){
       if (n++) return done(new Error('DELETE called several times'));

--- a/test/app.del.js
+++ b/test/app.del.js
@@ -1,10 +1,10 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app.del()', function(){
   it('should alias app.delete()', function(done){
-    var app = express();
+    const app = express();
 
     app.del('/tobi', function(req, res){
       res.end('deleted tobi!');

--- a/test/app.engine.js
+++ b/test/app.engine.js
@@ -1,7 +1,7 @@
 
-var express = require('../')
-  , fs = require('fs');
-var path = require('path')
+const express = require('../');
+const fs = require('fs');
+const path = require('path')
 
 function render(path, options, fn) {
   fs.readFile(path, 'utf8', function(err, str){
@@ -14,7 +14,7 @@ function render(path, options, fn) {
 describe('app', function(){
   describe('.engine(ext, fn)', function(){
     it('should map a template engine', function(done){
-      var app = express();
+      const app = express();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.engine('.html', render);
@@ -28,14 +28,14 @@ describe('app', function(){
     })
 
     it('should throw when the callback is missing', function(){
-      var app = express();
+      const app = express();
       (function(){
         app.engine('.html', null);
       }).should.throw('callback function required');
     })
 
     it('should work without leading "."', function(done){
-      var app = express();
+      const app = express();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.engine('html', render);
@@ -49,7 +49,7 @@ describe('app', function(){
     })
 
     it('should work "view engine" setting', function(done){
-      var app = express();
+      const app = express();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.engine('html', render);
@@ -64,7 +64,7 @@ describe('app', function(){
     })
 
     it('should work "view engine" with leading "."', function(done){
-      var app = express();
+      const app = express();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.engine('.html', render);

--- a/test/app.head.js
+++ b/test/app.head.js
@@ -1,11 +1,11 @@
 
-var express = require('../');
-var request = require('supertest');
-var assert = require('assert');
+const express = require('../');
+const request = require('supertest');
+const assert = require('assert');
 
 describe('HEAD', function(){
   it('should default to GET', function(done){
-    var app = express();
+    const app = express();
 
     app.get('/tobi', function(req, res){
       // send() detects HEAD
@@ -45,8 +45,8 @@ describe('HEAD', function(){
 
 describe('app.head()', function(){
   it('should override', function(done){
-    var app = express()
-      , called;
+    const app = express()
+    var called;
 
     app.head('/tobi', function(req, res){
       called = true;

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -1,15 +1,15 @@
 
-var express = require('../')
+const express = require('../')
 
 describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
-    var app = express();
+    const app = express();
 
     app.del('/tobi', function(req, res){
       res.end('deleted tobi!');
     });
 
-    var server = app.listen(9999, function(){
+    const server = app.listen(9999, function(){
       server.close();
       done();
     });

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -1,10 +1,10 @@
 
-var express = require('../')
+const express = require('../')
 
 describe('app', function(){
   describe('.locals(obj)', function(){
     it('should merge locals', function(){
-      var app = express();
+      const app = express();
       Object.keys(app.locals).should.eql(['settings']);
       app.locals.user = 'tobi';
       app.locals.age = 2;

--- a/test/app.request.js
+++ b/test/app.request.js
@@ -1,6 +1,6 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('app', function(){
   describe('.request', function(){

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,6 +1,6 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('throw after .end()', function(){
   it('should fail gracefully', function(done){

--- a/test/req.acceptsCharset.js
+++ b/test/req.acceptsCharset.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsCharset(type)', function(){
     describe('when Accept-Charset is not present', function(){
       it('should return true', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharset('utf-8') ? 'yes' : 'no');
@@ -20,7 +20,7 @@ describe('req', function(){
 
     describe('when Accept-Charset is not present', function(){
       it('should return true when present', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharset('utf-8') ? 'yes' : 'no');
@@ -33,7 +33,7 @@ describe('req', function(){
       })
 
       it('should return false otherwise', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharset('utf-8') ? 'yes' : 'no');

--- a/test/req.acceptsCharsets.js
+++ b/test/req.acceptsCharsets.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsCharsets(type)', function(){
     describe('when Accept-Charset is not present', function(){
       it('should return true', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharsets('utf-8') ? 'yes' : 'no');
@@ -20,7 +20,7 @@ describe('req', function(){
 
     describe('when Accept-Charset is not present', function(){
       it('should return true when present', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharsets('utf-8') ? 'yes' : 'no');
@@ -33,7 +33,7 @@ describe('req', function(){
       })
 
       it('should return false otherwise', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.end(req.acceptsCharsets('utf-8') ? 'yes' : 'no');

--- a/test/req.acceptsEncoding.js
+++ b/test/req.acceptsEncoding.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsEncoding', function(){
     it('should be true if encoding accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsEncoding('gzip').should.be.ok()
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should be false if encoding not accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsEncoding('bogus').should.not.be.ok()

--- a/test/req.acceptsEncodings.js
+++ b/test/req.acceptsEncodings.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsEncodingss', function(){
     it('should be true if encoding accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsEncodings('gzip').should.be.ok()
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should be false if encoding not accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsEncodings('bogus').should.not.be.ok()

--- a/test/req.acceptsLanguage.js
+++ b/test/req.acceptsLanguage.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsLanguage', function(){
     it('should be true if language accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsLanguage('en-us').should.be.ok()
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should be false if language not accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsLanguage('es').should.not.be.ok()
@@ -35,7 +35,7 @@ describe('req', function(){
 
     describe('when Accept-Language is not present', function(){
       it('should always return true', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           req.acceptsLanguage('en').should.be.ok()

--- a/test/req.acceptsLanguages.js
+++ b/test/req.acceptsLanguages.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.acceptsLanguages', function(){
     it('should be true if language accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsLanguages('en-us').should.be.ok()
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should be false if language not accepted', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.acceptsLanguages('es').should.not.be.ok()
@@ -35,7 +35,7 @@ describe('req', function(){
 
     describe('when Accept-Language is not present', function(){
       it('should always return true', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           req.acceptsLanguages('en').should.be.ok()

--- a/test/req.fresh.js
+++ b/test/req.fresh.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.fresh', function(){
     it('should return true when the resource is not modified', function(done){
-      var app = express();
-      var etag = '"12345"';
+      const app = express();
+      const etag = '"12345"';
 
       app.use(function(req, res){
         res.set('ETag', etag);
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should return false when the resource is modified', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('ETag', '"123"');
@@ -34,7 +34,7 @@ describe('req', function(){
     })
 
     it('should return false without response headers', function(done){
-      var app = express();
+      const app = express();
 
       app.disable('x-powered-by')
       app.use(function(req, res){

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , assert = require('assert');
+const express = require('../')
+const request = require('supertest')
+const assert = require('assert');
 
 describe('req', function(){
   describe('.get(field)', function(){
     it('should return the header field value', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         assert(req.get('Something-Else') === undefined);
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should special-case Referer', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.get('Referer'));
@@ -33,7 +33,7 @@ describe('req', function(){
     })
 
     it('should throw missing header name', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.end(req.get())
@@ -45,7 +45,7 @@ describe('req', function(){
     })
 
     it('should throw for non-string header name', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.end(req.get(42))

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest')
+const express = require('../')
+const request = require('supertest')
 
 describe('req', function(){
   describe('.host', function(){
     it('should return the Host when present', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.host);
@@ -18,7 +18,7 @@ describe('req', function(){
     })
 
     it('should strip port number', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.host);
@@ -31,7 +31,7 @@ describe('req', function(){
     })
 
     it('should return undefined otherwise', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.headers.host = null;
@@ -44,7 +44,7 @@ describe('req', function(){
     })
 
     it('should work with IPv6 Host', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.host);
@@ -57,7 +57,7 @@ describe('req', function(){
     })
 
     it('should work with IPv6 Host and port', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.host);
@@ -71,7 +71,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is enabled', function(){
       it('should respect X-Forwarded-Host', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -87,7 +87,7 @@ describe('req', function(){
       })
 
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){
-        var app = express();
+        const app = express();
 
         app.set('trust proxy', '10.0.0.1');
 
@@ -103,7 +103,7 @@ describe('req', function(){
       })
 
       it('should default to Host', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -119,7 +119,7 @@ describe('req', function(){
 
       describe('when trusting hop count', function () {
         it('should respect X-Forwarded-Host', function (done) {
-          var app = express();
+          const app = express();
 
           app.set('trust proxy', 1);
 
@@ -138,7 +138,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is disabled', function(){
       it('should ignore X-Forwarded-Host', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.end(req.host);

--- a/test/req.hostname.js
+++ b/test/req.hostname.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest')
+const express = require('../')
+const request = require('supertest')
 
 describe('req', function(){
   describe('.hostname', function(){
     it('should return the Host when present', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.hostname);
@@ -18,7 +18,7 @@ describe('req', function(){
     })
 
     it('should strip port number', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.hostname);
@@ -31,7 +31,7 @@ describe('req', function(){
     })
 
     it('should return undefined otherwise', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.headers.host = null;
@@ -44,7 +44,7 @@ describe('req', function(){
     })
 
     it('should work with IPv6 Host', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.hostname);
@@ -57,7 +57,7 @@ describe('req', function(){
     })
 
     it('should work with IPv6 Host and port', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.hostname);
@@ -71,7 +71,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is enabled', function(){
       it('should respect X-Forwarded-Host', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -87,7 +87,7 @@ describe('req', function(){
       })
 
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){
-        var app = express();
+        const app = express();
 
         app.set('trust proxy', '10.0.0.1');
 
@@ -103,7 +103,7 @@ describe('req', function(){
       })
 
       it('should default to Host', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -120,7 +120,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is disabled', function(){
       it('should ignore X-Forwarded-Host', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.end(req.hostname);

--- a/test/req.ip.js
+++ b/test/req.ip.js
@@ -1,13 +1,13 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.ip', function(){
     describe('when X-Forwarded-For is present', function(){
       describe('when "trust proxy" is enabled', function(){
         it('should return the client addr', function(done){
-          var app = express();
+          const app = express();
 
           app.enable('trust proxy');
 
@@ -22,7 +22,7 @@ describe('req', function(){
         })
 
         it('should return the addr after trusted proxy', function(done){
-          var app = express();
+          const app = express();
 
           app.set('trust proxy', 2);
 
@@ -37,7 +37,7 @@ describe('req', function(){
         })
 
         it('should return the addr after trusted proxy, from sub app', function (done) {
-          var app = express();
+          const app = express();
           var sub = express();
 
           app.set('trust proxy', 2);
@@ -56,7 +56,7 @@ describe('req', function(){
 
       describe('when "trust proxy" is disabled', function(){
         it('should return the remote address', function(done){
-          var app = express();
+          const app = express();
 
           app.use(function(req, res, next){
             res.send(req.ip);
@@ -71,7 +71,7 @@ describe('req', function(){
 
     describe('when X-Forwarded-For is not present', function(){
       it('should return the remote address', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 

--- a/test/req.ips.js
+++ b/test/req.ips.js
@@ -1,13 +1,13 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.ips', function(){
     describe('when X-Forwarded-For is present', function(){
       describe('when "trust proxy" is enabled', function(){
         it('should return an array of the specified addresses', function(done){
-          var app = express();
+          const app = express();
 
           app.enable('trust proxy');
 
@@ -22,7 +22,7 @@ describe('req', function(){
         })
 
         it('should stop at first untrusted', function(done){
-          var app = express();
+          const app = express();
 
           app.set('trust proxy', 2);
 
@@ -39,7 +39,7 @@ describe('req', function(){
 
       describe('when "trust proxy" is disabled', function(){
         it('should return an empty array', function(done){
-          var app = express();
+          const app = express();
 
           app.use(function(req, res, next){
             res.send(req.ips);
@@ -55,7 +55,7 @@ describe('req', function(){
 
     describe('when X-Forwarded-For is not present', function(){
       it('should return []', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res, next){
           res.send(req.ips);

--- a/test/req.is.js
+++ b/test/req.is.js
@@ -1,11 +1,11 @@
 
-var express = require('..')
-var request = require('supertest')
+const express = require('..')
+const request = require('supertest')
 
 describe('req.is()', function () {
   describe('when given a mime type', function () {
     it('should return the type when matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('application/json'))
@@ -19,7 +19,7 @@ describe('req.is()', function () {
     })
 
     it('should return false when not matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('image/jpeg'))
@@ -33,7 +33,7 @@ describe('req.is()', function () {
     })
 
     it('should ignore charset', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('application/json'))
@@ -49,7 +49,7 @@ describe('req.is()', function () {
 
   describe('when content-type is not present', function(){
     it('should return false', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('application/json'))
@@ -64,7 +64,7 @@ describe('req.is()', function () {
 
   describe('when given an extension', function(){
     it('should lookup the mime type', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('json'))
@@ -80,7 +80,7 @@ describe('req.is()', function () {
 
   describe('when given */subtype', function(){
     it('should return the full type when matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('*/json'))
@@ -94,7 +94,7 @@ describe('req.is()', function () {
     })
 
     it('should return false when not matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('*/html'))
@@ -108,7 +108,7 @@ describe('req.is()', function () {
     })
 
     it('should ignore charset', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('*/json'))
@@ -124,7 +124,7 @@ describe('req.is()', function () {
 
   describe('when given type/*', function(){
     it('should return the full type when matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('application/*'))
@@ -138,7 +138,7 @@ describe('req.is()', function () {
     })
 
     it('should return false when not matching', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('text/*'))
@@ -152,7 +152,7 @@ describe('req.is()', function () {
     })
 
     it('should ignore charset', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.is('application/*'))

--- a/test/req.param.js
+++ b/test/req.param.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , bodyParser = require('body-parser')
+const express = require('../')
+const request = require('supertest')
+const bodyParser = require('body-parser')
 
 describe('req', function(){
   describe('.param(name, default)', function(){
     it('should use the default value unless defined', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.param('name', 'tj'));
@@ -20,7 +20,7 @@ describe('req', function(){
 
   describe('.param(name)', function(){
     it('should check req.query', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.param('name'));
@@ -32,7 +32,7 @@ describe('req', function(){
     })
 
     it('should check req.body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(bodyParser.json());
 
@@ -47,7 +47,7 @@ describe('req', function(){
     })
 
     it('should check req.params', function(done){
-      var app = express();
+      const app = express();
 
       app.get('/user/:name', function(req, res){
         res.end(req.param('filter') + req.param('name'));

--- a/test/req.path.js
+++ b/test/req.path.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.path', function(){
     it('should return the parsed pathname', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.path);

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.protocol', function(){
     it('should return the protocol string', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.end(req.protocol);
@@ -18,7 +18,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is enabled', function(){
       it('should respect X-Forwarded-Proto', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -33,7 +33,7 @@ describe('req', function(){
       })
 
       it('should default to the socket addr if X-Forwarded-Proto not present', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -48,7 +48,7 @@ describe('req', function(){
       })
 
       it('should ignore X-Forwarded-Proto if socket addr not trusted', function(done){
-        var app = express();
+        const app = express();
 
         app.set('trust proxy', '10.0.0.1');
 
@@ -63,7 +63,7 @@ describe('req', function(){
       })
 
       it('should default to http', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -78,7 +78,7 @@ describe('req', function(){
 
       describe('when trusting hop count', function () {
         it('should respect X-Forwarded-Proto', function (done) {
-          var app = express();
+          const app = express();
 
           app.set('trust proxy', 1);
 
@@ -96,7 +96,7 @@ describe('req', function(){
 
     describe('when "trust proxy" is disabled', function(){
       it('should ignore X-Forwarded-Proto', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.end(req.protocol);

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.query', function(){
     it('should default to {}', function(done){
-      var app = createApp();
+      const app = createApp();
 
       request(app)
       .get('/')
@@ -13,7 +13,7 @@ describe('req', function(){
     });
 
     it('should default to parse complex keys', function (done) {
-      var app = createApp();
+      const app = createApp();
 
       request(app)
       .get('/?user[name]=tj')
@@ -22,7 +22,7 @@ describe('req', function(){
 
     describe('when "query parser" is extended', function () {
       it('should parse complex keys', function (done) {
-        var app = createApp('extended');
+        const app = createApp('extended');
 
         request(app)
         .get('/?user[name]=tj')
@@ -30,7 +30,7 @@ describe('req', function(){
       });
 
       it('should parse parameters with dots', function (done) {
-        var app = createApp('extended');
+        const app = createApp('extended');
 
         request(app)
         .get('/?user.name=tj')
@@ -40,7 +40,7 @@ describe('req', function(){
 
     describe('when "query parser" is simple', function () {
       it('should not parse complex keys', function (done) {
-        var app = createApp('simple');
+        const app = createApp('simple');
 
         request(app)
         .get('/?user%5Bname%5D=tj')
@@ -50,7 +50,7 @@ describe('req', function(){
 
     describe('when "query parser" is a function', function () {
       it('should parse using function', function (done) {
-        var app = createApp(function (str) {
+        const app = createApp(function (str) {
           return {'length': (str || '').length};
         });
 
@@ -62,7 +62,7 @@ describe('req', function(){
 
     describe('when "query parser" disabled', function () {
       it('should not parse query', function (done) {
-        var app = createApp(false);
+        const app = createApp(false);
 
         request(app)
         .get('/?user%5Bname%5D=tj')
@@ -72,7 +72,7 @@ describe('req', function(){
 
     describe('when "query parser" disabled', function () {
       it('should not parse complex keys', function (done) {
-        var app = createApp(true);
+        const app = createApp(true);
 
         request(app)
         .get('/?user%5Bname%5D=tj')
@@ -82,7 +82,7 @@ describe('req', function(){
 
     describe('when "query parser fn" is missing', function () {
       it('should act like "extended"', function (done) {
-        var app = express();
+        const app = express();
 
         delete app.settings['query parser'];
         delete app.settings['query parser fn'];
@@ -106,7 +106,7 @@ describe('req', function(){
 })
 
 function createApp(setting) {
-  var app = express();
+  const app = express();
 
   if (setting !== undefined) {
     app.set('query parser', setting);

--- a/test/req.range.js
+++ b/test/req.range.js
@@ -1,11 +1,11 @@
 
-var express = require('..');
-var request = require('supertest')
+const express = require('..');
+const request = require('supertest')
 
 describe('req', function(){
   describe('.range(size)', function(){
     it('should return parsed ranges', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.range(120))
@@ -18,7 +18,7 @@ describe('req', function(){
     })
 
     it('should cap to the given size', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.range(75))
@@ -31,7 +31,7 @@ describe('req', function(){
     })
 
     it('should cap to the given size when open-ended', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.range(75))
@@ -44,7 +44,7 @@ describe('req', function(){
     })
 
     it('should have a .type', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.range(120).type)
@@ -57,7 +57,7 @@ describe('req', function(){
     })
 
     it('should accept any type', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.json(req.range(120).type)
@@ -70,7 +70,7 @@ describe('req', function(){
     })
 
     it('should return undefined if no range', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.send(String(req.range(120)))
@@ -85,7 +85,7 @@ describe('req', function(){
   describe('.range(size, options)', function(){
     describe('with "combine: true" option', function(){
       it('should return combined ranges', function (done) {
-        var app = express()
+        const app = express()
 
         app.use(function (req, res) {
           res.json(req.range(120, {

--- a/test/req.route.js
+++ b/test/req.route.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.route', function(){
     it('should be the executed Route', function(done){
-      var app = express();
+      const app = express();
 
       app.get('/user/:id/:op?', function(req, res, next){
         req.route.path.should.equal('/user/:id/:op?');

--- a/test/req.secure.js
+++ b/test/req.secure.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../');
+const request = require('supertest');
 
 describe('req', function(){
   describe('.secure', function(){
     describe('when X-Forwarded-Proto is missing', function(){
       it('should return false when http', function(done){
-        var app = express();
+        const app = express();
 
         app.get('/', function(req, res){
           res.send(req.secure ? 'yes' : 'no');
@@ -22,7 +22,7 @@ describe('req', function(){
   describe('.secure', function(){
     describe('when X-Forwarded-Proto is present', function(){
       it('should return false when http', function(done){
-        var app = express();
+        const app = express();
 
         app.get('/', function(req, res){
           res.send(req.secure ? 'yes' : 'no');
@@ -35,7 +35,7 @@ describe('req', function(){
       })
 
       it('should return true when "trust proxy" is enabled', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -50,7 +50,7 @@ describe('req', function(){
       })
 
       it('should return false when initial proxy is http', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -65,7 +65,7 @@ describe('req', function(){
       })
 
       it('should return true when initial proxy is https', function(done){
-        var app = express();
+        const app = express();
 
         app.enable('trust proxy');
 
@@ -81,7 +81,7 @@ describe('req', function(){
 
       describe('when "trust proxy" trusting hop count', function () {
         it('should respect X-Forwarded-Proto', function (done) {
-          var app = express();
+          const app = express();
 
           app.set('trust proxy', 1);
 

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , cookieParser = require('cookie-parser')
+const express = require('../')
+const request = require('supertest')
+const cookieParser = require('cookie-parser')
 
 describe('req', function(){
   describe('.signedCookies', function(){
     it('should return a signed JSON cookie', function(done){
-      var app = express();
+      const app = express();
 
       app.use(cookieParser('secret'));
 
@@ -23,7 +23,7 @@ describe('req', function(){
       .get('/set')
       .end(function(err, res){
         if (err) return done(err);
-        var cookie = res.header['set-cookie'];
+        const cookie = res.header['set-cookie'];
 
         request(app)
         .get('/')

--- a/test/req.stale.js
+++ b/test/req.stale.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.stale', function(){
     it('should return false when the resource is not modified', function(done){
-      var app = express();
-      var etag = '"12345"';
+      const app = express();
+      const etag = '"12345"';
 
       app.use(function(req, res){
         res.set('ETag', etag);
@@ -20,7 +20,7 @@ describe('req', function(){
     })
 
     it('should return true when the resource is modified', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('ETag', '"123"');
@@ -34,7 +34,7 @@ describe('req', function(){
     })
 
     it('should return true without response headers', function(done){
-      var app = express();
+      const app = express();
 
       app.disable('x-powered-by')
       app.use(function(req, res){

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.subdomains', function(){
     describe('when present', function(){
       it('should return an array', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.send(req.subdomains);
@@ -19,7 +19,7 @@ describe('req', function(){
       })
 
       it('should work with IPv4 address', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.send(req.subdomains);
@@ -32,7 +32,7 @@ describe('req', function(){
       })
 
       it('should work with IPv6 address', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.send(req.subdomains);
@@ -47,7 +47,7 @@ describe('req', function(){
 
     describe('otherwise', function(){
       it('should return an empty array', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.send(req.subdomains);
@@ -62,7 +62,7 @@ describe('req', function(){
 
     describe('with no host', function(){
       it('should return an empty array', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           req.headers.host = null;
@@ -77,7 +77,7 @@ describe('req', function(){
 
     describe('with trusted X-Forwarded-Host', function () {
       it('should return an array', function (done) {
-        var app = express();
+        const app = express();
 
         app.set('trust proxy', true);
         app.use(function (req, res) {
@@ -94,7 +94,7 @@ describe('req', function(){
     describe('when subdomain offset is set', function(){
       describe('when subdomain offset is zero', function(){
         it('should return an array with the whole domain', function(done){
-          var app = express();
+          const app = express();
           app.set('subdomain offset', 0);
 
           app.use(function(req, res){
@@ -108,7 +108,7 @@ describe('req', function(){
         })
 
         it('should return an array with the whole IPv4', function (done) {
-          var app = express();
+          const app = express();
           app.set('subdomain offset', 0);
 
           app.use(function(req, res){
@@ -122,7 +122,7 @@ describe('req', function(){
         })
 
         it('should return an array with the whole IPv6', function (done) {
-          var app = express();
+          const app = express();
           app.set('subdomain offset', 0);
 
           app.use(function(req, res){
@@ -138,7 +138,7 @@ describe('req', function(){
 
       describe('when present', function(){
         it('should return an array', function(done){
-          var app = express();
+          const app = express();
           app.set('subdomain offset', 3);
 
           app.use(function(req, res){
@@ -154,7 +154,7 @@ describe('req', function(){
 
       describe('otherwise', function(){
         it('should return an empty array', function(done){
-          var app = express();
+          const app = express();
           app.set('subdomain offset', 3);
 
           app.use(function(req, res){

--- a/test/req.xhr.js
+++ b/test/req.xhr.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('req', function(){
   describe('.xhr', function(){
     it('should return true when X-Requested-With is xmlhttprequest', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.xhr.should.be.true()
@@ -22,7 +22,7 @@ describe('req', function(){
     })
 
     it('should case-insensitive', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.xhr.should.be.true()
@@ -39,7 +39,7 @@ describe('req', function(){
     })
 
     it('should return false otherwise', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.xhr.should.be.false()
@@ -56,7 +56,7 @@ describe('req', function(){
     })
 
     it('should return false when not present', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         req.xhr.should.be.false()

--- a/test/res.append.js
+++ b/test/res.append.js
@@ -1,7 +1,7 @@
 
-var express = require('..')
-var request = require('supertest')
-var should = require('should')
+const express = require('..')
+const request = require('supertest')
+const should = require('should')
 
 describe('res', function () {
   // note about these tests: "Link" and "X-*" are chosen because
@@ -10,7 +10,7 @@ describe('res', function () {
   // for outgoing, though
   describe('.append(field, val)', function () {
     it('should append multiple headers', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.append('Link', '<http://localhost/>')
@@ -28,7 +28,7 @@ describe('res', function () {
     })
 
     it('should accept array of values', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.append('Set-Cookie', ['foo=bar', 'fizz=buzz'])
@@ -44,7 +44,7 @@ describe('res', function () {
     })
 
     it('should get reset by res.set(field, val)', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.append('Link', '<http://localhost/>')
@@ -63,7 +63,7 @@ describe('res', function () {
     })
 
     it('should work with res.set(field, val) first', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.set('Link', '<http://localhost/>')
@@ -81,7 +81,7 @@ describe('res', function () {
     })
 
     it('should work with cookies', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.cookie('foo', 'bar')

--- a/test/res.attachment.js
+++ b/test/res.attachment.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.attachment()', function(){
     it('should Content-Disposition to attachment', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.attachment().send('foo');
@@ -19,7 +19,7 @@ describe('res', function(){
 
   describe('.attachment(filename)', function(){
     it('should add the filename param', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.attachment('/path/to/image.png');
@@ -32,7 +32,7 @@ describe('res', function(){
     })
 
     it('should set the Content-Type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.attachment('/path/to/image.png');
@@ -47,7 +47,7 @@ describe('res', function(){
 
   describe('.attachment(utf8filename)', function(){
     it('should add the filename and filename* params', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.attachment('/locales/日本語.txt');
@@ -61,7 +61,7 @@ describe('res', function(){
     })
 
     it('should set the Content-Type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.attachment('/locales/日本語.txt');

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.clearCookie(name)', function(){
     it('should set a cookie passed expiry', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.clearCookie('sid').end();
@@ -20,7 +20,7 @@ describe('res', function(){
 
   describe('.clearCookie(name, options)', function(){
     it('should set the given params', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.clearCookie('sid', { path: '/admin' }).end();

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -1,14 +1,14 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , cookie = require('cookie')
-  , cookieParser = require('cookie-parser')
-var merge = require('utils-merge');
+const express = require('../')
+const request = require('supertest')
+const cookie = require('cookie')
+const cookieParser = require('cookie-parser')
+const merge = require('utils-merge');
 
 describe('res', function(){
   describe('.cookie(name, object)', function(){
     it('should generate a JSON cookie', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.cookie('user', { name: 'tobi' }).end();
@@ -23,7 +23,7 @@ describe('res', function(){
 
   describe('.cookie(name, string)', function(){
     it('should set a cookie', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.cookie('name', 'tobi').end();
@@ -36,7 +36,7 @@ describe('res', function(){
     })
 
     it('should allow multiple calls', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.cookie('name', 'tobi');
@@ -57,7 +57,7 @@ describe('res', function(){
 
   describe('.cookie(name, string, options)', function(){
     it('should set params', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.cookie('name', 'tobi', { httpOnly: true, secure: true });
@@ -72,7 +72,7 @@ describe('res', function(){
 
     describe('maxAge', function(){
       it('should set relative expires', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.cookie('name', 'tobi', { maxAge: 1000 });
@@ -88,7 +88,7 @@ describe('res', function(){
       })
 
       it('should set max-age', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.cookie('name', 'tobi', { maxAge: 1000 });
@@ -101,7 +101,7 @@ describe('res', function(){
       })
 
       it('should not mutate the options object', function(done){
-        var app = express();
+        const app = express();
 
         var options = { maxAge: 1000 };
         var optionsCopy = merge({}, options);
@@ -122,7 +122,7 @@ describe('res', function(){
 
     describe('signed', function(){
       it('should generate a signed JSON cookie', function(done){
-        var app = express();
+        const app = express();
 
         app.use(cookieParser('foo bar baz'));
 
@@ -143,7 +143,7 @@ describe('res', function(){
 
     describe('signed without secret', function(){
       it('should throw an error', function(done){
-        var app = express();
+        const app = express();
 
         app.use(cookieParser());
 
@@ -159,7 +159,7 @@ describe('res', function(){
 
     describe('.signedCookie(name, string)', function(){
       it('should set a signed cookie', function(done){
-        var app = express();
+        const app = express();
 
         app.use(cookieParser('foo bar baz'));
 

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -1,13 +1,13 @@
 
-var after = require('after');
-var assert = require('assert');
-var express = require('..');
-var request = require('supertest');
+const after = require('after');
+const assert = require('assert');
+const express = require('..');
+const request = require('supertest');
 
 describe('res', function(){
   describe('.download(path)', function(){
     it('should transfer as an attachment', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.download('test/fixtures/user.html');
@@ -23,7 +23,7 @@ describe('res', function(){
 
   describe('.download(path, filename)', function(){
     it('should provide an alternate filename', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.download('test/fixtures/user.html', 'document');
@@ -39,8 +39,8 @@ describe('res', function(){
 
   describe('.download(path, fn)', function(){
     it('should invoke the callback', function(done){
-      var app = express();
-      var cb = after(2, done);
+      const app = express();
+      const cb = after(2, done);
 
       app.use(function(req, res){
         res.download('test/fixtures/user.html', cb);
@@ -56,8 +56,8 @@ describe('res', function(){
 
   describe('.download(path, filename, fn)', function(){
     it('should invoke the callback', function(done){
-      var app = express();
-      var cb = after(2, done);
+      const app = express();
+      const cb = after(2, done);
 
       app.use(function(req, res){
         res.download('test/fixtures/user.html', 'document', done);
@@ -73,7 +73,7 @@ describe('res', function(){
 
   describe('on failure', function(){
     it('should invoke the callback', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function (req, res, next) {
         res.download('test/fixtures/foobar.html', function(err){
@@ -88,7 +88,7 @@ describe('res', function(){
     })
 
     it('should remove Content-Disposition', function(done){
-      var app = express()
+      const app = express()
 
       app.use(function (req, res, next) {
         res.download('test/fixtures/foobar.html', function(err){

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -1,6 +1,11 @@
 
+<<<<<<< HEAD
 const express = require('../')
 const request = require('supertest')
+=======
+const express = require('../');
+const request = require('supertest');
+>>>>>>> more var to const changes
 const assert = require('assert');
 
 const app1 = express();

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -1,9 +1,9 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , assert = require('assert');
+const express = require('../')
+const request = require('supertest')
+const assert = require('assert');
 
-var app1 = express();
+const app1 = express();
 
 app1.use(function(req, res, next){
   res.format({
@@ -29,7 +29,7 @@ app1.use(function(err, req, res, next){
   res.send(err.status, 'Supports: ' + err.types.join(', '));
 })
 
-var app2 = express();
+const app2 = express();
 
 app2.use(function(req, res, next){
   res.format({
@@ -43,7 +43,7 @@ app2.use(function(err, req, res, next){
   res.send(err.status, 'Supports: ' + err.types.join(', '));
 })
 
-var app3 = express();
+const app3 = express();
 
 app3.use(function(req, res, next){
   res.format({
@@ -52,7 +52,7 @@ app3.use(function(req, res, next){
   })
 });
 
-var app4 = express();
+const app4 = express();
 
 app4.get('/', function(req, res, next){
   res.format({
@@ -66,7 +66,7 @@ app4.use(function(err, req, res, next){
   res.send(err.status, 'Supports: ' + err.types.join(', '));
 })
 
-var app5 = express();
+const app5 = express();
 
 app5.use(function (req, res, next) {
   res.format({
@@ -85,7 +85,7 @@ describe('res', function(){
     })
 
     describe('with parameters', function(){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res, next){
         res.format({
@@ -123,8 +123,8 @@ describe('res', function(){
     })
 
     describe('in router', function(){
-      var app = express();
-      var router = express.Router();
+      const app = express();
+      const router = express.Router();
 
       router.get('/', function(req, res, next){
         res.format({

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -1,11 +1,5 @@
-
-<<<<<<< HEAD
-const express = require('../')
-const request = require('supertest')
-=======
 const express = require('../');
 const request = require('supertest');
->>>>>>> more var to const changes
 const assert = require('assert');
 
 const app1 = express();

--- a/test/res.get.js
+++ b/test/res.get.js
@@ -1,11 +1,11 @@
 
-var express = require('..');
-var request = require('supertest');
+const express = require('..');
+const request = require('supertest');
 
 describe('res', function(){
   describe('.get(field)', function(){
     it('should get the response header field', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.setHeader('Content-Type', 'text/x-foo');

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -1,12 +1,12 @@
 
-var express = require('../')
+const express = require('../')
   , request = require('supertest')
   , assert = require('assert');
 
 describe('res', function(){
   describe('.json(object)', function(){
     it('should not support jsonp callbacks', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.json({ foo: 'bar' });
@@ -18,7 +18,7 @@ describe('res', function(){
     })
 
     it('should not override previous Content-Types', function(done){
-      var app = express();
+      const app = express();
 
       app.get('/', function(req, res){
         res.type('application/vnd.example+json');
@@ -33,7 +33,7 @@ describe('res', function(){
 
     describe('when given primitives', function(){
       it('should respond with json for null', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.json(null);
@@ -46,7 +46,7 @@ describe('res', function(){
       })
 
       it('should respond with json for Number', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.json(300);
@@ -59,7 +59,7 @@ describe('res', function(){
       })
 
       it('should respond with json for String', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.json('str');
@@ -74,7 +74,7 @@ describe('res', function(){
 
     describe('when given an array', function(){
       it('should respond with json', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.json(['foo', 'bar', 'baz']);
@@ -89,7 +89,7 @@ describe('res', function(){
 
     describe('when given an object', function(){
       it('should respond with json', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.json({ name: 'tobi' });
@@ -104,7 +104,7 @@ describe('res', function(){
 
     describe('"json replacer" setting', function(){
       it('should be passed to JSON.stringify()', function(done){
-        var app = express();
+        const app = express();
 
         app.set('json replacer', function(key, val){
           return '_' == key[0]
@@ -125,12 +125,12 @@ describe('res', function(){
 
     describe('"json spaces" setting', function(){
       it('should be undefined by default', function(){
-        var app = express();
+        const app = express();
         assert(undefined === app.get('json spaces'));
       })
 
       it('should be passed to JSON.stringify()', function(done){
-        var app = express();
+        const app = express();
 
         app.set('json spaces', 2);
 
@@ -148,7 +148,7 @@ describe('res', function(){
 
   describe('.json(status, object)', function(){
     it('should respond with json and set the .statusCode', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.json(201, { id: 1 });
@@ -163,7 +163,7 @@ describe('res', function(){
 
   describe('.json(object, status)', function(){
     it('should respond with json and set the .statusCode for backwards compat', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.json({ id: 1 }, 201);
@@ -176,7 +176,7 @@ describe('res', function(){
     })
 
     it('should use status as second number for backwards compat', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.json(200, 201);

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -1,13 +1,13 @@
 
-var express = require('../')
-  , request = require('supertest')
-  , assert = require('assert');
-var utils = require('./support/utils');
+const express = require('../')
+const request = require('supertest')
+const assert = require('assert');
+const utils = require('./support/utils');
 
 describe('res', function(){
   describe('.jsonp(object)', function(){
     it('should respond with jsonp', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -20,7 +20,7 @@ describe('res', function(){
     })
 
     it('should use first callback parameter with jsonp', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -33,7 +33,7 @@ describe('res', function(){
     })
 
     it('should ignore object callback parameter with jsonp', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -46,7 +46,7 @@ describe('res', function(){
     })
 
     it('should allow renaming callback', function(done){
-      var app = express();
+      const app = express();
 
       app.set('jsonp callback name', 'clb');
 
@@ -61,7 +61,7 @@ describe('res', function(){
     })
 
     it('should allow []', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -74,7 +74,7 @@ describe('res', function(){
     })
 
     it('should disallow arbitrary js', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({});
@@ -87,7 +87,7 @@ describe('res', function(){
     })
 
     it('should escape utf whitespace', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ str: '\u2028 \u2029 woot' });
@@ -100,7 +100,7 @@ describe('res', function(){
     });
 
     it('should not escape utf whitespace for json fallback', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ str: '\u2028 \u2029 woot' });
@@ -113,7 +113,7 @@ describe('res', function(){
     });
 
     it('should include security header and prologue', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ count: 1 });
@@ -127,7 +127,7 @@ describe('res', function(){
     })
 
     it('should not override previous Content-Types with no callback', function(done){
-      var app = express();
+      const app = express();
 
       app.get('/', function(req, res){
         res.type('application/vnd.example+json');
@@ -142,7 +142,7 @@ describe('res', function(){
     })
 
     it('should override previous Content-Types with callback', function(done){
-      var app = express();
+      const app = express();
 
       app.get('/', function(req, res){
         res.type('application/vnd.example+json');
@@ -158,7 +158,7 @@ describe('res', function(){
 
     describe('when given primitives', function(){
       it('should respond with json', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp(null);
@@ -173,7 +173,7 @@ describe('res', function(){
 
     describe('when given an array', function(){
       it('should respond with json', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp(['foo', 'bar', 'baz']);
@@ -188,7 +188,7 @@ describe('res', function(){
 
     describe('when given an object', function(){
       it('should respond with json', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp({ name: 'tobi' });
@@ -203,7 +203,7 @@ describe('res', function(){
 
     describe('when given primitives', function(){
       it('should respond with json for null', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp(null);
@@ -216,7 +216,7 @@ describe('res', function(){
       })
 
       it('should respond with json for Number', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp(300);
@@ -229,7 +229,7 @@ describe('res', function(){
       })
 
       it('should respond with json for String', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.jsonp('str');
@@ -244,7 +244,7 @@ describe('res', function(){
 
     describe('"json replacer" setting', function(){
       it('should be passed to JSON.stringify()', function(done){
-        var app = express();
+        const app = express();
 
         app.set('json replacer', function(key, val){
           return '_' == key[0]
@@ -265,12 +265,12 @@ describe('res', function(){
 
     describe('"json spaces" setting', function(){
       it('should be undefined by default', function(){
-        var app = express();
+        const app = express();
         assert(undefined === app.get('json spaces'));
       })
 
       it('should be passed to JSON.stringify()', function(done){
-        var app = express();
+        const app = express();
 
         app.set('json spaces', 2);
 
@@ -288,7 +288,7 @@ describe('res', function(){
 
   describe('.jsonp(status, object)', function(){
     it('should respond with json and set the .statusCode', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp(201, { id: 1 });
@@ -303,7 +303,7 @@ describe('res', function(){
 
   describe('.jsonp(object, status)', function(){
     it('should respond with json and set the .statusCode for backwards compat', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp({ id: 1 }, 201);
@@ -316,7 +316,7 @@ describe('res', function(){
     })
 
     it('should use status as second number for backwards compat', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.jsonp(200, 201);
@@ -330,7 +330,7 @@ describe('res', function(){
   })
 
   it('should not override previous Content-Types', function(done){
-    var app = express();
+    const app = express();
 
     app.get('/', function(req, res){
       res.type('application/vnd.example+json');

--- a/test/res.links.js
+++ b/test/res.links.js
@@ -1,11 +1,11 @@
 
-var express = require('..');
-var request = require('supertest');
+const express = require('..');
+const request = require('supertest');
 
 describe('res', function(){
   describe('.links(obj)', function(){
     it('should set Link header field', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.links({
@@ -22,7 +22,7 @@ describe('res', function(){
     })
 
     it('should set Link header field for multiple calls', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.links({

--- a/test/res.locals.js
+++ b/test/res.locals.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.locals', function(){
     it('should be empty by default', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         Object.keys(res.locals).should.eql([]);
@@ -19,8 +19,8 @@ describe('res', function(){
   })
 
   it('should work when mounted', function(done){
-    var app = express();
-    var blog = express();
+    const app = express();
+    const blog = express();
 
     app.use(blog);
 

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.location(url)', function(){
     it('should set the header', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.location('http://google.com').end();
@@ -18,7 +18,7 @@ describe('res', function(){
     })
 
     it('should encode "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.location('https://google.com?q=\u2603 §10').end()
@@ -31,7 +31,7 @@ describe('res', function(){
     })
 
     it('should not touch already-encoded sequences in "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.location('https://google.com?q=%A710').end()

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -1,12 +1,12 @@
 
-var express = require('..');
-var request = require('supertest');
-var utils = require('./support/utils');
+const express = require('..');
+const request = require('supertest');
+const utils = require('./support/utils');
 
 describe('res', function(){
   describe('.redirect(url)', function(){
     it('should default to a 302 redirect', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com');
@@ -19,7 +19,7 @@ describe('res', function(){
     })
 
     it('should encode "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.redirect('https://google.com?q=\u2603 §10')
@@ -32,7 +32,7 @@ describe('res', function(){
     })
 
     it('should not touch already-encoded sequences in "url"', function (done) {
-      var app = express()
+      const app = express()
 
       app.use(function (req, res) {
         res.redirect('https://google.com?q=%A710')
@@ -47,7 +47,7 @@ describe('res', function(){
 
   describe('.redirect(status, url)', function(){
     it('should set the response status', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect(303, 'http://google.com');
@@ -62,7 +62,7 @@ describe('res', function(){
 
   describe('.redirect(url, status)', function(){
     it('should set the response status', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com', 303);
@@ -77,7 +77,7 @@ describe('res', function(){
 
   describe('when the request method is HEAD', function(){
     it('should ignore the body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com');
@@ -92,7 +92,7 @@ describe('res', function(){
 
   describe('when accepting html', function(){
     it('should respond with html', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com');
@@ -107,7 +107,7 @@ describe('res', function(){
     })
 
     it('should escape the url', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('<la\'me>');
@@ -123,7 +123,7 @@ describe('res', function(){
     })
 
     it('should include the redirect type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect(301, 'http://google.com');
@@ -140,7 +140,7 @@ describe('res', function(){
 
   describe('when accepting text', function(){
     it('should respond with text', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com');
@@ -155,7 +155,7 @@ describe('res', function(){
     })
 
     it('should encode the url', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://example.com/?param=<script>alert("hax");</script>');
@@ -171,7 +171,7 @@ describe('res', function(){
     })
 
     it('should include the redirect type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect(301, 'http://google.com');
@@ -188,7 +188,7 @@ describe('res', function(){
 
   describe('when accepting neither text or html', function(){
     it('should respond with an empty body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.redirect('http://google.com');

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -1,13 +1,13 @@
 
-var express = require('..');
-var path = require('path')
-var request = require('supertest');
-var tmpl = require('./support/tmpl');
+const express = require('..');
+const path = require('path')
+const request = require('supertest');
+const tmpl = require('./support/tmpl');
 
 describe('res', function(){
   describe('.render(name)', function(){
     it('should support absolute paths', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.locals.user = { name: 'tobi' };
 
@@ -21,7 +21,7 @@ describe('res', function(){
     })
 
     it('should support absolute paths with "view engine"', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.locals.user = { name: 'tobi' };
       app.set('view engine', 'tmpl');
@@ -36,7 +36,7 @@ describe('res', function(){
     })
 
     it('should error without "view engine" set and no file extension', function (done) {
-      var app = createApp();
+      const app = createApp();
 
       app.locals.user = { name: 'tobi' };
 
@@ -50,7 +50,7 @@ describe('res', function(){
     })
 
     it('should expose app.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.locals.user = { name: 'tobi' };
@@ -65,7 +65,7 @@ describe('res', function(){
     })
 
     it('should expose app.locals with `name` property', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.locals.name = 'tobi';
@@ -80,7 +80,7 @@ describe('res', function(){
     })
 
     it('should support index.<engine>', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.set('view engine', 'tmpl');
@@ -96,7 +96,7 @@ describe('res', function(){
 
     describe('when an error occurs', function(){
       it('should next(err)', function(done){
-        var app = createApp();
+        const app = createApp();
 
         app.set('views', path.join(__dirname, 'fixtures'))
 
@@ -116,7 +116,7 @@ describe('res', function(){
 
     describe('when "view engine" is given', function(){
       it('should render the template', function(done){
-        var app = createApp();
+        const app = createApp();
 
         app.set('view engine', 'tmpl');
         app.set('views', path.join(__dirname, 'fixtures'))
@@ -133,7 +133,7 @@ describe('res', function(){
 
     describe('when "views" is given', function(){
       it('should lookup the file in the path', function(done){
-        var app = createApp();
+        const app = createApp();
 
         app.set('views', path.join(__dirname, 'fixtures', 'default_layout'))
 
@@ -148,8 +148,8 @@ describe('res', function(){
 
       describe('when array of paths', function(){
         it('should lookup the file in the path', function(done){
-          var app = createApp();
-          var views = [
+          const app = createApp();
+          const views = [
             path.join(__dirname, 'fixtures', 'local_layout'),
             path.join(__dirname, 'fixtures', 'default_layout')
           ]
@@ -166,8 +166,8 @@ describe('res', function(){
         })
 
         it('should lookup in later paths until found', function(done){
-          var app = createApp();
-          var views = [
+          const app = createApp();
+          const views = [
             path.join(__dirname, 'fixtures', 'local_layout'),
             path.join(__dirname, 'fixtures', 'default_layout')
           ]
@@ -188,11 +188,11 @@ describe('res', function(){
 
   describe('.render(name, option)', function(){
     it('should render the template', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
 
-      var user = { name: 'tobi' };
+      const user = { name: 'tobi' };
 
       app.use(function(req, res){
         res.render('user.tmpl', { user: user });
@@ -204,7 +204,7 @@ describe('res', function(){
     })
 
     it('should expose app.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.locals.user = { name: 'tobi' };
@@ -219,7 +219,7 @@ describe('res', function(){
     })
 
     it('should expose res.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
 
@@ -234,7 +234,7 @@ describe('res', function(){
     })
 
     it('should give precedence to res.locals over app.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.locals.user = { name: 'tobi' };
@@ -250,10 +250,10 @@ describe('res', function(){
     })
 
     it('should give precedence to res.render() locals over res.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
-      var jane = { name: 'jane' };
+      const jane = { name: 'jane' };
 
       app.use(function(req, res){
         res.locals.user = { name: 'tobi' };
@@ -266,11 +266,11 @@ describe('res', function(){
     })
 
     it('should give precedence to res.render() locals over app.locals', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
       app.locals.user = { name: 'tobi' };
-      var jane = { name: 'jane' };
+      const jane = { name: 'jane' };
 
       app.use(function(req, res){
         res.render('user.tmpl', { user: jane });
@@ -284,7 +284,7 @@ describe('res', function(){
 
   describe('.render(name, options, fn)', function(){
     it('should pass the resulting string', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
 
@@ -304,7 +304,7 @@ describe('res', function(){
 
   describe('.render(name, fn)', function(){
     it('should pass the resulting string', function(done){
-      var app = createApp();
+      const app = createApp();
 
       app.set('views', path.join(__dirname, 'fixtures'))
 
@@ -323,7 +323,7 @@ describe('res', function(){
 
     describe('when an error occurs', function(){
       it('should pass it to the callback', function(done){
-        var app = createApp();
+        const app = createApp();
 
         app.set('views', path.join(__dirname, 'fixtures'))
 
@@ -342,7 +342,7 @@ describe('res', function(){
 })
 
 function createApp() {
-  var app = express();
+  const app = express();
 
   app.engine('.tmpl', tmpl);
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -283,7 +283,7 @@ describe('res', function(){
 
   it('should always check regardless of length', function(done){
     const app = express();
-    var etag = '"asdf"';
+    const etag = '"asdf"';
 
     app.use(function(req, res, next){
       res.set('ETag', etag);
@@ -298,7 +298,7 @@ describe('res', function(){
 
   it('should respond with 304 Not Modified when fresh', function(done){
     const app = express();
-    var etag = '"asdf"';
+    const etag = '"asdf"';
 
     app.use(function(req, res){
       var str = Array(1000).join('-');
@@ -314,7 +314,7 @@ describe('res', function(){
 
   it('should not perform freshness check unless 2xx or 304', function(done){
     const app = express();
-    var etag = '"asdf"';
+    const etag = '"asdf"';
 
     app.use(function(req, res, next){
       res.status(500);

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -283,11 +283,7 @@ describe('res', function(){
 
   it('should always check regardless of length', function(done){
     const app = express();
-<<<<<<< HEAD
     const etag = '"asdf"';
-=======
-    var etag = '"asdf"';
->>>>>>> more var to const changes
 
     app.use(function(req, res, next){
       res.set('ETag', etag);
@@ -302,11 +298,7 @@ describe('res', function(){
 
   it('should respond with 304 Not Modified when fresh', function(done){
     const app = express();
-<<<<<<< HEAD
     const etag = '"asdf"';
-=======
-    var etag = '"asdf"';
->>>>>>> more var to const changes
 
     app.use(function(req, res){
       var str = Array(1000).join('-');
@@ -322,11 +314,7 @@ describe('res', function(){
 
   it('should not perform freshness check unless 2xx or 304', function(done){
     const app = express();
-<<<<<<< HEAD
     const etag = '"asdf"';
-=======
-    var etag = '"asdf"';
->>>>>>> more var to const changes
 
     app.use(function(req, res, next){
       res.status(500);

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -283,7 +283,11 @@ describe('res', function(){
 
   it('should always check regardless of length', function(done){
     const app = express();
+<<<<<<< HEAD
     const etag = '"asdf"';
+=======
+    var etag = '"asdf"';
+>>>>>>> more var to const changes
 
     app.use(function(req, res, next){
       res.set('ETag', etag);
@@ -298,7 +302,11 @@ describe('res', function(){
 
   it('should respond with 304 Not Modified when fresh', function(done){
     const app = express();
+<<<<<<< HEAD
     const etag = '"asdf"';
+=======
+    var etag = '"asdf"';
+>>>>>>> more var to const changes
 
     app.use(function(req, res){
       var str = Array(1000).join('-');
@@ -314,7 +322,11 @@ describe('res', function(){
 
   it('should not perform freshness check unless 2xx or 304', function(done){
     const app = express();
+<<<<<<< HEAD
     const etag = '"asdf"';
+=======
+    var etag = '"asdf"';
+>>>>>>> more var to const changes
 
     app.use(function(req, res, next){
       res.status(500);

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -1,13 +1,13 @@
 
-var express = require('..');
-var methods = require('methods');
-var request = require('supertest');
-var utils = require('./support/utils');
+const express = require('..');
+const methods = require('methods');
+const request = require('supertest');
+const utils = require('./support/utils');
 
 describe('res', function(){
   describe('.send()', function(){
     it('should set body to ""', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send();
@@ -21,7 +21,7 @@ describe('res', function(){
 
   describe('.send(null)', function(){
     it('should set body to ""', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(null);
@@ -36,7 +36,7 @@ describe('res', function(){
 
   describe('.send(undefined)', function(){
     it('should set body to ""', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(undefined);
@@ -50,7 +50,7 @@ describe('res', function(){
 
   describe('.send(code)', function(){
     it('should set .statusCode', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(201).should.equal(res);
@@ -65,7 +65,7 @@ describe('res', function(){
 
   describe('.send(code, body)', function(){
     it('should set .statusCode and body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(201, 'Created :)');
@@ -80,7 +80,7 @@ describe('res', function(){
 
   describe('.send(body, code)', function(){
     it('should be supported for backwards compat', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send('Bad!', 400);
@@ -95,7 +95,7 @@ describe('res', function(){
 
   describe('.send(code, number)', function(){
     it('should send number as json', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(200, 0.123);
@@ -110,7 +110,7 @@ describe('res', function(){
 
   describe('.send(String)', function(){
     it('should send as html', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send('<p>hey</p>');
@@ -123,7 +123,7 @@ describe('res', function(){
     })
 
     it('should set ETag', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         var str = Array(1000).join('-');
@@ -137,7 +137,7 @@ describe('res', function(){
     })
 
     it('should not override Content-Type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('Content-Type', 'text/plain').send('hey');
@@ -150,7 +150,7 @@ describe('res', function(){
     })
 
     it('should override charset in Content-Type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('Content-Type', 'text/plain; charset=iso-8859-1').send('hey');
@@ -163,7 +163,7 @@ describe('res', function(){
     })
 
     it('should keep charset in Content-Type for Buffers', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('Content-Type', 'text/plain; charset=iso-8859-1').send(new Buffer('hi'));
@@ -178,7 +178,7 @@ describe('res', function(){
 
   describe('.send(Buffer)', function(){
     it('should send as octet-stream', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send(new Buffer('hello'));
@@ -191,7 +191,7 @@ describe('res', function(){
     })
 
     it('should set ETag', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         var str = Array(1000).join('-');
@@ -205,7 +205,7 @@ describe('res', function(){
     })
 
     it('should not override Content-Type', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.set('Content-Type', 'text/plain').send(new Buffer('hey'));
@@ -220,7 +220,7 @@ describe('res', function(){
 
   describe('.send(Object)', function(){
     it('should send as application/json', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send({ name: 'tobi' });
@@ -235,7 +235,7 @@ describe('res', function(){
 
   describe('when the request method is HEAD', function(){
     it('should ignore the body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.send('yay');
@@ -249,7 +249,7 @@ describe('res', function(){
 
   describe('when .statusCode is 204', function(){
     it('should strip Content-* fields, Transfer-Encoding field, and body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.status(204).set('Transfer-Encoding', 'chunked').send('foo');
@@ -266,7 +266,7 @@ describe('res', function(){
 
   describe('when .statusCode is 304', function(){
     it('should strip Content-* fields, Transfer-Encoding field, and body', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.status(304).set('Transfer-Encoding', 'chunked').send('foo');
@@ -282,7 +282,7 @@ describe('res', function(){
   })
 
   it('should always check regardless of length', function(done){
-    var app = express();
+    const app = express();
     var etag = '"asdf"';
 
     app.use(function(req, res, next){
@@ -297,7 +297,7 @@ describe('res', function(){
   })
 
   it('should respond with 304 Not Modified when fresh', function(done){
-    var app = express();
+    const app = express();
     var etag = '"asdf"';
 
     app.use(function(req, res){
@@ -313,7 +313,7 @@ describe('res', function(){
   })
 
   it('should not perform freshness check unless 2xx or 304', function(done){
-    var app = express();
+    const app = express();
     var etag = '"asdf"';
 
     app.use(function(req, res, next){
@@ -330,7 +330,7 @@ describe('res', function(){
   })
 
   it('should not support jsonp callbacks', function(done){
-    var app = express();
+    const app = express();
 
     app.use(function(req, res){
       res.send({ foo: 'bar' });
@@ -344,7 +344,7 @@ describe('res', function(){
   describe('"etag" setting', function () {
     describe('when enabled', function () {
       it('should send ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           res.send('kajdslfkasdf');
@@ -362,7 +362,7 @@ describe('res', function(){
         if (method === 'connect') return;
 
         it('should send ETag in response to ' + method.toUpperCase() + ' request', function (done) {
-          var app = express();
+          const app = express();
 
           app[method]('/', function (req, res) {
             res.send('kajdslfkasdf');
@@ -376,7 +376,7 @@ describe('res', function(){
       });
 
       it('should send ETag for empty string response', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           res.send('');
@@ -391,7 +391,7 @@ describe('res', function(){
       })
 
       it('should send ETag for long response', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           var str = Array(1000).join('-');
@@ -407,7 +407,7 @@ describe('res', function(){
       });
 
       it('should not override ETag when manually set', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           res.set('etag', '"asdf"');
@@ -423,7 +423,7 @@ describe('res', function(){
       });
 
       it('should not send ETag for res.send()', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           res.send();
@@ -440,7 +440,7 @@ describe('res', function(){
 
     describe('when disabled', function () {
       it('should send no ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.use(function (req, res) {
           var str = Array(1000).join('-');
@@ -456,7 +456,7 @@ describe('res', function(){
       });
 
       it('should send ETag when manually set', function (done) {
-        var app = express();
+        const app = express();
 
         app.disable('etag');
 
@@ -474,7 +474,7 @@ describe('res', function(){
 
     describe('when "strong"', function () {
       it('should send strong ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.set('etag', 'strong');
 
@@ -491,7 +491,7 @@ describe('res', function(){
 
     describe('when "weak"', function () {
       it('should send weak ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.set('etag', 'weak');
 
@@ -508,7 +508,7 @@ describe('res', function(){
 
     describe('when a function', function () {
       it('should send custom ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.set('etag', function (body, encoding) {
           var chunk = !Buffer.isBuffer(body)
@@ -529,7 +529,7 @@ describe('res', function(){
       })
 
       it('should not send falsy ETag', function (done) {
-        var app = express();
+        const app = express();
 
         app.set('etag', function (body, encoding) {
           return undefined;

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -711,7 +711,16 @@ describe('res', function(){
 
       describe('with non-GET', function(){
         it('should still serve', function(done){
+<<<<<<< HEAD
           const app = express()
+=======
+<<<<<<< HEAD
+          var app = express()
+=======
+          const app = express()
+          var calls = 0;
+>>>>>>> more var to const changes
+>>>>>>> more var to const changes
 
           app.use(function(req, res){
             res.sendfile(path.join(__dirname, '/fixtures/name.txt'))

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -1,18 +1,18 @@
 
-var after = require('after');
-var express = require('../')
-  , request = require('supertest')
-  , assert = require('assert');
-var onFinished = require('on-finished');
-var path = require('path');
-var should = require('should');
-var fixtures = path.join(__dirname, 'fixtures');
-var utils = require('./support/utils');
+const after = require('after');
+const express = require('../')
+const request = require('supertest')
+const assert = require('assert');
+const onFinished = require('on-finished');
+const path = require('path');
+const should = require('should');
+const fixtures = path.join(__dirname, 'fixtures');
+const utils = require('./support/utils');
 
 describe('res', function(){
   describe('.sendFile(path)', function () {
     it('should error missing path', function (done) {
-      var app = createApp();
+      const app = createApp();
 
       request(app)
       .get('/')
@@ -20,7 +20,7 @@ describe('res', function(){
     });
 
     it('should transfer a file', function (done) {
-      var app = createApp(path.resolve(fixtures, 'name.txt'));
+      const app = createApp(path.resolve(fixtures, 'name.txt'));
 
       request(app)
       .get('/')
@@ -28,7 +28,7 @@ describe('res', function(){
     });
 
     it('should transfer a file with special characters in string', function (done) {
-      var app = createApp(path.resolve(fixtures, '% of dogs.txt'));
+      const app = createApp(path.resolve(fixtures, '% of dogs.txt'));
 
       request(app)
       .get('/')
@@ -36,7 +36,7 @@ describe('res', function(){
     });
 
     it('should include ETag', function (done) {
-      var app = createApp(path.resolve(fixtures, 'name.txt'));
+      const app = createApp(path.resolve(fixtures, 'name.txt'));
 
       request(app)
       .get('/')
@@ -45,14 +45,14 @@ describe('res', function(){
     });
 
     it('should 304 when ETag matches', function (done) {
-      var app = createApp(path.resolve(fixtures, 'name.txt'));
+      const app = createApp(path.resolve(fixtures, 'name.txt'));
 
       request(app)
       .get('/')
       .expect('ETag', /^(?:W\/)?"[^"]+"$/)
       .expect(200, 'tobi', function (err, res) {
         if (err) return done(err);
-        var etag = res.headers.etag;
+        const etag = res.headers.etag;
         request(app)
         .get('/')
         .set('If-None-Match', etag)
@@ -61,7 +61,7 @@ describe('res', function(){
     });
 
     it('should 404 for directory', function (done) {
-      var app = createApp(path.resolve(fixtures, 'blog'));
+      const app = createApp(path.resolve(fixtures, 'blog'));
 
       request(app)
       .get('/')
@@ -69,7 +69,7 @@ describe('res', function(){
     });
 
     it('should 404 when not found', function (done) {
-      var app = createApp(path.resolve(fixtures, 'does-no-exist'));
+      const app = createApp(path.resolve(fixtures, 'does-no-exist'));
 
       app.use(function (req, res) {
         res.statusCode = 200;
@@ -82,7 +82,7 @@ describe('res', function(){
     });
 
     it('should not override manual content-types', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.contentType('application/x-bogus');
@@ -96,8 +96,8 @@ describe('res', function(){
     })
 
     it('should not error if the client aborts', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         setImmediate(function () {
@@ -112,13 +112,13 @@ describe('res', function(){
         cb();
       });
 
-      var test = request(app).get('/');
+      const test = request(app).get('/');
       test.expect(200, cb);
     })
 
     describe('with "cacheControl" option', function () {
       it('should enable cacheControl by default', function (done) {
-        var app = createApp(path.resolve(__dirname, 'fixtures/name.txt'))
+        const app = createApp(path.resolve(__dirname, 'fixtures/name.txt'))
 
         request(app)
         .get('/')
@@ -127,7 +127,7 @@ describe('res', function(){
       })
 
       it('should accept cacheControl option', function (done) {
-        var app = createApp(path.resolve(__dirname, 'fixtures/name.txt'), { cacheControl: false })
+        const app = createApp(path.resolve(__dirname, 'fixtures/name.txt'), { cacheControl: false })
 
         request(app)
         .get('/')
@@ -138,7 +138,7 @@ describe('res', function(){
 
     describe('with "dotfiles" option', function () {
       it('should not serve dotfiles by default', function (done) {
-        var app = createApp(path.resolve(__dirname, 'fixtures/.name'));
+        const app = createApp(path.resolve(__dirname, 'fixtures/.name'));
 
         request(app)
         .get('/')
@@ -146,7 +146,7 @@ describe('res', function(){
       });
 
       it('should accept dotfiles option', function(done){
-        var app = createApp(path.resolve(__dirname, 'fixtures/.name'), { dotfiles: 'allow' });
+        const app = createApp(path.resolve(__dirname, 'fixtures/.name'), { dotfiles: 'allow' });
 
         request(app)
         .get('/')
@@ -160,7 +160,7 @@ describe('res', function(){
           'x-success': 'sent',
           'x-other': 'done'
         };
-        var app = createApp(path.resolve(__dirname, 'fixtures/name.txt'), { headers: headers });
+        const app = createApp(path.resolve(__dirname, 'fixtures/name.txt'), { headers: headers });
 
         request(app)
         .get('/')
@@ -170,8 +170,8 @@ describe('res', function(){
       });
 
       it('should ignore headers option on 404', function (done) {
-        var headers = { 'x-success': 'sent' };
-        var app = createApp(path.resolve(__dirname, 'fixtures/does-not-exist'), { headers: headers });
+        const headers = { 'x-success': 'sent' };
+        const app = createApp(path.resolve(__dirname, 'fixtures/does-not-exist'), { headers: headers });
 
         request(app)
         .get('/')
@@ -182,7 +182,7 @@ describe('res', function(){
 
     describe('with "root" option', function () {
       it('should not transfer relative with without', function (done) {
-        var app = createApp('test/fixtures/name.txt');
+        const app = createApp('test/fixtures/name.txt');
 
         request(app)
         .get('/')
@@ -190,7 +190,7 @@ describe('res', function(){
       })
 
       it('should serve relative to "root"', function (done) {
-        var app = createApp('name.txt', {root: fixtures});
+        const app = createApp('name.txt', {root: fixtures});
 
         request(app)
         .get('/')
@@ -198,7 +198,7 @@ describe('res', function(){
       })
 
       it('should disallow requesting out of "root"', function (done) {
-        var app = createApp('foo/../../user.html', {root: fixtures});
+        const app = createApp('foo/../../user.html', {root: fixtures});
 
         request(app)
         .get('/')
@@ -209,8 +209,8 @@ describe('res', function(){
 
   describe('.sendFile(path, fn)', function () {
     it('should invoke the callback when complete', function (done) {
-      var cb = after(2, done);
-      var app = createApp(path.resolve(fixtures, 'name.txt'), cb);
+      const cb = after(2, done);
+      const app = createApp(path.resolve(fixtures, 'name.txt'), cb);
 
       request(app)
       .get('/')
@@ -218,8 +218,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback when client aborts', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         setImmediate(function () {
@@ -237,8 +237,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback when client already aborted', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         onFinished(res, function () {
@@ -256,8 +256,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback without error when HEAD', function (done) {
-      var app = express();
-      var cb = after(2, done);
+      const app = express();
+      const cb = after(2, done);
 
       app.use(function (req, res) {
         res.sendFile(path.resolve(fixtures, 'name.txt'), cb);
@@ -269,8 +269,8 @@ describe('res', function(){
     });
 
     it('should invoke the callback without error when 304', function (done) {
-      var app = express();
-      var cb = after(3, done);
+      const app = express();
+      const cb = after(3, done);
 
       app.use(function (req, res) {
         res.sendFile(path.resolve(fixtures, 'name.txt'), cb);
@@ -290,7 +290,7 @@ describe('res', function(){
     });
 
     it('should invoke the callback on 404', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.sendFile(path.resolve(fixtures, 'does-not-exist'), function (err) {
@@ -316,8 +316,8 @@ describe('res', function(){
 
   describe('.sendfile(path, fn)', function(){
     it('should invoke the callback when complete', function(done){
-      var app = express();
-      var cb = after(2, done);
+      const app = express();
+      const cb = after(2, done);
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/user.html', cb)
@@ -329,7 +329,7 @@ describe('res', function(){
     })
 
     it('should utilize the same options as express.static()', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/user.html', { maxAge: 60000 });
@@ -342,8 +342,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback when client aborts', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         setImmediate(function () {
@@ -361,8 +361,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback when client already aborted', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         onFinished(res, function () {
@@ -380,8 +380,8 @@ describe('res', function(){
     })
 
     it('should invoke the callback without error when HEAD', function (done) {
-      var app = express();
-      var cb = after(2, done);
+      const app = express();
+      const cb = after(2, done);
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/name.txt', cb);
@@ -393,8 +393,8 @@ describe('res', function(){
     });
 
     it('should invoke the callback without error when 304', function (done) {
-      var app = express();
-      var cb = after(3, done);
+      const app = express();
+      const cb = after(3, done);
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/name.txt', cb);
@@ -414,7 +414,7 @@ describe('res', function(){
     });
 
     it('should invoke the callback on 404', function(done){
-      var app = express();
+      const app = express();
       var calls = 0;
 
       app.use(function(req, res){
@@ -431,7 +431,7 @@ describe('res', function(){
     })
 
     it('should not override manual content-types', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.contentType('txt');
@@ -445,7 +445,7 @@ describe('res', function(){
     })
 
     it('should invoke the callback on 403', function(done){
-      var app = express()
+      const app = express()
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/foo/../user.html', function(err){
@@ -461,7 +461,7 @@ describe('res', function(){
     })
 
     it('should invoke the callback on socket error', function(done){
-      var app = express()
+      const app = express()
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/user.html', function(err){
@@ -481,7 +481,7 @@ describe('res', function(){
 
   describe('.sendfile(path)', function(){
     it('should not serve dotfiles', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/.name');
@@ -493,7 +493,7 @@ describe('res', function(){
     })
 
     it('should accept dotfiles option', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/.name', { dotfiles: 'allow' });
@@ -505,8 +505,8 @@ describe('res', function(){
     })
 
     it('should accept headers option', function(done){
-      var app = express();
-      var headers = {
+      const app = express();
+      const headers = {
         'x-success': 'sent',
         'x-other': 'done'
       };
@@ -523,8 +523,8 @@ describe('res', function(){
     })
 
     it('should ignore headers option on 404', function(done){
-      var app = express();
-      var headers = { 'x-success': 'sent' };
+      const app = express();
+      const headers = { 'x-success': 'sent' };
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/user.nothing', { headers: headers });
@@ -537,7 +537,7 @@ describe('res', function(){
     })
 
     it('should transfer a file', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/name.txt');
@@ -549,7 +549,7 @@ describe('res', function(){
     });
 
     it('should transfer a directory index file', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/blog/');
@@ -561,7 +561,7 @@ describe('res', function(){
     });
 
     it('should 404 for directory without trailing slash', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/blog');
@@ -573,7 +573,7 @@ describe('res', function(){
     });
 
     it('should transfer a file with urlencoded name', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.sendfile('test/fixtures/%25%20of%20dogs.txt');
@@ -585,8 +585,8 @@ describe('res', function(){
     });
 
     it('should not error if the client aborts', function (done) {
-      var cb = after(1, done);
-      var app = express();
+      const cb = after(1, done);
+      const app = express();
 
       app.use(function (req, res) {
         setImmediate(function () {
@@ -607,7 +607,7 @@ describe('res', function(){
 
     describe('with an absolute path', function(){
       it('should transfer the file', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile(path.join(__dirname, '/fixtures/user.html'))
@@ -622,7 +622,7 @@ describe('res', function(){
 
     describe('with a relative path', function(){
       it('should transfer the file', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile('test/fixtures/user.html');
@@ -635,7 +635,7 @@ describe('res', function(){
       })
 
       it('should serve relative to "root"', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile('user.html', { root: 'test/fixtures/' });
@@ -648,7 +648,7 @@ describe('res', function(){
       })
 
       it('should consider ../ malicious when "root" is not set', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile('test/fixtures/foo/../user.html');
@@ -660,7 +660,7 @@ describe('res', function(){
       })
 
       it('should allow ../ when "root" is set', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile('foo/../user.html', { root: 'test/fixtures' });
@@ -672,7 +672,7 @@ describe('res', function(){
       })
 
       it('should disallow requesting out of "root"', function(done){
-        var app = express();
+        const app = express();
 
         app.use(function(req, res){
           res.sendfile('foo/../../user.html', { root: 'test/fixtures' });
@@ -684,8 +684,8 @@ describe('res', function(){
       })
 
       it('should next(404) when not found', function(done){
-        var app = express()
-          , calls = 0;
+        const app = express()
+        var calls = 0;
 
         app.use(function(req, res){
           res.sendfile('user.html');
@@ -711,7 +711,7 @@ describe('res', function(){
 
       describe('with non-GET', function(){
         it('should still serve', function(done){
-          var app = express()
+          const app = express()
 
           app.use(function(req, res){
             res.sendfile(path.join(__dirname, '/fixtures/name.txt'))
@@ -728,7 +728,7 @@ describe('res', function(){
 
 describe('.sendfile(path, options)', function () {
   it('should pass options to send module', function (done) {
-    var app = express()
+    const app = express()
 
     app.use(function (req, res) {
       res.sendfile(path.resolve(fixtures, 'name.txt'), { start: 0, end: 1 })
@@ -741,7 +741,7 @@ describe('.sendfile(path, options)', function () {
 })
 
 function createApp(path, options, fn) {
-  var app = express();
+  const app = express();
 
   app.use(function (req, res) {
     res.sendFile(path, options, fn);

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -445,7 +445,7 @@ describe('res', function(){
     })
 
     it('should invoke the callback on 403', function(done){
-      const app = express()
+      const app = express();
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/foo/../user.html', function(err){
@@ -461,7 +461,7 @@ describe('res', function(){
     })
 
     it('should invoke the callback on socket error', function(done){
-      const app = express()
+      const app = express();
 
       app.use(function(req, res){
         res.sendfile('test/fixtures/user.html', function(err){
@@ -684,7 +684,7 @@ describe('res', function(){
       })
 
       it('should next(404) when not found', function(done){
-        const app = express()
+        const app = express();
         var calls = 0;
 
         app.use(function(req, res){
@@ -711,24 +711,7 @@ describe('res', function(){
 
       describe('with non-GET', function(){
         it('should still serve', function(done){
-<<<<<<< HEAD
-<<<<<<< HEAD
-          const app = express()
-=======
-=======
->>>>>>> more var to const changes
-<<<<<<< HEAD
-          var app = express()
-=======
-          const app = express()
-          var calls = 0;
->>>>>>> more var to const changes
-<<<<<<< HEAD
-=======
-=======
-          const app = express()
->>>>>>> more var to const changes
->>>>>>> more var to const changes
+          const app = express();
 
           app.use(function(req, res){
             res.sendfile(path.join(__dirname, '/fixtures/name.txt'))
@@ -745,7 +728,7 @@ describe('res', function(){
 
 describe('.sendfile(path, options)', function () {
   it('should pass options to send module', function (done) {
-    const app = express()
+    const app = express();
 
     app.use(function (req, res) {
       res.sendfile(path.resolve(fixtures, 'name.txt'), { start: 0, end: 1 })

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -712,13 +712,21 @@ describe('res', function(){
       describe('with non-GET', function(){
         it('should still serve', function(done){
 <<<<<<< HEAD
+<<<<<<< HEAD
           const app = express()
 =======
+=======
+>>>>>>> more var to const changes
 <<<<<<< HEAD
           var app = express()
 =======
           const app = express()
           var calls = 0;
+>>>>>>> more var to const changes
+<<<<<<< HEAD
+=======
+=======
+          const app = express()
 >>>>>>> more var to const changes
 >>>>>>> more var to const changes
 

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -1,11 +1,11 @@
 
-var express = require('..')
-var request = require('supertest')
+const express = require('..')
+const request = require('supertest')
 
 describe('res', function () {
   describe('.sendStatus(statusCode)', function () {
     it('should send the status code and message as body', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendStatus(201);
@@ -17,7 +17,7 @@ describe('res', function () {
     })
 
     it('should work with unknown code', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.sendStatus(599);

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -1,4 +1,3 @@
-
 const express = require('../')
 const request = require('supertest');
 

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -1,11 +1,11 @@
 
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.status(code)', function(){
     it('should set the response .statusCode', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.status(201).end('Created');

--- a/test/res.type.js
+++ b/test/res.type.js
@@ -1,11 +1,10 @@
-
-var express = require('../')
-  , request = require('supertest');
+const express = require('../')
+const request = require('supertest');
 
 describe('res', function(){
   describe('.type(str)', function(){
     it('should set the Content-Type based on a filename', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.type('foo.js').end('var name = "tj";');
@@ -17,7 +16,7 @@ describe('res', function(){
     })
 
     it('should default to application/octet-stream', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.type('rawr').end('var name = "tj";');
@@ -29,7 +28,7 @@ describe('res', function(){
     })
 
     it('should set the Content-Type with type/subtype', function(done){
-      var app = express();
+      const app = express();
 
       app.use(function(req, res){
         res.type('application/vnd.amazon.ebook')

--- a/test/res.vary.js
+++ b/test/res.vary.js
@@ -1,12 +1,12 @@
 
-var express = require('..');
-var request = require('supertest');
-var utils = require('./support/utils');
+const express = require('..');
+const request = require('supertest');
+const utils = require('./support/utils');
 
 describe('res.vary()', function(){
   describe('with no arguments', function(){
     it('should not set Vary', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.vary();
@@ -22,7 +22,7 @@ describe('res.vary()', function(){
 
   describe('with an empty array', function(){
     it('should not set Vary', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.vary([]);
@@ -38,7 +38,7 @@ describe('res.vary()', function(){
 
   describe('with an array', function(){
     it('should set the values', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.vary(['Accept', 'Accept-Language', 'Accept-Encoding']);
@@ -54,7 +54,7 @@ describe('res.vary()', function(){
 
   describe('with a string', function(){
     it('should set the value', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.vary('Accept');
@@ -70,7 +70,7 @@ describe('res.vary()', function(){
 
   describe('when the value is present', function(){
     it('should not add it again', function (done) {
-      var app = express();
+      const app = express();
 
       app.use(function (req, res) {
         res.vary('Accept');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 
-var assert = require('assert');
-var utils = require('../lib/utils');
+const assert = require('assert');
+const utils = require('../lib/utils');
 
 describe('utils.etag(body, encoding)', function(){
   it('should support strings', function(){


### PR DESCRIPTION
Converted var to const. Refactored assignment statements
of the form ` var var1 \n , var2` to `const var \n const var 2` 
to better maintain consistency with other test files.