### PR TITLE
deps: send 0.16.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+unreleased
+===================
+
+  * deps: send@0.16.0
+    - Set charset as "UTF-8" for .js and .json files
+
 4.15.5 / 2017-09-24
 ===================
 

--- a/History.md
+++ b/History.md
@@ -2,7 +2,13 @@ unreleased
 ===================
 
   * deps: send@0.16.0
-    - Set charset as "UTF-8" for .js and .json files
+    - Add immutable option
+    - Fix missing </html> in default error & redirects
+    - Use instance methods on steam to check for listeners
+    - deps: mime@1.4.1
+      - Add 70 new types for file extensions
+      - Set charset as "UTF-8" for .js and .json
+    - perf: improve path validation speed
 
 4.15.5 / 2017-09-24
 ===================

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "proxy-addr": "~1.1.5",
     "qs": "6.5.0",
     "range-parser": "~1.2.0",
-    "send": "0.15.6",
+    "send": "0.16.0",
     "serve-static": "1.12.6",
     "setprototypeof": "1.0.3",
     "statuses": "~1.3.1",

--- a/test/res.type.js
+++ b/test/res.type.js
@@ -13,7 +13,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Content-Type', 'application/javascript', done);
+      .expect('Content-Type', 'application/javascript; charset=utf-8', done);
     })
 
     it('should default to application/octet-stream', function(done){


### PR DESCRIPTION
This fixes a security issue found in `mime`, which got updated in `send` 0.16

https://nodesecurity.io/advisories/535