### PR TITLE
Request for request #3327, allowing res.download to supply options to res.sendFile

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -506,30 +506,39 @@ res.sendfile = deprecate.function(res.sendfile,
  * when the data transfer is complete, or when an error has
  * ocurred. Be sure to check `res.headersSent` if you plan to respond.
  *
- * This method uses `res.sendfile()`.
+ * This method uses `res.sendfile()`, and optionally `options` to pass to it.
+ * By default a 'Content-Disposition' header will be added, unless a headers
+ * field is explicitly provided in the `options`.
  *
  * @public
  */
 
-res.download = function download(path, filename, callback) {
+res.download = function download(path, filename, options, callback) {
   var done = callback;
   var name = filename;
+  var opts = options || {};
 
-  // support function as second arg
+  // support function as second or third arg
   if (typeof filename === 'function') {
     done = filename;
     name = null;
+    opts = {};
+  } else if (typeof options === 'function') {
+    done = options;
+    opts = {};
   }
 
-  // set Content-Disposition when file is sent
-  var headers = {
-    'Content-Disposition': contentDisposition(name || path)
-  };
+  // set Content-Disposition when file is sent if no headers are provided
+  if (!('headers' in opts)) {
+    opts.headers = {
+      'Content-Disposition': contentDisposition(name || path)
+    };
+  }
 
   // Resolve the full path for sendFile
   var fullPath = resolve(path);
 
-  return this.sendFile(fullPath, { headers: headers }, done);
+  return this.sendFile(fullPath, opts, done);
 };
 
 /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -506,9 +506,10 @@ res.sendfile = deprecate.function(res.sendfile,
  * when the data transfer is complete, or when an error has
  * ocurred. Be sure to check `res.headersSent` if you plan to respond.
  *
- * This method uses `res.sendfile()`, and optionally `options` to pass to it.
- * By default a 'Content-Disposition' header will be added, unless a headers
- * field is explicitly provided in the `options`.
+ * This method uses `res.sendFile()`, and optionally `options` to pass to it.
+ * By default a 'Content-Disposition' header will be added to the `options` - this can
+ * be overriden by providing your own 'Content-Disposition', but it is recommended
+ * to just use `res.sendFile()` directly instead for that use case.
  *
  * @public
  */
@@ -528,11 +529,14 @@ res.download = function download(path, filename, options, callback) {
     opts = {};
   }
 
-  // set Content-Disposition when file is sent if no headers are provided
+  // add headers to opts if the field doesn't exist
   if (!('headers' in opts)) {
-    opts.headers = {
-      'Content-Disposition': contentDisposition(name || path)
-    };
+    opts.headers = {};
+  }
+
+  // set Content-Disposition when file is sent unless a Content-Disposition is provided
+  if (!('Content-Disposition' in opts.headers)) {
+    opts.headers['Content-Disposition'] = contentDisposition(name || path);
   }
 
   // Resolve the full path for sendFile

--- a/lib/response.js
+++ b/lib/response.js
@@ -507,9 +507,9 @@ res.sendfile = deprecate.function(res.sendfile,
  * ocurred. Be sure to check `res.headersSent` if you plan to respond.
  *
  * This method uses `res.sendFile()`, and optionally `options` to pass to it.
- * By default a 'Content-Disposition' header will be added to the `options` - this can
- * be overriden by providing your own 'Content-Disposition', but it is recommended
- * to just use `res.sendFile()` directly instead for that use case.
+ * This function will set the 'Content-Disposition' header in `options`, and will
+ * override any 'Content-Disposition' header passed to it. If this doesn't meet
+ * your use case it is recommended to just use `res.sendFile()` directly instead.
  *
  * @public
  */
@@ -534,10 +534,8 @@ res.download = function download(path, filename, options, callback) {
     opts.headers = {};
   }
 
-  // set Content-Disposition when file is sent unless a Content-Disposition is provided
-  if (!('Content-Disposition' in opts.headers)) {
-    opts.headers['Content-Disposition'] = contentDisposition(name || path);
-  }
+  // set Content-Disposition when file is sent, overriding the passed instance if necessary
+  opts.headers['Content-Disposition'] = contentDisposition(name || path);
 
   // Resolve the full path for sendFile
   var fullPath = resolve(path);

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -113,7 +113,7 @@ describe('res', function(){
   })
 
   describe('.download(path, filename, options, fn)', function(){
-    it('should allow the default header to be overwritten', function(done){
+    it('should not allow the default header to be overwritten', function(done){
       var app = express();
       var cb = after(2, done);
       var options = {
@@ -129,7 +129,7 @@ describe('res', function(){
       request(app)
       .get('/')
       .expect('Content-Type', 'text/html; charset=UTF-8')
-      .expect('Content-Disposition', 'attachment; filename="customFilename"')
+      .expect('Content-Disposition', 'attachment; filename="document"')
       .expect(200, cb);
     })
   })

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -90,10 +90,15 @@ describe('res', function(){
   })
 
   describe('.download(path, filename, options, fn)', function(){
-    it('should allow options in addition to default header', function(done){
+    it('should allow options in to merge with the default header', function(done){
       var app = express();
       var cb = after(2, done);
-      var options = { dotfiles: 'allow' };
+      var options = {
+        dotfiles: 'allow',
+        headers: {
+          'X-Express': 'merged'
+        }
+    };
 
       app.use(function(req, res){
         res.download('test/fixtures/.name', 'document', options, done);
@@ -101,6 +106,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
+      .expect('X-Express', 'merged')
       .expect('Content-Disposition', 'attachment; filename="document"')
       .expect(200, 'tobi', cb);
     })

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -71,6 +71,63 @@ describe('res', function(){
     })
   })
 
+  describe('.download(path, filename, options, fn)', function(){
+    it('should invoke the callback with the default header', function(done){
+      var app = express();
+      var cb = after(2, done);
+      var options = {};
+
+      app.use(function(req, res){
+        res.download('test/fixtures/user.html', 'document', options, done);
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=UTF-8')
+      .expect('Content-Disposition', 'attachment; filename="document"')
+      .expect(200, cb);
+    })
+  })
+
+  describe('.download(path, filename, options, fn)', function(){
+    it('should allow options in addition to default header', function(done){
+      var app = express();
+      var cb = after(2, done);
+      var options = { dotfiles: 'allow' };
+
+      app.use(function(req, res){
+        res.download('test/fixtures/.name', 'document', options, done);
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Disposition', 'attachment; filename="document"')
+      .expect(200, 'tobi', cb);
+    })
+  })
+
+  describe('.download(path, filename, options, fn)', function(){
+    it('should allow the default header to be overwritten', function(done){
+      var app = express();
+      var cb = after(2, done);
+      var options = {
+        headers: {
+          'Content-Disposition': 'attachment; filename="customFilename"'
+        }
+    };
+
+      app.use(function(req, res){
+        res.download('test/fixtures/user.html', 'document', options, done);
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=UTF-8')
+      .expect('Content-Disposition', 'attachment; filename="customFilename"')
+      .expect(200, cb);
+    })
+  })
+
   describe('on failure', function(){
     it('should invoke the callback', function(done){
       var app = express();


### PR DESCRIPTION
- Added an "options" field to res.download, allowing for options to be passed into sendFile
- Options will include the existing Content-Disposition header by default, unless explicit headers are provided
- Added tests for the new res.download functionality - with blank options, with allowed dotfiles, and with a custom Content-Disposition