### PR TITLE
Auto file extension lookup with multiple view engines

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -51,17 +51,18 @@ module.exports = View;
 
 function View(name, options) {
   var opts = options || {};
+  var fileName = name;
 
   this.defaultEngine = opts.defaultEngine;
   this.ext = extname(name);
   this.name = name;
   this.root = opts.root;
 
+  var ext = this.ext;
+
   if (!this.ext && !this.defaultEngine) {
     throw new Error('No default engine was specified and no extension was provided.');
   }
-
-  var fileName = name;
 
   if (!this.ext) {
     // get extension from default engine name
@@ -87,11 +88,27 @@ function View(name, options) {
     opts.engines[this.ext] = fn
   }
 
-  // store loaded engine
-  this.engine = opts.engines[this.ext];
-
   // lookup path
   this.path = this.lookup(fileName);
+
+  // no path found for the default engine? Try another engine.
+  if (!this.path && !ext) {
+    for (var key in opts.engines) {
+      if (key === this.ext) continue; // ignore default engine
+
+      fileName = name + key;
+      this.path = this.lookup(fileName);
+
+      // path valid?
+      if (this.path) {
+        this.ext = key;
+        break;
+      }
+    }
+  }
+
+  // store loaded engine
+  this.engine = opts.engines[this.ext];
 }
 
 /**

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -108,6 +108,24 @@ describe('res', function(){
       .expect('<h1>blog post</h1>', done);
     })
 
+    describe('when there are multiple view engines', function(){
+      it('should fallback to the next view engine when no file extension is set', function(done){
+        var app = createApp();
+
+        app.engine('.ntl', tmpl);
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'ntl');
+
+        app.use(function(req, res){
+          res.render('email');
+        });
+
+        request(app)
+        .get('/')
+        .expect('<p>This is an email</p>', done);
+      })
+    })
+
     describe('when an error occurs', function(){
       it('should next(err)', function(done){
         var app = createApp();


### PR DESCRIPTION
When there is no file extension defined, express will now try to use any extension that is registered with an engine. The default extension set by `app.set('view engine')` is still observed first.

Related issue: #3485