### PR TITLE
Add "view options" settings for rendering engines

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -542,12 +542,13 @@ app.render = function render(name, options, callback) {
     opts = {};
   }
 
-  // merge app.settings["view options"] or app.locals
+  // merge app.locals
+  merge(renderOptions, this.locals);
+
+  // merge app.settings["view options"]
   var viewOptions = this.settings["view options"];
   if (typeof viewOptions === "object") {
     merge(renderOptions, viewOptions);
-  } else {
-    merge(renderOptions, this.locals);
   }
 
   // merge options._locals

--- a/lib/application.js
+++ b/lib/application.js
@@ -542,8 +542,13 @@ app.render = function render(name, options, callback) {
     opts = {};
   }
 
-  // merge app.locals
-  merge(renderOptions, this.locals);
+  // merge app.settings["view options"] or app.locals
+  var viewOptions = this.settings["view options"];
+  if (typeof viewOptions === "object") {
+    merge(renderOptions, viewOptions);
+  } else {
+    merge(renderOptions, this.locals);
+  }
 
   // merge options._locals
   if (opts._locals) {

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -44,6 +44,32 @@ describe('app', function(){
       })
     })
 
+    it('should use view options', function(done){
+      var app = createApp();
+
+      app.set('views', path.join(__dirname, 'fixtures'))
+      app.locals.user = { name: 'tobi' };
+      app.set('view options', {
+        uppercase: true,
+      });
+
+      app.render('user.tmpl', function (err, str) {
+        if (err) return done(err);
+        str.should.equal('<P>TOBI</P>');
+      })
+
+      app.set('view options', {
+        uppercase: false,
+      });
+
+      app.render('user.tmpl', function (err, str) {
+        if (err) return done(err);
+        str.should.equal('<p>tobi</p>');
+        done();
+      })
+    })
+
+
     it('should support index.<engine>', function(done){
       var app = createApp();
 

--- a/test/support/tmpl.js
+++ b/test/support/tmpl.js
@@ -11,6 +11,9 @@ module.exports = function renderFile(fileName, options, callback) {
 
     try {
       str = str.replace(variableRegExp, generateVariableLookup(options));
+      if (options.uppercase) {
+        str = str.toUpperCase();
+      }
     } catch (e) {
       err = e;
       err.name = 'RenderError'


### PR DESCRIPTION
Avoids cluttering app.locals, and is consistent
with the assignment of the "view engine" settings:
```js
app.set("view options", {
    basedir: "somedir"
});
app.set("view engine", "pug");
```
The intent is also stated more clearly in comparison to:
```js
app.locals.basedir = "somedir"
```