### PR TITLE
Enable async ( non breaking change )

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -401,7 +401,12 @@ proto.process_params = function process_params(layer, called, req, res, done) {
     if (!fn) return param();
 
     try {
-      fn(req, res, paramCallback, paramVal, key.name);
+      var isAsync = typeof fn === 'function' && fn.constructor !== Function;
+      if (isAsync) {
+        fn(req, res, paramCallback, paramVal, key.name).catch(paramCallback)
+      } else {
+        fn(req, res, paramCallback, paramVal, key.name)
+      } 
     } catch (e) {
       paramCallback(e);
     }

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -406,7 +406,7 @@ proto.process_params = function process_params(layer, called, req, res, done) {
         fn(req, res, paramCallback, paramVal, key.name).catch(paramCallback)
       } else {
         fn(req, res, paramCallback, paramVal, key.name)
-      } 
+      }
     } catch (e) {
       paramCallback(e);
     }

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -68,7 +68,12 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    var isAsync = typeof fn === 'function' && fn.constructor !== Function;
+    if (isAsync) {
+      fn(error, req, res, next).catch(next);
+    } else {
+      fn(error, req, res, next);
+    }
   } catch (err) {
     next(err);
   }
@@ -92,7 +97,12 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    var isAsync = typeof fn === 'function' && fn.constructor !== Function;
+    if (isAsync) {
+      fn(req, res, next).catch(next);
+    } else {
+      fn(req, res, next);
+    }
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
I added async function dettection.
It should work on very early version and this one does not care for function response but rather tests the function itself if its `AsyncFunction` or just a Function. Any old version should fallback to the simple function execution while newer versions will default to 'fn().catch(next)` method.
(newer NodeJS use `AsyncFunction` instead of `Function` as constructor for `async function(){}`


also about the proper solution in express 5.0. Do you want me to merge master there since it seem like the router is missing.


