### PR TITLE
remove unecessary comparison in test/res.send.js

### DIFF
--- a/test/res.send.js
+++ b/test/res.send.js
@@ -54,7 +54,7 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        res.send(201).should.equal(res);
+        res.send(201);
       });
 
       request(app)

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -294,6 +294,18 @@ describe('res', function(){
     })
   })
 
+  it('should be chainable', function(done){
+    var app = express();
+
+    app.use(function (req, res) {
+      res.send().should.equal(res);
+    });
+
+    request(app)
+      .get('/')
+      .expect('', done);
+  })
+
   it('should always check regardless of length', function(done){
     var app = express();
     var etag = '"asdf"';


### PR DESCRIPTION
I think it is unnecessary about res equal res.   
Should add a new test case if want to validate res.send is chainable.