### PR TITLE
Fixed unexpected behaviour of parseExtendedQueryString function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -290,7 +290,8 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    arrayLimit: Infinity
   });
 }
 


### PR DESCRIPTION
There is a default arrays length limit in qs.parse (qs module), undocumented in Express' docs, that causes the trasformation of a query string parameter to Object instead of Array if it's length is > 20.
Setting arrayLimit option to Infinity prevents this unexpected behaviour.