### PR TITLE
If XFH header has multiple values while proxying, use oldest

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -427,6 +427,11 @@ defineGetter(req, 'path', function path() {
 defineGetter(req, 'hostname', function hostname(){
   var trust = this.app.get('trust proxy fn');
   var host = this.get('X-Forwarded-Host');
+  if (Array.isArray(host)) {
+    if (host.length > 0) {
+      host = host[0];
+    }
+  }
 
   if (!host || !trust(this.connection.remoteAddress, 0)) {
     host = this.get('Host');


### PR DESCRIPTION
If an express server is sitting behind multiple proxies, it's
    conceivable that multiple X-Forwarded-Host headers might get set. In
    that case, Express should not crash and instead take the oldest
    (left-most) header value to use as the host.