### PR TITLE
Set Default Env to Production

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -68,7 +68,7 @@ app.init = function init() {
  */
 
 app.defaultConfiguration = function defaultConfiguration() {
-  var env = process.env.NODE_ENV || 'development';
+  var env = process.env.NODE_ENV || 'production';
 
   // default settings
   this.enable('x-powered-by');

--- a/test/app.js
+++ b/test/app.js
@@ -101,10 +101,10 @@ describe('in production', function(){
 })
 
 describe('without NODE_ENV', function(){
-  it('should default to development', function(){
+  it('should default to production', function(){
     process.env.NODE_ENV = '';
     var app = express();
-    app.get('env').should.equal('development');
+    app.get('env').should.equal('production');
     process.env.NODE_ENV = 'test';
   })
 })


### PR DESCRIPTION
- updated the default `env` in `application.js` to be 'production'
- updated the appropriate test

in support of https://github.com/expressjs/express/issues/3346