### PR TITLE
add set option 'handler-wrapper' to wrap handlers on execution ( proposition )

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -362,6 +362,9 @@ app.set = function set(setting, val) {
 
   // trigger matched settings
   switch (setting) {
+    case 'handler-wrapper':
+      this._router.setWrapper(val);
+      break;
     case 'etag':
       this.set('etag fn', compileETag(val));
       break;

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -56,7 +56,7 @@ var proto = module.exports = function(options) {
   router.mergeParams = opts.mergeParams;
   router.strict = opts.strict;
   router.stack = [];
-
+  router._wrapperFunction = null;
   return router;
 };
 
@@ -128,6 +128,14 @@ proto.param = function param(name, fn) {
   return this;
 };
 
+proto.setWrapper = function setWrapper(fn) {
+  // ensure we end up with a
+  // middleware function
+  if ('function' !== typeof fn) {
+    throw new Error('invalid wrapper() for set wrapper, got ' + fn);
+  }
+  this._wrapperFunction = fn;
+};
 /**
  * Dispatch a req, res into the router.
  * @private
@@ -161,7 +169,7 @@ proto.handle = function handle(req, res, out) {
 
   // for options requests, respond with a default if nothing else responds
   if (req.method === 'OPTIONS') {
-    done = wrap(done, function(old, err) {
+    done = wrap(done, function (old, err) {
       if (err || options.length === 0) return old(err);
       sendOptionsResponse(res, options, old);
     });
@@ -350,7 +358,7 @@ proto.process_params = function process_params(layer, called, req, res, done) {
       return done(err);
     }
 
-    if (i >= keys.length ) {
+    if (i >= keys.length) {
       return done();
     }
 
@@ -426,6 +434,7 @@ proto.process_params = function process_params(layer, called, req, res, done) {
  */
 
 proto.use = function use(fn) {
+  var self = this;
   var offset = 0;
   var path = '/';
 
@@ -465,7 +474,7 @@ proto.use = function use(fn) {
       sensitive: this.caseSensitive,
       strict: false,
       end: false
-    }, fn);
+    }, fn, self._wrapperFunction);
 
     layer.route = undefined;
 
@@ -489,13 +498,13 @@ proto.use = function use(fn) {
  */
 
 proto.route = function route(path) {
+  var self = this;
   var route = new Route(path);
-
   var layer = new Layer(path, {
     sensitive: this.caseSensitive,
     strict: this.strict,
     end: true
-  }, route.dispatch.bind(route));
+  }, route.dispatch.bind(route), self._wrapperFunction);
 
   layer.route = route;
 
@@ -504,8 +513,8 @@ proto.route = function route(path) {
 };
 
 // create Router#VERB functions
-methods.concat('all').forEach(function(method){
-  proto[method] = function(path){
+methods.concat('all').forEach(function (method) {
+  proto[method] = function (path) {
     var route = this.route(path)
     route[method].apply(route, slice.call(arguments, 1));
     return this;

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -474,7 +474,7 @@ proto.use = function use(fn) {
       sensitive: this.caseSensitive,
       strict: false,
       end: false
-    }, fn, self._wrapperFunction);
+    }, fn);
 
     layer.route = undefined;
 

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -30,9 +30,9 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 module.exports = Layer;
 
-function Layer(path, options, fn) {
+function Layer(path, options, fn, wrapperFunction) {
   if (!(this instanceof Layer)) {
-    return new Layer(path, options, fn);
+    return new Layer(path, options, fn, wrapperFunction);
   }
 
   debug('new %o', path)
@@ -43,7 +43,7 @@ function Layer(path, options, fn) {
   this.params = undefined;
   this.path = undefined;
   this.regexp = pathRegexp(path, this.keys = [], opts);
-
+  this.wrapperFunction = wrapperFunction || null;
   // set fast path flags
   this.regexp.fast_star = path === '*'
   this.regexp.fast_slash = path === '/' && opts.end === false
@@ -61,6 +61,7 @@ function Layer(path, options, fn) {
 
 Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   var fn = this.handle;
+  var wrapperFunction = this.wrapperFunction;
 
   if (fn.length !== 4) {
     // not a standard error handler
@@ -68,7 +69,11 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    if (typeof wrapperFunction === 'function') {
+      wrapperFunction(fn)(error, req, res, next);
+    } else {
+      fn(error, req, res, next);
+    }
   } catch (err) {
     next(err);
   }
@@ -85,6 +90,7 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
 
 Layer.prototype.handle_request = function handle(req, res, next) {
   var fn = this.handle;
+  var wrapperFunction = this.wrapperFunction;
 
   if (fn.length > 3) {
     // not a standard request handler
@@ -92,7 +98,11 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    if (typeof wrapperFunction === 'function') {
+      wrapperFunction(fn)(req, res, next);
+    } else {
+      fn(req, res, next);
+    }
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
Could be used to set `async await` outside of express scope or could be used to send response using handlers result. Also could greatly improve `midleware` diversity and capabilities.

skipping `midleware` since it feels unnecessary. 

What do you think?