### PR TITLE
fix several examples

### DIFF
--- a/examples/markdown/views/missing.md
+++ b/examples/markdown/views/missing.md
@@ -1,0 +1,4 @@
+
+# {title}
+
+Ops! The file is lost...

--- a/examples/markdown/views/missing.md
+++ b/examples/markdown/views/missing.md
@@ -1,4 +1,0 @@
-
-# {title}
-
-Ops! The file is lost...

--- a/examples/online/index.js
+++ b/examples/online/index.js
@@ -1,10 +1,10 @@
-// first (if you have not done it yet):
-// $ npm install redis
-// $ brew install redis
-// $ redis-server
+
+// install redis first:
+// https://redis.io/
 
 // then:
-// $ npm install online
+// $ npm install redis online
+// $ redis-server
 
 /**
  * Module dependencies.

--- a/examples/online/index.js
+++ b/examples/online/index.js
@@ -1,4 +1,4 @@
-// first (if you have not done it yes):
+// first (if you have not done it yet):
 // $ npm install redis
 // $ brew install redis
 // $ redis-server

--- a/examples/online/index.js
+++ b/examples/online/index.js
@@ -1,6 +1,10 @@
-// first:
-// $ npm install redis online
+// first (if you have not done it yes):
+// $ npm install redis
+// $ brew install redis
 // $ redis-server
+
+// then:
+// $ npm install online
 
 /**
  * Module dependencies.

--- a/examples/params/index.js
+++ b/examples/params/index.js
@@ -68,7 +68,7 @@ app.get('/users/:from-:to', function(req, res, next){
   var from = req.params.from;
   var to = req.params.to;
   var names = users.map(function(user){ return user.name; });
-  res.send('users ' + names.slice(from, to).join(', '));
+  res.send('users ' + names.slice(from, to + 1).join(', '));
 });
 
 /* istanbul ignore next */

--- a/examples/route-separation/views/index.ejs
+++ b/examples/route-separation/views/index.ejs
@@ -4,7 +4,7 @@
 
 <ul>
   <li>Visit the <a href="/users">users</a> page.</li>
-  <li>Visit the <a href="/users">posts</a> page.</li>
+  <li>Visit the <a href="/posts">posts</a> page.</li>
 </ul>
 
 <% include footer %>

--- a/examples/search/index.js
+++ b/examples/search/index.js
@@ -1,6 +1,9 @@
-// first (if you have not done it yet):
+
+// install redis first:
+// https://redis.io/
+
+// then:
 // $ npm install redis
-// $ brew install redis
 // $ redis-server
 
 /**

--- a/examples/search/index.js
+++ b/examples/search/index.js
@@ -1,5 +1,6 @@
-// first:
+// first (if you have not done it yes):
 // $ npm install redis
+// $ brew install redis
 // $ redis-server
 
 /**

--- a/examples/search/index.js
+++ b/examples/search/index.js
@@ -1,4 +1,4 @@
-// first (if you have not done it yes):
+// first (if you have not done it yet):
 // $ npm install redis
 // $ brew install redis
 // $ redis-server

--- a/examples/session/index.js
+++ b/examples/session/index.js
@@ -1,6 +1,9 @@
-// first (if you have not done it yet):
+
+// install redis first:
+// https://redis.io/
+
+// then:
 // $ npm install redis
-// $ brew install redis
 // $ redis-server
 
 var express = require('../..');

--- a/examples/session/index.js
+++ b/examples/session/index.js
@@ -1,5 +1,6 @@
-// first:
+// first (if you have not done it yes):
 // $ npm install redis
+// $ brew install redis
 // $ redis-server
 
 var express = require('../..');

--- a/examples/session/index.js
+++ b/examples/session/index.js
@@ -1,4 +1,4 @@
-// first (if you have not done it yes):
+// first (if you have not done it yet):
 // $ npm install redis
 // $ brew install redis
 // $ redis-server

--- a/examples/view-constructor/github-view.js
+++ b/examples/view-constructor/github-view.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var http = require('http');
+var https = require('https');
 var path = require('path');
 var extname = path.extname;
 


### PR DESCRIPTION
**1. examples/params**

http://localhost:3000/users/0-2
users tj, tobi     <-- lost loki

Because user/0 is tj, that’s means the 0 is the data, not index of array.
So, users/0-2 must be include user/2.

　
**2. examples/route-separation**

http://localhost:3000
Click link "posts", jumped to the "users" page.

　
**3. examples/view-constructor**

http://localhost:3000/
ReferenceError: https is not defined

　
**4. examples/online, examples/search, and examples/session**

// install redis first:
// https://redis.io/

// then:
// $ npm install redis
// $ redis-server

If the user has installed redis, then there is no problem reinstalling redis. But if the user has not done it yet, and here does not prompt the user to install redis, this example will run failure, the user will be confused.
