### PR TITLE
add `async await` syntax support to Router

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -92,7 +92,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    // support `async await` syntax
+    var rt = fn(req, res, next);
+    if(rt && rt.catch) rt.catch(next);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
add `async await` error handle support to Router.