### PR TITLE
lint: rename .eslintrc to .eslintrc.yml

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "rules": {
-    "eol-last": "error",
-    "indent": ["error", 2, { "SwitchCase": 1 }],
-    "no-trailing-spaces": "error",
-    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": true }]
-  }
-}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,7 @@
+root: true
+
+rules:
+  eol-last: error
+  indent: [error, 2, {SwitchCase: 1}]
+  no-trailing-spaces: error
+  no-unused-vars: [error, {vars: all, args: none, ignoreRestSiblings: true}]

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - "5.12"
   - "6.12"
   - "7.10"
-  - "8.4"
+  - "8.9"
 matrix:
   include:
     - node_js: "8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - nodejs_version: "5.12"
     - nodejs_version: "6.12"
     - nodejs_version: "7.10"
-    - nodejs_version: "8.4"
+    - nodejs_version: "8.9"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
`.eslintrc` is deprecated. 
See https://eslint.org/docs/user-guide/configuring#configuration-file-formats.

I changed to `.eslintrc.yaml` because Node is using Yaml.(https://github.com/nodejs/node/pull/7699)



