### PR TITLE
Fix error message for route

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -448,7 +448,7 @@ proto.use = function use(fn) {
   var callbacks = flatten(slice.call(arguments, offset));
 
   if (callbacks.length === 0) {
-    throw new TypeError('Router.use() requires middleware functions');
+    throw new TypeError('Router.use() requires middleware function');
   }
 
   for (var i = 0; i < callbacks.length; i++) {

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -175,7 +175,7 @@ Route.prototype.all = function all() {
 
     if (typeof handle !== 'function') {
       var type = toString.call(handle);
-      var msg = 'Route.all() requires callback functions but got a ' + type;
+      var msg = 'Route.all() requires callback function but got a ' + type;
       throw new TypeError(msg);
     }
 
@@ -198,7 +198,7 @@ methods.forEach(function(method){
 
       if (typeof handle !== 'function') {
         var type = toString.call(handle);
-        var msg = 'Route.' + method + '() requires callback functions but got a ' + type;
+        var msg = 'Route.' + method + '() requires callback function but got a ' + type;
         throw new Error(msg);
       }
 


### PR DESCRIPTION
Instead of complaining that *functions* are missing, let's tell users that we're missing a single *function*.