### PR TITLE
res.format(): call default using `obj` as the context

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
   * Allow `options` without `filename` in `res.download`
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
+  * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`
   * deps: finalhandler@1.2.0
     - Remove set content headers that break response

--- a/lib/response.js
+++ b/lib/response.js
@@ -684,9 +684,8 @@ res.format = function(obj){
   var req = this.req;
   var next = req.next;
 
-  var fn = obj.default;
-  if (fn) delete obj.default;
-  var keys = Object.keys(obj);
+  var keys = Object.keys(obj)
+    .filter(function (v) { return v !== 'default' })
 
   var key = keys.length > 0
     ? req.accepts(keys)
@@ -697,8 +696,8 @@ res.format = function(obj){
   if (key) {
     this.set('Content-Type', normalizeType(key).value);
     obj[key](req, this, next);
-  } else if (fn) {
-    fn();
+  } else if (obj.default) {
+    obj.default(req, this, next)
   } else {
     var err = new Error('Not Acceptable');
     err.status = err.statusCode = 406;

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -50,7 +50,12 @@ var app3 = express();
 app3.use(function(req, res, next){
   res.format({
     text: function(){ res.send('hey') },
-    default: function(){ res.send('default') }
+    default: function (a, b, c) {
+      assert(req === a)
+      assert(res === b)
+      assert(next === c)
+      res.send('default')
+    }
   })
 });
 
@@ -117,6 +122,28 @@ describe('res', function(){
         .get('/')
         .set('Accept', '*/*')
         .expect('hey', done);
+      })
+
+      it('should be able to invoke other formatter', function (done) {
+        var app = express()
+
+        app.use(function (req, res, next) {
+          res.format({
+            json: function () { res.send('json') },
+            default: function () {
+              res.header('x-default', '1')
+              this.json()
+            }
+          })
+        })
+
+        request(app)
+          .get('/')
+          .set('Accept', 'text/plain')
+          .expect(200)
+          .expect('x-default', '1')
+          .expect('json')
+          .end(done)
       })
     })
 


### PR DESCRIPTION
... so that it may refer to the other handlers via `this`. This is useful for cases where you want to delegate the `default` behavior to one of the other registered handlers, e.g.:

```js
app.get('/:item', (req, res) => res.format({
  json() { res.send(req.item) }
, text() { res.send(req.item.toString()) }
, xml()  { res.send(req.item.toXML()) }
, default() { this.json() }
}))
```

Without this, I have to pre-declare the default `json` handler separately, making it inconsistent with how the non-default handlers are declared and making the overall code more complex:

```js
app.get('/:item', (req, res) => {
  function sendJSON() { res.send(req.item) }
  res.format({
    json: sendJSON
  , text() { res.send(req.item.toString()) }
  , xml()  { res.send(req.item.toXML()) }
  , default: sendJSON
  })
})
```

The regular (non-`default`) handlers are already called with the `obj` as their context, so this would match their behavior too.