### PR TITLE
Add support for throwing in async handlers.

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -67,6 +67,10 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
     return next(error);
   }
 
+  if (fn.constructor.name === 'AsyncFunction') {
+    return fn(error, req, res, next).catch(next)
+  }
+
   try {
     fn(error, req, res, next);
   } catch (err) {
@@ -89,6 +93,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   if (fn.length > 3) {
     // not a standard request handler
     return next();
+  }
+  if (fn.constructor.name === 'AsyncFunction') {
+    return fn(req, res, next).catch(next)
   }
 
   try {

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -10,6 +10,7 @@ var assert = require('assert');
  * @public
  */
 exports.shouldNotHaveHeader = shouldNotHaveHeader;
+exports.asyncFunctionsSupported = asyncFunctionsSupported;
 
 /**
  * Assert that a supertest response does not have a header.
@@ -21,4 +22,18 @@ function shouldNotHaveHeader(header) {
   return function (res) {
     assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header);
   };
+}
+
+/**
+ * Determines whether or not current environment supports async/await
+ *
+ * @returns {boolean}
+ */
+function asyncFunctionsSupported() {
+  try {
+    new Function([],"return async function(){}");
+    return true
+  } catch(e) {
+    return false
+  }
 }


### PR DESCRIPTION
Adds support for throwing in async handlers without an unhandledPromiseRejectionError warning.

Tested on 8.10.x and made so tests still pass on 0.10.x.

closes #3696