### PR TITLE
Added app.extend()

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -24,6 +24,7 @@ var http = require('http');
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
+var extendObject = require('./utils').extendObject;
 var deprecate = require('depd')('express');
 var flatten = require('array-flatten');
 var merge = require('utils-merge');
@@ -407,7 +408,7 @@ app.extend = function(setting, val) {
 
   if (typeof val === 'undefined') {
     return this;
-  } else if (val === null || typeof val !== 'object') {
+  } else if (val === null || typeof val !== 'object' || val instanceof Array) {
     throw new Error('value needs to be an object');
   }
 
@@ -421,11 +422,8 @@ app.extend = function(setting, val) {
     return this;
   }
 
-  // extend from the intial object type
-  var newObject = Array.isArray(this.settings[setting]) ? [] : {};
-
   // extend value
-  this.settings[setting] = Object.assign(newObject, this.settings[setting], val);
+  this.settings[setting] = extendObject({}, this.settings[setting], val);
 
   return this;
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -384,6 +384,50 @@ app.set = function set(setting, val) {
 };
 
 /**
+ * Extend `setting` with `val`, or return `setting`'s value.
+ *
+ *    app.set('foo', { 'bar' : 1 })
+ *    app.expand('foo', { 'baz' : 1 });
+ *    app.expand('foo');
+ *    // => { "bar" : 1, "baz" : 1 }
+ *
+ * Mounted servers inherit their parent server's settings.
+ *
+ * @param {String} setting
+ * @param {*} [val]
+ * @return {Server} for chaining
+ * @public
+ */
+
+app.extend = function(setting, val) {
+  if (arguments.length === 1) {
+    // app.get(setting)
+    return this.settings[setting];
+  }
+
+  if (typeof val === 'undefined') {
+    return this;
+  } else if (val === null || typeof val !== 'object') {
+    throw new Error('value needs to be an object');
+  }
+
+  debug('extend "%s" with %o', setting, val);
+
+  var currentSetting = this.settings[setting];
+
+  // no object yet, set value
+  if (currentSetting === null || typeof currentSetting !== 'object') {
+    this.settings[setting] = val;
+    return this;
+  }
+
+  // extend value
+  this.settings[setting] = Object.assign(this.settings[setting], val);
+
+  return this;
+};
+
+/**
  * Return the app's absolute pathname
  * based on the parent(s) that have
  * mounted it.

--- a/lib/application.js
+++ b/lib/application.js
@@ -421,8 +421,11 @@ app.extend = function(setting, val) {
     return this;
   }
 
+  // extend from the intial object type
+  var newObject = Array.isArray(this.settings[setting]) ? [] : {};
+
   // extend value
-  this.settings[setting] = Object.assign(this.settings[setting], val);
+  this.settings[setting] = Object.assign(newObject, this.settings[setting], val);
 
   return this;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -263,6 +263,31 @@ exports.setCharset = function setCharset(type, charset) {
 };
 
 /**
+ * Extend an object
+ *
+ * @param {Object} object The destination object
+ * @param {...Object} source The source objects
+ * @returns {Object}
+ * @private
+ */
+
+exports.extendObject = function(target, source) {
+  if (typeof target !== 'object') {
+    target = {};
+  }
+
+  for (var prop in source) {
+    target[prop] = source[prop];
+  }
+
+  for (var a = 2, l = arguments.length; a < l; a++) {
+    exports.extendObject(target, arguments[a]);
+  }
+
+  return target;
+}
+
+/**
  * Create an ETag generator function, generating ETags with
  * the given options.
  *

--- a/test/config.js
+++ b/test/config.js
@@ -132,6 +132,23 @@ describe('config', function () {
       assert.deepEqual(app.get('foo'), { 'bar' : 1, 'baz' : 1 });
     })
 
+    it('should not extend by reference', function () {
+      var app1 = express();
+      var app2 = express();
+
+      app1.set('foo', { active: false });
+      assert.equal(app1.get('foo').active, false);
+      assert.equal(app2.get('foo'), undefined);
+
+      app1.use(app2);
+      assert.equal(app1.get('foo').active, false);
+      assert.equal(app2.get('foo').active, false);
+
+      app2.extend('foo', { active: true });
+      assert.deepEqual(app1.get('foo'), { active: false });
+      assert.deepEqual(app2.get('foo'), { active: true });
+    })
+
     it('should return the app', function () {
       var app = express();
       assert.equal(app.extend('foo', { 'bar' : 1 }), app);
@@ -142,7 +159,7 @@ describe('config', function () {
       assert.equal(app.extend('foo', undefined), app);
     })
 
-    it('should thorw on bad value', function () {
+    it('should throw on a bad value', function () {
       var app = express();
       (function(){
         app.extend('foo', null);

--- a/test/config.js
+++ b/test/config.js
@@ -118,6 +118,38 @@ describe('config', function () {
     })
   })
 
+  describe('.extend()', function () {
+    it('should set if value is nonexistent', function () {
+      var app = express();
+      app.extend('foo', { 'bar' : 1 });
+      assert.deepEqual(app.get('foo'), { 'bar' : 1 });
+    })
+
+    it('should extend an object', function () {
+      var app = express();
+      app.extend('foo', { 'bar' : 1 });
+      app.extend('foo', { 'baz' : 1 });
+      assert.deepEqual(app.get('foo'), { 'bar' : 1, 'baz' : 1 });
+    })
+
+    it('should return the app', function () {
+      var app = express();
+      assert.equal(app.extend('foo', { 'bar' : 1 }), app);
+    })
+
+    it('should return the app when undefined', function () {
+      var app = express();
+      assert.equal(app.extend('foo', undefined), app);
+    })
+
+    it('should thorw on bad value', function () {
+      var app = express();
+      (function(){
+        app.extend('foo', null);
+      }).should.throw('value needs to be an object');
+    })
+  })
+
   describe('.enable()', function(){
     it('should set the value to true', function(){
       var app = express();

--- a/test/config.js
+++ b/test/config.js
@@ -164,6 +164,9 @@ describe('config', function () {
       (function(){
         app.extend('foo', null);
       }).should.throw('value needs to be an object');
+      (function(){
+        app.extend('foo', []);
+      }).should.throw('value needs to be an object');
     })
   })
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -93,3 +93,51 @@ describe('utils.flatten(arr)', function(){
       .should.eql(['one', 'two', 'three', 'four', 'five']);
   })
 })
+
+describe('utils.extendObject', function(){
+  var result;
+
+  it('can extend an object with the attributes of another', function(){
+    assert.strictEqual(utils.extendObject({}, {a: 'b'}).a, 'b');
+  })
+
+  it('properties in source override destination', function(){
+    assert.strictEqual(utils.extendObject({a: 'x'}, {a: 'b'}).a, 'b');
+  })
+
+  it('properties not in source don\'t get overridden', function(){
+    assert.strictEqual(utils.extendObject({x: 'x'}, {a: 'b'}).x, 'x');
+  })
+
+  it('can extend from multiple source objects', function(){
+    result = utils.extendObject({x: 'x'}, {a: 'a'}, {b: 'b'});
+    assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'});
+  })
+
+  it('extending from multiple source objects last property trumps', function(){
+    result = utils.extendObject({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
+    assert.deepEqual(result, {x: 2, a: 'b'});
+  })
+
+  it('extend copies undefined values', function(){
+    result = utils.extendObject({}, {a: void 0, b: null});
+    assert.equal(result.hasOwnProperty('a'), true);
+    assert.equal(result.hasOwnProperty('b'), true);
+  })
+
+  it('extend copies all properties from source', function(){
+    var F = function(){};
+    F.prototype = {a: 'b'};
+    var subObj = new F();
+    subObj.c = 'd';
+    assert.deepEqual(utils.extendObject({}, subObj), {a: 'b', c: 'd'});
+  })
+
+  it('should not error on `null` or `undefined` sources', function(){
+    try {
+      result = {};
+      utils.extendObject(result, null, void 0, {a: 1});
+    } catch (e) { /* ignored */ }
+    assert.strictEqual(result.a, 1);
+  })
+})


### PR DESCRIPTION
Added `app.extend()`, which provides an easy way to update certain properties of a setting.
Example:
```
app.set('foo', { 'bar' : 1 })
app.extend('foo', { 'baz' : 1 });
app.get('foo');
// => { "bar" : 1, "baz" : 1 }
```

Related issue #3499 