### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
   [![Linux Build][travis-image]][travis-url]
   [![Windows Build][appveyor-image]][appveyor-url]
   [![Test Coverage][coveralls-image]][coveralls-url]
+  [![SemVer Stability][semver-image]][semver-url]
 
 ```js
 var express = require('express')
@@ -151,3 +152,5 @@ The current lead maintainer is [Douglas Christopher Wilson](https://github.com/d
 [gratipay-url-visionmedia]: https://gratipay.com/visionmedia/
 [gratipay-image-dougwilson]: https://img.shields.io/gratipay/dougwilson.svg
 [gratipay-url-dougwilson]: https://gratipay.com/dougwilson/
+[semver-image]: https://api.dependabot.com/badges/compatibility_score?dependency-name=express&package-manager=npm_and_yarn&version-scheme=semver
+[semver-url]: https://dependabot.com/compatibility-score.html?dependency-name=express&package-manager=npm_and_yarn&version-scheme=semver


### PR DESCRIPTION
Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=express&package-manager=npm_and_yarn&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=express&package-manager=npm_and_yarn&version-scheme=semver)

If you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use Express and checks what percentage of the time specs pass on the upgrade PR.

The score is slightly lower than 100% because some projects have flaky specs, but I'm working on filtering them out from the data, too :octocat:.