### PR TITLE
making route and router configurable to automatically send 405 responses (fix for #2414)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -251,9 +251,9 @@ app.use = function use(fn) {
  * @public
  */
 
-app.route = function route(path) {
+app.route = function route(path, config) {
   this.lazyrouter();
-  return this._router.route(path);
+  return this._router.route(path, config);
 };
 
 /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -138,7 +138,8 @@ app.lazyrouter = function lazyrouter() {
   if (!this._router) {
     this._router = new Router({
       caseSensitive: this.enabled('case sensitive routing'),
-      strict: this.enabled('strict routing')
+      strict: this.enabled('strict routing'),
+      automatic405: typeof this.set('automatic 405') === 'boolean' ? this.set('automatic 405') : false
     });
 
     this._router.use(query(this.get('query parser fn')));

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -56,6 +56,7 @@ var proto = module.exports = function(options) {
   router.mergeParams = opts.mergeParams;
   router.strict = opts.strict;
   router.stack = [];
+  router.automatic405 = opts.automatic405;
 
   return router;
 };
@@ -250,6 +251,7 @@ proto.handle = function handle(req, res, out) {
 
       // don't even bother matching route
       if (!has_method && method !== 'HEAD') {
+        if (route.automatic405) res.status(405).end();
         match = false;
         continue;
       }
@@ -484,17 +486,22 @@ proto.use = function use(fn) {
  * and middleware to routes.
  *
  * @param {String} path
+ * @param {Object} config
  * @return {Route}
  * @public
  */
 
-proto.route = function route(path) {
-  var route = new Route(path);
+proto.route = function route(path, config) {
+  var opts = config || {};
+
+  var route = new Route(path, {
+    automatic405: opts.hasOwnProperty('automatic405') ? opts.automatic405 : this.automatic405
+  });
 
   var layer = new Layer(path, {
     sensitive: this.caseSensitive,
     strict: this.strict,
-    end: true
+    end: true,
   }, route.dispatch.bind(route));
 
   layer.route = route;

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -56,7 +56,7 @@ var proto = module.exports = function(options) {
   router.mergeParams = opts.mergeParams;
   router.strict = opts.strict;
   router.stack = [];
-  router.automatic405 = opts.automatic405;
+  router.automatic405 = typeof opts.automatic405 === 'boolean' ? opts.automatic405 : false;
 
   return router;
 };

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -46,7 +46,7 @@ function Route(path, config) {
 
   this.path = path;
   this.stack = [];
-  this.automatic405 = opts.automatic405;
+  this.automatic405 = typeof opts.automatic405 === 'boolean' ? opts.automatic405 : false;
 
   debug('new %o', path)
 

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -37,12 +37,16 @@ module.exports = Route;
  * Initialize `Route` with the given `path`,
  *
  * @param {String} path
+ * @param {Object} config
  * @public
  */
 
-function Route(path) {
+function Route(path, config) {
+  var opts = config || {};
+
   this.path = path;
   this.stack = [];
+  this.automatic405 = opts.automatic405;
 
   debug('new %o', path)
 

--- a/test/app.route.js
+++ b/test/app.route.js
@@ -59,4 +59,20 @@ describe('app.route', function(){
     .get('/test')
     .expect(404, done);
   });
+
+  it('should respond with status 405 if request method is not present on route and route is configured for auto 405', function(done){
+    var app = express();
+
+    app.route('/', { automatic405: true })
+    .get(function(req, res) {
+      res.send('get');
+    })
+    .post(function(req, res) {
+      res.send('post');
+    });
+
+    request(app)
+    .put('/')
+    .expect(405, done);
+  });
 });

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -962,6 +962,71 @@ describe('app.router', function(){
     })
   })
 
+  describe('when automatic405 property is set on router', function(){
+    it('should respond with status 405 if request method is not present on route', function(done){
+      var app = express();
+      var router = new express.Router({ automatic405: true });
+
+      router.route('/')
+      .get(function(req, res) {
+        res.send('get');
+      })
+      .put(function(req, res) {
+        res.send('put');
+      });
+
+      app.use(router);
+
+      request(app)
+      .post('/')
+      .expect(405, done);
+    })
+
+    it('can be overridden by route', function(done){
+      var app = express();
+      var router = new express.Router({ automatic405: true });
+
+      router.route('/')
+      .get(function(req, res) {
+        res.send('get');
+      });
+
+      router.route('/foo', { automatic405: false })
+      .post(function(req, res) {
+        res.send('post');
+      });
+
+      app.use(router);
+
+      request(app)
+      .put('/foo')
+      .expect(404, done);
+    })
+
+    it('should respond according to request handler when request method matches', function(done){
+      var app = express();
+      var router = new express.Router({ automatic405: true });
+
+      router.route('/')
+      .get(function(req, res) {
+        res.send('get');
+      })
+      .put(function(req, res) {
+        res.send('put');
+      });
+
+      router.post('/foo', function(req, res) {
+        res.send('post');
+      });
+
+      app.use(router);
+
+      request(app)
+      .post('/foo')
+      .expect('post', done);
+    })
+  })
+
   describe('when next(err) is called', function(){
     it('should break out of app.router', function(done){
       var app = express()


### PR DESCRIPTION
Hi,

This PR resolves issue #2414 by making route and router configurable as suggested by @dougwilson in this issue.

Making POST request to following route will respond with 405 Method not allowed
```javascript
// route-specific
app.route('/', { automatic405: true })
.get(handler)
```
Also all the routes on router can be configured and particular routes can made to override router's configuration
```javascript
// router-wide default
var router = express.Router({ automatic405: true })

// can be overridden
router.route(path, { automatic405: false })
.get(handler)
``` 
