### PR TITLE
fix examples/cookie-sessions and the test

### DIFF
--- a/examples/cookie-sessions/index.js
+++ b/examples/cookie-sessions/index.js
@@ -16,7 +16,7 @@ app.use(count);
 // custom middleware
 function count(req, res) {
   req.session.count = req.session.count || 0;
-  var n = req.session.count++;
+  var n = ++ req.session.count;
   res.send('viewed ' + n + ' times\n');
 }
 

--- a/test/acceptance/cookie-sessions.js
+++ b/test/acceptance/cookie-sessions.js
@@ -7,7 +7,7 @@ describe('cookie-sessions', function () {
     it('should display no views', function (done) {
       request(app)
       .get('/')
-      .expect(200, 'viewed 0 times\n', done)
+      .expect(200, 'viewed 1 times\n', done)
     })
 
     it('should set a session cookie', function (done) {
@@ -20,12 +20,12 @@ describe('cookie-sessions', function () {
     it('should display 1 view on revisit', function (done) {
       request(app)
       .get('/')
-      .expect(200, 'viewed 0 times\n', function (err, res) {
+      .expect(200, 'viewed 1 times\n', function (err, res) {
         if (err) return done(err)
         request(app)
         .get('/')
         .set('Cookie', getCookies(res))
-        .expect(200, 'viewed 1 times\n', done)
+        .expect(200, 'viewed 2 times\n', done)
       })
     })
   })


### PR DESCRIPTION
In real world, the first is 1, the second is 2. So:

On first visit, the viewed times should be 1 instead of 0.
On second visit, the viewed times should be 2 instead of 1.