### PR TITLE
res.send: if number, not override statusCode if already defined by res.status(code)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -64,6 +64,7 @@ var charsetRegExp = /;\s*charset\s*=/;
  */
 
 res.status = function status(code) {
+  this._statusCode = this.statusCode;
   this.statusCode = code;
   return this;
 };
@@ -133,9 +134,12 @@ res.send = function send(body) {
       this.type('txt');
     }
 
-    deprecate('res.send(status): Use res.sendStatus(status) instead');
-    this.statusCode = chunk;
-    chunk = statuses[chunk]
+    // Check if statusCode was set by res.status()
+    if (!this._statusCode) {
+      deprecate('res.send(status): Use res.sendStatus(status) instead');
+      this.statusCode = chunk;
+      chunk = statuses[chunk]
+    }
   }
 
   switch (typeof chunk) {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -64,6 +64,20 @@ describe('res', function(){
     })
   })
 
+  describe('.send(number)', function () {
+    it('should not set statusCode if already set by .status(code)', function (done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.status(200).send(400);
+      });
+
+      request(app)
+      .get('/')
+      .expect(200, '400', done);
+    })
+  })
+
   describe('.send(code, body)', function(){
     it('should set .statusCode and body', function(done){
       var app = express();


### PR DESCRIPTION
Fixes #3506