### PR TITLE
req.hostname: check first comma-delimited host

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ unreleased
 
   * Improve error message for non-strings to `res.sendFile`
   * Improve error message for `null`/`undefined` to `res.status`
+  * Support multiple hosts in `X-Forwarded-Host`
 
 4.16.4 / 2018-10-10
 ===================

--- a/lib/request.js
+++ b/lib/request.js
@@ -430,6 +430,10 @@ defineGetter(req, 'hostname', function hostname(){
 
   if (!host || !trust(this.connection.remoteAddress, 0)) {
     host = this.get('Host');
+  } else if (host.indexOf(',') !== -1) {
+    // Note: X-Forwarded-Host is normally only ever a
+    //       single value, but this is to be safe.
+    host = host.substring(0, host.indexOf(',')).trimRight()
   }
 
   if (!host) return;

--- a/test/req.hostname.js
+++ b/test/req.hostname.js
@@ -116,6 +116,56 @@ describe('req', function(){
         .set('Host', 'example.com')
         .expect('example.com', done);
       })
+
+      describe('when multiple X-Forwarded-Host', function () {
+        it('should use the first value', function (done) {
+          var app = express()
+
+          app.enable('trust proxy')
+
+          app.use(function (req, res) {
+            res.send(req.hostname)
+          })
+
+          request(app)
+          .get('/')
+          .set('Host', 'localhost')
+          .set('X-Forwarded-Host', 'example.com, foobar.com')
+          .expect(200, 'example.com', done)
+        })
+
+        it('should remove OWS around comma', function (done) {
+          var app = express()
+
+          app.enable('trust proxy')
+
+          app.use(function (req, res) {
+            res.send(req.hostname)
+          })
+
+          request(app)
+          .get('/')
+          .set('Host', 'localhost')
+          .set('X-Forwarded-Host', 'example.com , foobar.com')
+          .expect(200, 'example.com', done)
+        })
+
+        it('should strip port number', function (done) {
+          var app = express()
+
+          app.enable('trust proxy')
+
+          app.use(function (req, res) {
+            res.send(req.hostname)
+          })
+
+          request(app)
+          .get('/')
+          .set('Host', 'localhost')
+          .set('X-Forwarded-Host', 'example.com:8080 , foobar.com:8888')
+          .expect(200, 'example.com', done)
+        })
+      })
     })
 
     describe('when "trust proxy" is disabled', function(){


### PR DESCRIPTION
Fixes #3494 