### PR TITLE
Integrate TravisBuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,12 @@ script:
   - "npm run test-ci"
   - "npm run lint"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"
+notifications:
+  webhooks:
+      urls:
+        - https://www.travisbuddy.com/
+      on_success: never
+      on_failure: always
+      on_start: never
+      on_cancel: never
+      on_error: never


### PR DESCRIPTION
TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contirbutors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed.

Here's an example: https://github.com/bluzi/express/pull/1