### PR TITLE
Auth test errors in node >8

### DIFF
--- a/examples/auth/pass.js
+++ b/examples/auth/pass.js
@@ -31,7 +31,7 @@ var iterations = 12000;
 
 exports.hash = function (pwd, salt, fn) {
   if (3 == arguments.length) {
-    crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+    crypto.pbkdf2(pwd, salt, iterations, len, 'sha512', function(err, hash){
       fn(err, hash.toString('base64'));
     });
   } else {
@@ -39,7 +39,7 @@ exports.hash = function (pwd, salt, fn) {
     crypto.randomBytes(len, function(err, salt){
       if (err) return fn(err);
       salt = salt.toString('base64');
-      crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+      crypto.pbkdf2(pwd, salt, iterations, len, 'sha512', function(err, hash){
         if (err) return fn(err);
         fn(null, salt, hash.toString('base64'));
       });


### PR DESCRIPTION
The tests on the 5.x branch were failing in node>8 because digest is now required.  This fixes that missing argument.