### PR TITLE
Bump body-parser to remove Node 10 deprecations

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,15 @@ unreleased
 ==========
 
   * Fix JSDoc for `Router` constructor
+  * deps: body-parser@1.18.3
+    - Fix deprecation warnings on Node.js 10+
+    - Fix stack trace for strict json parse error
+    - deps: depd@~1.1.2
+    - deps: http-errors@~1.6.3
+    - deps: iconv-lite@0.4.23
+    - deps: qs@6.5.2
+    - deps: raw-body@2.3.3
+    - deps: type-is@~1.6.16
   * deps: qs@6.5.2
 
 4.16.3 / 2018-03-12

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "accepts": "~1.3.5",
     "array-flatten": "1.1.1",
-    "body-parser": "1.18.2",
+    "body-parser": "1.18.3",
     "content-disposition": "0.5.2",
     "content-type": "~1.0.4",
     "cookie": "0.3.1",


### PR DESCRIPTION
This gets rid of `new Buffer()` deprecation warnings on Node v10 by bumping body-parser to the 1.18.3 version that was recently released by @dougwilson.

Also bumped qs to 6.5.2 to avoid duplicate versions.

See expressjs/body-parser#312 for details.