### PR TITLE
add app.listenPromise

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -29,6 +29,7 @@ var flatten = require('array-flatten');
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var setPrototypeOf = require('setprototypeof')
+var promisify = require('util').promisify
 var slice = Array.prototype.slice;
 
 /**
@@ -615,7 +616,14 @@ app.render = function render(name, options, callback) {
 
 app.listen = function listen() {
   var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
+  var hasCb = typeof arguments[Math.min(1, arguments.length-1)] === 'function';
+  // if a callback is given, use it
+  if (hasCb) return server.listen.apply(server, arguments);
+  // else return a Promise
+  return promisify(server.listen).apply(server, arguments)
+    .then(function () {
+      return server
+    });
 };
 
 /**


### PR DESCRIPTION
Proposing this new method

https://github.com/nodejs/node/issues/21482

or maybe we could have a breaking change for express 5, where .listen return a Promise if no callback is given?

I think it's be great, since doing: 
```js
const server = app.listen(process.env.PORT || 3000);
console.log(server.address().port)
```
is unsafe (it can throw since .listen is async, and .address not necessarily available just after)

but I guess you'll want to preserve the API chaining style for .listen

maybe a `app.ready()` returning a Promise rather?
