### PR TITLE
enable async/await on handlers

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -385,7 +385,7 @@ proto.process_params = function process_params(layer, called, req, res, done) {
   }
 
   // single param callbacks
-  function paramCallback(err) {
+  async function paramCallback(err) {
     var fn = paramCallbacks[paramIndex++];
 
     // store updated value
@@ -401,7 +401,7 @@ proto.process_params = function process_params(layer, called, req, res, done) {
     if (!fn) return param();
 
     try {
-      fn(req, res, paramCallback, paramVal, key.name);
+      await fn(req, res, paramCallback, paramVal, key.name);
     } catch (e) {
       paramCallback(e);
     }

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -59,7 +59,7 @@ function Layer(path, options, fn) {
  * @api private
  */
 
-Layer.prototype.handle_error = function handle_error(error, req, res, next) {
+Layer.prototype.handle_error = async function handle_error(error, req, res, next) {
   var fn = this.handle;
 
   if (fn.length !== 4) {
@@ -68,7 +68,7 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    await fn(error, req, res, next);
   } catch (err) {
     next(err);
   }
@@ -83,7 +83,7 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
  * @api private
  */
 
-Layer.prototype.handle_request = function handle(req, res, next) {
+Layer.prototype.handle_request = async function handle(req, res, next) {
   var fn = this.handle;
 
   if (fn.length > 3) {
@@ -92,7 +92,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    await fn(req, res, next);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
In nodeJs 7.6 async/await was enabled
the newest version is 10.5.0
even aws lambdas now support 8.x.x so i felt comfortable adding `async` and `await` to enable this functionality

This is a simple way to enable full async support rather then using wrappers.

