### PR TITLE
TypeError in send(Buffer) when an ETag is set

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -178,16 +178,16 @@ res.send = function send(body) {
   // populate Content-Length
   var len
   if (chunk !== undefined) {
-    if (!generateETag && chunk.length < 1000) {
+    if (Buffer.isBuffer(chunk)) {
+      // get length of Buffer
+      len = chunk.length
+    } else if (!generateETag && chunk.length < 1000) {
       // just calculate length when no ETag + small chunk
       len = Buffer.byteLength(chunk, encoding)
-    } else if (!Buffer.isBuffer(chunk)) {
+    } else {
       // convert chunk to Buffer and calculate
       chunk = Buffer.from(chunk, encoding)
       encoding = undefined;
-      len = chunk.length
-    } else {
-      // get length of Buffer
       len = chunk.length
     }
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -216,6 +216,21 @@ describe('res', function(){
       .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(200, 'hey', done);
     })
+
+    it('should set the content length if the ETag is already set', function(done) {
+      var app = express();
+
+      app.use(function(req, res) {
+        res.type('text/plain').set('ETag', 'test123').send(Buffer.from('hey'))
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect('ETag', 'test123')
+      .expect('Content-Length', 3)
+      .expect(200, 'hey', done);
+    })
   })
 
   describe('.send(Object)', function(){


### PR DESCRIPTION
A recent [commit](https://github.com/expressjs/express/commit/48940e61202be07677659b3b9d87c967fc4e8bdc) introduced a condition where TypeError will be thrown when calling `res.send(Buffer)`. 

If an ETag has already been set, `generateETag` will be false, and if `chunk` is a Buffer with a length less than 1000, `Buffer.byteLength` will be used to calculate the length, but the `chunk` is a Buffer and not a string.
