### PR TITLE
Update body-parser to latest version 1.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "accepts": "~1.3.5",
     "array-flatten": "1.1.1",
-    "body-parser": "1.18.2",
+    "body-parser": "1.18.3",
     "content-disposition": "0.5.2",
     "content-type": "~1.0.4",
     "cookie": "0.3.1",


### PR DESCRIPTION
The implication of this change (other than getting the changes in `body-parser@1.18.3`) is smaller footprint in node_modules for projects which also require `body-parser` from its latest version.
Currently such projects will have 2 copies of `body-parser`.