### PR TITLE
jsdoc optional param

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -35,7 +35,7 @@ var toString = Object.prototype.toString;
 /**
  * Initialize a new `Router` with the given `options`.
  *
- * @param {Object} options
+ * @param {Object} [options] options
  * @return {Router} which is an callable function
  * @public
  */


### PR DESCRIPTION
This param is optional, so we can use new Router() without options, but in this case WebStorm is scolds