### PR TITLE
handle undefined statusCode with an error

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -136,6 +136,10 @@ res.send = function send(body) {
     deprecate('res.send(status): Use res.sendStatus(status) instead');
     this.statusCode = chunk;
     chunk = statuses[chunk]
+  } else if ( (typeof chunk === 'string') &&
+    (arguments.length === 1) &&
+    (parseInt(chunk) === NaN )) {
+    throw new Error('statusCode was not a number');
   }
 
   switch (typeof chunk) {
@@ -340,6 +344,10 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
+  if (parseInt(statusCode) === NaN) {
+    throw new Error('statusCode was not a number');
+  }
+
   var body = statuses[statusCode] || String(statusCode)
 
   this.statusCode = statusCode;


### PR DESCRIPTION
# description

We can bettor handle the error case when an undefined is sent as the status code in the response as it currently goes down to the node layer and does not give a clear error.

```js
var express = require('express');
var app = express();

app.get('/', function (req, res) {
  //res.status(undefined).send('not ok');
  // or
 res.sendStatus(undefined);
});

app.listen(3000);

```

If the status code is undefined when you call

```js
res.status(undefinded).send('');
```
you get an error OF COURSE. But I think we could handle this case a bit more clearly than the stack trace allows.

## instructions to reproduce

npm start

then hit the end point

```
curl -X GET http://localhost:3000/ 

```

The following is what you currently see if you send an undefined statusCode in a response.

```
> express-status-undefined-error@1.0.0 start /Users/ghinks/dev/doodles/express-status-undefined-error
> node server.js

TypeError: Cannot read property 'toString' of undefined
    at ServerResponse.writeHead (_http_server.js:190:44)
    at ServerResponse._implicitHeader (_http_server.js:157:8)
    at ServerResponse.OutgoingMessage.end (_http_outgoing.js:548:10)
    at ServerResponse.send (/Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/response.js:211:10)
    at /Users/ghinks/dev/doodles/express-status-undefined-error/server.js:9:25
    at Layer.handle [as handle_request] (/Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/router/layer.js:95:5)
    at /Users/ghinks/dev/doodles/express-status-undefined-error/node_modules/express/lib/router/index.js:281:22
 ```

I think that something with 

```
Error: statusCode was not a number
```

is maybe an improvement.