### PR TITLE
remove nodejs 9 in nightly 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ node_js:
   - "6.14"
   - "7.10"
   - "8.12"
+  - "9.11"
 matrix:
   include:
-    - node_js: "9"
-      env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly"
     - node_js: "10"
       env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly"
     - node_js: "11"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "6.14"
     - nodejs_version: "7.10"
     - nodejs_version: "8.12"
+    - nodejs_version: "9.11"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
NodeJS 9 is no longer nightly. This is the current non-LTS version of nodejs.