### PR TITLE
fix broken 'ok' assertions in tests

### DIFF
--- a/test/Route.js
+++ b/test/Route.js
@@ -104,7 +104,7 @@ describe('Route', function(){
 
       route.dispatch(req, {}, function (err) {
         if (err) return done(err);
-        should(req.called).be.true;
+        should(req.called).be.true();
         done();
       });
     })
@@ -234,7 +234,7 @@ describe('Route', function(){
 
       route.all(function(err, req, res, next){
         // this should not execute
-        true.should.be.false;
+        true.should.be.false();
       });
 
       route.dispatch(req, {}, done);

--- a/test/Route.js
+++ b/test/Route.js
@@ -25,7 +25,7 @@ describe('Route', function(){
 
       route.dispatch(req, {}, function (err) {
         if (err) return done(err);
-        should(req.called).be.ok;
+        should(req.called).be.ok();
         done();
       });
     })
@@ -84,7 +84,7 @@ describe('Route', function(){
 
       route.dispatch(req, {}, function (err) {
         if (err) return done(err);
-        should(req.called).be.ok;
+        should(req.called).be.ok();
         done();
       });
     })
@@ -156,7 +156,7 @@ describe('Route', function(){
       });
 
       route.dispatch(req, {}, function (err) {
-        should(err).be.ok;
+        should(err).be.ok();
         should(err.message).equal('foobar');
         req.order.should.equal('a');
         done();
@@ -182,7 +182,7 @@ describe('Route', function(){
       });
 
       route.dispatch(req, {}, function (err) {
-        should(err).be.ok;
+        should(err).be.ok();
         should(err.message).equal('foobar');
         req.order.should.equal('a');
         done();
@@ -222,7 +222,7 @@ describe('Route', function(){
       });
 
       route.dispatch(req, {}, function(err){
-        should(err).be.ok;
+        should(err).be.ok();
         err.message.should.equal('boom!');
         done();
       });

--- a/test/Router.js
+++ b/test/Router.js
@@ -47,7 +47,7 @@ describe('Router', function(){
     var router = new Router();
 
     router.use(function (req, res) {
-      false.should.be.true;
+      false.should.be.true();
     });
 
     router.handle({ url: '', method: 'GET' }, {}, done);

--- a/test/app.js
+++ b/test/app.js
@@ -86,7 +86,7 @@ describe('in development', function(){
   it('should disable "view cache"', function(){
     process.env.NODE_ENV = 'development';
     var app = express();
-    app.enabled('view cache').should.be.false;
+    app.enabled('view cache').should.be.false();
     process.env.NODE_ENV = 'test';
   })
 })
@@ -95,7 +95,7 @@ describe('in production', function(){
   it('should enable "view cache"', function(){
     process.env.NODE_ENV = 'production';
     var app = express();
-    app.enabled('view cache').should.be.true;
+    app.enabled('view cache').should.be.true();
     process.env.NODE_ENV = 'test';
   })
 })

--- a/test/app.param.js
+++ b/test/app.param.js
@@ -57,13 +57,13 @@ describe('app', function(){
 
       app.get('/post/:id', function(req, res){
         var id = req.params.id;
-        id.should.be.a.Number;
+        id.should.be.a.Number();
         res.send('' + id);
       });
 
       app.get('/user/:uid', function(req, res){
         var id = req.params.id;
-        id.should.be.a.Number;
+        id.should.be.a.Number();
         res.send('' + id);
       });
 
@@ -91,7 +91,7 @@ describe('app', function(){
 
       app.get('/user/:id', function(req, res){
         var id = req.params.id;
-        id.should.be.a.Number;
+        id.should.be.a.Number();
         res.send('' + id);
       });
 

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -72,7 +72,7 @@ describe('app', function(){
       app.set('view', View);
 
       app.render('something', function(err, str){
-        err.should.be.ok;
+        err.should.be.ok();
         err.message.should.equal('err!');
         done();
       })

--- a/test/app.routes.error.js
+++ b/test/app.routes.error.js
@@ -44,10 +44,10 @@ describe('app', function(){
         d = true;
         next();
       }, function(req, res){
-        a.should.be.false;
-        b.should.be.true;
-        c.should.be.true;
-        d.should.be.false;
+        a.should.be.false();
+        b.should.be.true();
+        c.should.be.true();
+        d.should.be.false();
         res.send(204);
       });
 

--- a/test/exports.js
+++ b/test/exports.js
@@ -5,19 +5,19 @@ var should = require('should');
 
 describe('exports', function(){
   it('should expose Router', function(){
-    express.Router.should.be.a.Function;
+    express.Router.should.be.a.Function();
   })
 
   it('should expose the application prototype', function(){
-    express.application.set.should.be.a.Function;
+    express.application.set.should.be.a.Function();
   })
 
   it('should expose the request prototype', function(){
-    express.request.accepts.should.be.a.Function;
+    express.request.accepts.should.be.a.Function();
   })
 
   it('should expose the response prototype', function(){
-    express.response.send.should.be.a.Function;
+    express.response.send.should.be.a.Function();
   })
 
   it('should permit modifying the .application prototype', function(){

--- a/test/req.acceptsEncoding.js
+++ b/test/req.acceptsEncoding.js
@@ -8,8 +8,8 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsEncoding('gzip').should.be.ok;
-        req.acceptsEncoding('deflate').should.be.ok;
+        req.acceptsEncoding('gzip').should.be.ok();
+        req.acceptsEncoding('deflate').should.be.ok();
         res.end();
       });
 
@@ -23,7 +23,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsEncoding('bogus').should.not.be.ok;
+        req.acceptsEncoding('bogus').should.not.be.ok();
         res.end();
       });
 

--- a/test/req.acceptsEncodings.js
+++ b/test/req.acceptsEncodings.js
@@ -8,8 +8,8 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsEncodings('gzip').should.be.ok;
-        req.acceptsEncodings('deflate').should.be.ok;
+        req.acceptsEncodings('gzip').should.be.ok();
+        req.acceptsEncodings('deflate').should.be.ok();
         res.end();
       });
 
@@ -23,7 +23,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsEncodings('bogus').should.not.be.ok;
+        req.acceptsEncodings('bogus').should.not.be.ok();
         res.end();
       });
 

--- a/test/req.acceptsLanguage.js
+++ b/test/req.acceptsLanguage.js
@@ -8,8 +8,8 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsLanguage('en-us').should.be.ok;
-        req.acceptsLanguage('en').should.be.ok;
+        req.acceptsLanguage('en-us').should.be.ok();
+        req.acceptsLanguage('en').should.be.ok();
         res.end();
       });
 
@@ -23,7 +23,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsLanguage('es').should.not.be.ok;
+        req.acceptsLanguage('es').should.not.be.ok();
         res.end();
       });
 
@@ -38,9 +38,9 @@ describe('req', function(){
         var app = express();
 
         app.use(function(req, res){
-          req.acceptsLanguage('en').should.be.ok;
-          req.acceptsLanguage('es').should.be.ok;
-          req.acceptsLanguage('jp').should.be.ok;
+          req.acceptsLanguage('en').should.be.ok();
+          req.acceptsLanguage('es').should.be.ok();
+          req.acceptsLanguage('jp').should.be.ok();
           res.end();
         });
 

--- a/test/req.acceptsLanguages.js
+++ b/test/req.acceptsLanguages.js
@@ -8,8 +8,8 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsLanguages('en-us').should.be.ok;
-        req.acceptsLanguages('en').should.be.ok;
+        req.acceptsLanguages('en-us').should.be.ok();
+        req.acceptsLanguages('en').should.be.ok();
         res.end();
       });
 
@@ -23,7 +23,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.acceptsLanguages('es').should.not.be.ok;
+        req.acceptsLanguages('es').should.not.be.ok();
         res.end();
       });
 
@@ -38,9 +38,9 @@ describe('req', function(){
         var app = express();
 
         app.use(function(req, res){
-          req.acceptsLanguages('en').should.be.ok;
-          req.acceptsLanguages('es').should.be.ok;
-          req.acceptsLanguages('jp').should.be.ok;
+          req.acceptsLanguages('en').should.be.ok();
+          req.acceptsLanguages('es').should.be.ok();
+          req.acceptsLanguages('jp').should.be.ok();
           res.end();
         });
 

--- a/test/req.xhr.js
+++ b/test/req.xhr.js
@@ -8,7 +8,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.xhr.should.be.true;
+        req.xhr.should.be.true();
         res.end();
       });
 
@@ -25,7 +25,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.xhr.should.be.true;
+        req.xhr.should.be.true();
         res.end();
       });
 
@@ -42,7 +42,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.xhr.should.be.false;
+        req.xhr.should.be.false();
         res.end();
       });
 
