### PR TITLE
Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ node_js:
   - "7.10"
   - "8.12"
   - "9.11"
+  - "10.12"
 matrix:
   include:
-    - node_js: "10"
-      env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly"
     - node_js: "11"
       env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly"
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
     - nodejs_version: "7.10"
     - nodejs_version: "8.12"
     - nodejs_version: "9.11"
+    - nodejs_version: "10.12"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
This updates the Travis CI and Appveyor build matrix to the latest versions available on both platforms and adds builds against Node 11.x nightlies on Travis.

Closes #3617 because of similar changes for Node v9.