### PR TITLE
enable async/await on handlers ( old school )

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -401,7 +401,8 @@ proto.process_params = function process_params(layer, called, req, res, done) {
     if (!fn) return param();
 
     try {
-      fn(req, res, paramCallback, paramVal, key.name);
+      var promise = fn(req, res, paramCallback, paramVal, key.name);
+      promise && promise.catch && promise.catch(paramCallback);
     } catch (e) {
       paramCallback(e);
     }

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -68,7 +68,8 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    var promise = fn(error, req, res, next);
+    promise && promise.catch && promise.catch(next);
   } catch (err) {
     next(err);
   }
@@ -92,7 +93,8 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    var promise = fn(req, res, next);
+    promise && promise.catch && promise.catch(next);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
Same as the other pull request to allow async handlers for express.
This one is a simple old school solution in case support for older versions is needed...