@@ -59,7 +59,7 @@ describe('req', function(){
       var app = express();
 
       app.use(function(req, res){
-        req.xhr.should.be.false;
+        req.xhr.should.be.false();
         res.end();
       });
 

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -108,7 +108,7 @@ describe('res', function(){
       });
 
       app.use(function (err, req, res, next) {
-        err.code.should.be.empty;
+        err.code.should.be.empty();
         cb();
       });
 
@@ -600,7 +600,7 @@ describe('res', function(){
       });
 
       app.use(function (err, req, res, next) {
-        err.code.should.be.empty;
+        err.code.should.be.empty();
         cb();
       });
 

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -224,7 +224,7 @@ describe('res', function(){
       app.use(function (req, res) {
         setImmediate(function () {
           res.sendFile(path.resolve(fixtures, 'name.txt'), function (err) {
-            should(err).be.ok;
+            should(err).be.ok();
             err.code.should.equal('ECONNABORTED');
             cb();
           });
@@ -243,7 +243,7 @@ describe('res', function(){
       app.use(function (req, res) {
         onFinished(res, function () {
           res.sendFile(path.resolve(fixtures, 'name.txt'), function (err) {
-            should(err).be.ok;
+            should(err).be.ok();
             err.code.should.equal('ECONNABORTED');
             cb();
           });
@@ -294,7 +294,7 @@ describe('res', function(){
 
       app.use(function (req, res) {
         res.sendFile(path.resolve(fixtures, 'does-not-exist'), function (err) {
-          should(err).be.ok;
+          should(err).be.ok();
           err.status.should.equal(404);
           res.send('got it');
         });
@@ -348,7 +348,7 @@ describe('res', function(){
       app.use(function (req, res) {
         setImmediate(function () {
           res.sendfile('test/fixtures/name.txt', function (err) {
-            should(err).be.ok;
+            should(err).be.ok();
             err.code.should.equal('ECONNABORTED');
             cb();
           });
@@ -367,7 +367,7 @@ describe('res', function(){
       app.use(function (req, res) {
         onFinished(res, function () {
           res.sendfile('test/fixtures/name.txt', function (err) {
-            should(err).be.ok;
+            should(err).be.ok();
             err.code.should.equal('ECONNABORTED');
             cb();
           });


### PR DESCRIPTION
`should.js`' `ok` assertions must be called to work properly

this doesn't raise error:
```js
describe.only('should.be.ok', function() {
    it('passes, but should not', function() {
        var x = false;
        x.should.be.ok;
    });
});
```

fails as it should:
```js
describe.only('should.be.ok', function() {
    it('fails as it should', function() {
        var x = false;
        x.should.be.ok();
    });
});
```