### PR TITLE
build: Node.js@9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "6.12"
     - nodejs_version: "7.10"
     - nodejs_version: "8.9"
+    - nodejs_version: "9"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
We'll release Node@10 on Apr 2018 so will add 9(current).
Travis seems to be OK. https://github.com/expressjs/express/blob/master/.travis.yml#L17