### PR TITLE
update debug package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.3.1",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.9",
+    "debug": "^3.1.0",
     "depd": "~1.1.1",
     "encodeurl": "~1.0.1",
     "escape-html": "~1.0.3",
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "after": "0.8.2",
+    "connect-redis": "~2.4.1",
     "cookie-parser": "~1.4.3",
     "cookie-session": "1.3.2",
     "ejs": "2.5.7",
@@ -75,7 +76,6 @@
     "pbkdf2-password": "1.2.1",
     "should": "13.1.0",
     "supertest": "1.2.0",
-    "connect-redis": "~2.4.1",
     "vhost": "~3.0.2"
   },
   "engines": {


### PR DESCRIPTION
## Current behaviour

`debug` package has a [security vulnerability](visionmedia/debug#501).

## New behaviour

The new `debug` version fixes the security vulnerability.
This will fix the red "dependencies" badge in the README.

