### PR TITLE
fixing a path concatenation bug in ejs example

### DIFF
--- a/examples/ejs/index.js
+++ b/examples/ejs/index.js
@@ -26,7 +26,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 // Path to our public directory
 
-app.use(express.static(path.join(__dirname + 'public')));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Without this you would need to
 // supply the extension to res.render()


### PR DESCRIPTION
In the ejs example with layouts, there's a bug in the path concatenation of the public folder, which prevents the static assets from being served.