### PR TITLE
Add group to support multi route definition

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -147,6 +147,27 @@ app.lazyrouter = function lazyrouter() {
 };
 
 /**
+ * Allow to group multi routes under the same path.
+ *
+ * @example
+ *  app.group('/api/v1', (v1) => {
+ *    v1.get('/ping', (res, req, next) => { // ... });
+ *    v1.post('/example', (res, req, next) => { // ... } );
+ *  });
+ *
+ * @public
+ */
+app.group = function group(groupName, routes) {
+  var router = this._router;
+
+  this.use(groupName, router);
+
+  routes(router);
+
+  return router;
+};
+
+/**
  * Dispatch a req, res pair into the application. Starts pipeline processing.
  *
  * If no callback is provided, then default error handlers will respond

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -33,6 +33,27 @@ describe('app.router', function(){
     .expect(200, '1', done);
   })
 
+  describe('group', function(){
+    it('should accept group of routes and return different results', function() {
+      var app = express();
+
+      app.group('/api/v1', function(v1) {
+        v1.get('/ping', function(res, req, next) {
+          res.end('v1');
+        });
+      });
+
+      app.group('/api/v2', function(v2) {
+        v2.get('/ping', function(res, req, next) {
+          res.end('v2');
+        });
+      });
+
+      request(app).get('/api/v1/ping').expect(200, 'v1');
+      request(app).get('/api/v2/ping').expect(200, 'v2');
+    })
+  })
+
   describe('methods', function(){
     methods.concat('del').forEach(function(method){
       if (method === 'connect') return;
@@ -86,7 +107,7 @@ describe('app.router', function(){
       .post('/')
       .expect('X-Method-Altered', '1')
       .expect(200, 'deleted everything', cb);
-    });
+    })
   })
 
   describe('decode params', function () {


### PR DESCRIPTION
Make it easier to define many routes under a specific group/prefix - best example would be specify routes per version. or write many routes under specific group (i.e `user/..` etc).

```js
app.group('/api/v1', function(v1) {
  v1.get('/ping', function(res, req, next) {
    res.end('v1');
  });
});

app.group('/api/v2', function(v2) {
  v2.get('/ping', function(res, req, next) {
    res.end('v2');
  });
});
```

I couldn't find a better way to define many routes under a specific "group"/"domain" - if there is a better way to do it I am open minded - Thanks!