### PR TITLE
Move settings methods to app.settings and deprecate old versions

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 unreleased
 ========================
 
+* Deprecate `.get(setting)`, `.set()`, `.disable()`, `.enable()`, `.enabled()`, `.disabled()` in favor of new
+`.settings` api
 * Remove `utils-merge` dependency - use spread syntax instead
 * Remove `Object.setPrototypeOf` polyfill
 * cleanup: remove AsyncLocalStorage check from tests

--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -13,8 +13,8 @@ var app = module.exports = express();
 
 // config
 
-app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
+app.settings.set('view engine', 'ejs');
+app.settings.set('views', path.join(__dirname, 'views'));
 
 // middleware
 

--- a/examples/ejs/index.js
+++ b/examples/ejs/index.js
@@ -24,7 +24,7 @@ app.engine('.html', require('ejs').__express);
 
 // Optional since express defaults to CWD/views
 
-app.set('views', path.join(__dirname, 'views'));
+app.settings.set('views', path.join(__dirname, 'views'));
 
 // Path to our public directory
 
@@ -33,7 +33,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 // Without this you would need to
 // supply the extension to res.render()
 // ex: res.render('users.html').
-app.set('view engine', 'html');
+app.settings.set('view engine', 'html');
 
 // Dummy users
 var users = [

--- a/examples/error-pages/index.js
+++ b/examples/error-pages/index.js
@@ -11,17 +11,17 @@ var logger = require('morgan');
 var silent = process.env.NODE_ENV === 'test'
 
 // general config
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'ejs');
+app.settings.set('views', path.join(__dirname, 'views'));
+app.settings.set('view engine', 'ejs');
 
 // our custom "verbose errors" setting
 // which we can use in the templates
 // via settings['verbose errors']
-app.enable('verbose errors');
+app.settings.enable('verbose errors');
 
 // disable them in production
 // use $ NODE_ENV=production node examples/error-pages
-if (app.settings.env === 'production') app.disable('verbose errors')
+if (app.settings.env === 'production') app.settings.disable('verbose errors')
 
 silent || app.use(logger('dev'));
 

--- a/examples/error/index.js
+++ b/examples/error/index.js
@@ -7,7 +7,7 @@
 var express = require('../../');
 var logger = require('morgan');
 var app = module.exports = express();
-var test = app.get('env') === 'test'
+var test = app.settings.get('env') === 'test'
 
 if (!test) app.use(logger('dev'));
 

--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -24,10 +24,10 @@ app.engine('md', function(path, options, fn){
   });
 });
 
-app.set('views', path.join(__dirname, 'views'));
+app.settings.set('views', path.join(__dirname, 'views'));
 
-// make it the default, so we don't need .md
-app.set('view engine', 'md');
+// make it the default so we dont need .md
+app.settings.set('view engine', 'md');
 
 app.get('/', function(req, res){
   res.render('index', { title: 'Markdown Example' });

--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -26,7 +26,7 @@ app.engine('md', function(path, options, fn){
 
 app.settings.set('views', path.join(__dirname, 'views'));
 
-// make it the default so we dont need .md
+// make it the default, so we don't need .md
 app.settings.set('view engine', 'md');
 
 app.get('/', function(req, res){

--- a/examples/mvc/index.js
+++ b/examples/mvc/index.js
@@ -14,10 +14,10 @@ var app = module.exports = express();
 
 // set our default template engine to "ejs"
 // which prevents the need for using file extensions
-app.set('view engine', 'ejs');
+app.settings.set('view engine', 'ejs');
 
 // set views for error and 404 pages
-app.set('views', path.join(__dirname, 'views'));
+app.settings.set('views', path.join(__dirname, 'views'));
 
 // define a custom res.message() method
 // which stores messages in the session

--- a/examples/mvc/lib/boot.js
+++ b/examples/mvc/lib/boot.js
@@ -24,8 +24,8 @@ module.exports = function(parent, options){
     var url;
 
     // allow specifying the view engine
-    if (obj.engine) app.set('view engine', obj.engine);
-    app.set('views', path.join(__dirname, '..', 'controllers', name, 'views'));
+    if (obj.engine) app.settings.set('view engine', obj.engine);
+    app.settings.set('views', path.join(__dirname, '..', 'controllers', name, 'views'));
 
     // generate routes based
     // on the exported methods

--- a/examples/route-separation/index.js
+++ b/examples/route-separation/index.js
@@ -18,8 +18,8 @@ module.exports = app;
 
 // Config
 
-app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
+app.settings.set('view engine', 'ejs');
+app.settings.set('views', path.join(__dirname, 'views'));
 
 /* istanbul ignore next */
 if (!module.parent) {

--- a/examples/view-constructor/github-view.js
+++ b/examples/view-constructor/github-view.js
@@ -24,7 +24,7 @@ function GithubView(name, options){
   this.name = name;
   options = options || {};
   this.engine = options.engines[extname(name)];
-  // "root" is the app.set('views') setting, however
+  // "root" is the app.settings.set('views') setting, however
   // in your own implementation you could ignore this
   this.path = '/' + options.root + '/master/' + name;
 }

--- a/examples/view-constructor/index.js
+++ b/examples/view-constructor/index.js
@@ -24,10 +24,10 @@ app.engine('md', function(str, options, fn){
 });
 
 // pointing to a particular github repo to load files from it
-app.set('views', 'expressjs/express');
+app.settings.set('views', 'expressjs/express');
 
 // register a new view constructor
-app.set('view', GithubView);
+app.settings.set('view', GithubView);
 
 app.get('/', function(req, res){
   // rendering a view relative to the repo.

--- a/examples/view-locals/index.js
+++ b/examples/view-locals/index.js
@@ -9,8 +9,8 @@ var path = require('node:path');
 var User = require('./user');
 var app = express();
 
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'ejs');
+app.settings.set('views', path.join(__dirname, 'views'));
+app.settings.set('view engine', 'ejs');
 
 // filter ferrets only
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -24,6 +24,8 @@ var compileTrust = require('./utils').compileTrust;
 var resolve = require('node:path').resolve;
 var once = require('once')
 var Router = require('router');
+var deprecate = require('depd')('express');
+var StoreSettings = require('./settings');
 
 /**
  * Module variables.
@@ -61,7 +63,21 @@ app.init = function init() {
 
   this.cache = Object.create(null);
   this.engines = Object.create(null);
-  this.settings = Object.create(null);
+  this.settings = new StoreSettings({
+    setters: {
+      'etag': function (val) {
+        this.set('etag fn', compileETag(val))
+      },
+      'query parser': function (val) {
+        this.set('query parser fn', compileQueryParser(val))
+      },
+      'trust proxy': function (val) {
+        this.set('trust proxy fn', compileTrust(val))
+        // trust proxy inherit back-compat
+        this.set(trustProxyDefaultSymbol, false)
+      }
+    }
+  })
 
   this.defaultConfiguration();
 
@@ -91,34 +107,31 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this.enable('x-powered-by');
-  this.set('etag', 'weak');
-  this.set('env', env);
-  this.set('query parser', 'simple')
-  this.set('subdomain offset', 2);
-  this.set('trust proxy', false);
+  this.settings.enable('x-powered-by')
+  this.settings.set('etag', 'weak')
+  this.settings.set('env', env)
+  this.settings.set('query parser', 'simple')
+  this.settings.set('subdomain offset', 2)
+  this.settings.set('trust proxy', false)
 
   // trust proxy inherit back-compat
-  Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
-    configurable: true,
-    value: true
-  });
+  this.settings.set(trustProxyDefaultSymbol, true)
 
   debug('booting in %s mode', env);
 
   this.on('mount', function onmount(parent) {
     // inherit trust proxy
-    if (this.settings[trustProxyDefaultSymbol] === true
-      && typeof parent.settings['trust proxy fn'] === 'function') {
-      delete this.settings['trust proxy'];
-      delete this.settings['trust proxy fn'];
+    if (this.settings.get(trustProxyDefaultSymbol) === true
+      && typeof parent.settings.get('trust proxy fn') === 'function') {
+      this.settings.unset('trust proxy')
+      this.settings.unset('trust proxy fn')
     }
 
     // inherit protos
     Object.setPrototypeOf(this.request, parent.request)
     Object.setPrototypeOf(this.response, parent.response)
     Object.setPrototypeOf(this.engines, parent.engines)
-    Object.setPrototypeOf(this.settings, parent.settings)
+    this.settings.inheritFrom(parent.settings)
   });
 
   // setup locals
@@ -128,15 +141,15 @@ app.defaultConfiguration = function defaultConfiguration() {
   this.mountpath = '/';
 
   // default locals
-  this.locals.settings = this.settings;
+  this.locals.settings = this.settings.settings
 
   // default configuration
-  this.set('view', View);
-  this.set('views', resolve('views'));
-  this.set('jsonp callback name', 'callback');
+  this.settings.set('view', View)
+  this.settings.set('views', resolve('views'))
+  this.settings.set('jsonp callback name', 'callback')
 
   if (env === 'production') {
-    this.enable('view cache');
+    this.settings.enable('view cache')
   }
 };
 
@@ -152,7 +165,7 @@ app.defaultConfiguration = function defaultConfiguration() {
 app.handle = function handle(req, res, callback) {
   // final handler
   var done = callback || finalhandler(req, res, {
-    env: this.get('env'),
+    env: this.settings.get('env'),
     onerror: logerror.bind(this)
   });
 
@@ -182,7 +195,7 @@ app.handle = function handle(req, res, callback) {
  * See Router#use() documentation for details.
  *
  * If the _fn_ parameter is an express app, then it will be
- * mounted at the _route_ specified.
+ * mounted at the _route_ specifiedy
  *
  * @public
  */
@@ -348,39 +361,10 @@ app.param = function param(name, fn) {
  * @public
  */
 
-app.set = function set(setting, val) {
-  if (arguments.length === 1) {
-    // app.get(setting)
-    return this.settings[setting];
-  }
-
-  debug('set "%s" to %o', setting, val);
-
-  // set value
-  this.settings[setting] = val;
-
-  // trigger matched settings
-  switch (setting) {
-    case 'etag':
-      this.set('etag fn', compileETag(val));
-      break;
-    case 'query parser':
-      this.set('query parser fn', compileQueryParser(val));
-      break;
-    case 'trust proxy':
-      this.set('trust proxy fn', compileTrust(val));
-
-      // trust proxy inherit back-compat
-      Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
-        configurable: true,
-        value: false
-      });
-
-      break;
-  }
-
-  return this;
-};
+app.set = deprecate.function(function set(setting, val) {
+  this.settings.set(setting, val)
+  return this
+}, 'app.set: Use app.settings.set instead')
 
 /**
  * Return the app's absolute pathname
@@ -417,9 +401,9 @@ app.path = function path() {
  * @public
  */
 
-app.enabled = function enabled(setting) {
-  return Boolean(this.set(setting));
-};
+app.enabled = deprecate.function(function enabled(setting) {
+  return this.settings.enabled(setting)
+}, 'app.enabled: Use app.settings.endabled instead')
 
 /**
  * Check if `setting` is disabled.
@@ -436,9 +420,9 @@ app.enabled = function enabled(setting) {
  * @public
  */
 
-app.disabled = function disabled(setting) {
-  return !this.set(setting);
-};
+app.disabled = deprecate.function(function disabled(setting) {
+  return this.settings.disabled(setting)
+}, 'app.disabled: Use app.settings.disabled instead')
 
 /**
  * Enable `setting`.
@@ -448,9 +432,10 @@ app.disabled = function disabled(setting) {
  * @public
  */
 
-app.enable = function enable(setting) {
-  return this.set(setting, true);
-};
+app.enable = deprecate.function(function enable(setting) {
+  this.settings.set(setting, true)
+  return this
+}, 'app.enable: Use app.settings.enable instead')
 
 /**
  * Disable `setting`.
@@ -460,9 +445,10 @@ app.enable = function enable(setting) {
  * @public
  */
 
-app.disable = function disable(setting) {
-  return this.set(setting, false);
-};
+app.disable = deprecate.function(function disable(setting) {
+  this.settings.set(setting, false)
+  return this
+}, 'app.disable: Use app.settings.disable instead')
 
 /**
  * Delegate `.VERB(...)` calls to `router.VERB(...)`.
@@ -472,7 +458,7 @@ methods.forEach(function (method) {
   app[method] = function (path) {
     if (method === 'get' && arguments.length === 1) {
       // app.get(setting)
-      return this.set(path);
+      return this.settings.get(path)
     }
 
     var route = this.route(path);
@@ -537,7 +523,7 @@ app.render = function render(name, options, callback) {
 
   // set .cache unless explicitly provided
   if (renderOptions.cache == null) {
-    renderOptions.cache = this.enabled('view cache');
+    renderOptions.cache = this.settings.enabled('view cache')
   }
 
   // primed cache
@@ -547,11 +533,11 @@ app.render = function render(name, options, callback) {
 
   // view
   if (!view) {
-    var View = this.get('view');
+    var View = this.settings.get('view')
 
     view = new View(name, {
-      defaultEngine: this.get('view engine'),
-      root: this.get('views'),
+      defaultEngine: this.settings.get('view engine'),
+      root: this.settings.get('views'),
       engines: engines
     });
 
@@ -614,7 +600,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.settings.get('env') !== 'test') console.error(err.stack || err.toString())
 }
 
 /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -63,21 +63,60 @@ app.init = function init() {
 
   this.cache = Object.create(null);
   this.engines = Object.create(null);
-  this.settings = new StoreSettings({
+
+  // THis whole complicated bit is to maintain backward
+  // compat in v5. In v6 we should be able to remove this
+  // and directly assign `settingsStore` to `settings`
+  const settingsStore = new StoreSettings({
     setters: {
       'etag': function (val) {
-        this.set('etag fn', compileETag(val))
+        this.set('etag fn', compileETag(val));
       },
       'query parser': function (val) {
-        this.set('query parser fn', compileQueryParser(val))
+        this.set('query parser fn', compileQueryParser(val));
       },
       'trust proxy': function (val) {
-        this.set('trust proxy fn', compileTrust(val))
+        this.set('trust proxy fn', compileTrust(val));
         // trust proxy inherit back-compat
-        this.set(trustProxyDefaultSymbol, false)
+        this.set(trustProxyDefaultSymbol, false);
       }
     }
-  })
+  });
+
+  // The prototypical inheritence here is to allow the
+  // new api's to also update the plain object which is
+  // exposed to users so they can do things like
+  // app.locals.settings.foo = 'bar' which while not
+  // documented, was possiable in express historically
+  this.settings = Object.create(settingsStore.settings);
+
+  // This allows for the new api to be exposed while
+  // still supporting apps setting values which are the
+  // same names as the properties/methods of the new api
+  for (const prop of Object.keys(Object.getOwnPropertyDescriptors(Object.getPrototypeOf(settingsStore)))) {
+    if (prop === 'constructor') {
+      continue;
+    }
+    Object.defineProperty(this.settings, prop, {
+      enumerable: false,
+      configurable: false,
+      get: () => {
+        const storeVal = settingsStore.get(prop);
+        if (storeVal) {
+          return storeVal;
+        }
+        const storeFnc = Reflect.get(settingsStore, prop);
+        if (typeof storeFnc !== 'function') {
+          return storeFnc;
+        }
+        return storeFnc.bind(settingsStore);
+      },
+      set: (val) => {
+        deprecate(`Directly assigning a setting named ${prop} is deprecated and will be removed`);
+        return Reflect.set(this.settings, prop, val);
+      }
+    });
+  }
 
   this.defaultConfiguration();
 
@@ -141,7 +180,7 @@ app.defaultConfiguration = function defaultConfiguration() {
   this.mountpath = '/';
 
   // default locals
-  this.locals.settings = this.settings.settings
+  this.locals.settings = this.settings;
 
   // default configuration
   this.settings.set('view', View)

--- a/lib/application.js
+++ b/lib/application.js
@@ -195,7 +195,7 @@ app.handle = function handle(req, res, callback) {
  * See Router#use() documentation for details.
  *
  * If the _fn_ parameter is an express app, then it will be
- * mounted at the _route_ specifiedy
+ * mounted at the _route_ specified.
  *
  * @public
  */

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,52 +1,63 @@
 'use strict'
 
-var Settings = module.exports = function Settings (opts) {
-  opts = opts || {}
-  this.parent = null
-  this.settings = Object.create(null)
-  this._setters = opts.setters || Object.create(null)
-}
+module.exports = class Settings {
+  #parent;
+  settings;
+  #setters;
 
-Settings.prototype.set = function (setting, val) {
-  if (arguments.length === 1) {
-    return this.get(setting)
+  constructor (opts) {
+    this.#parent = null;
+    this.settings = Object.create(null);
+    this.#setters = opts?.setters || Object.create(null);
   }
 
-  this.settings[setting] = val
+  set (setting, val) {
+    if (arguments.length === 1) {
+      return this.get(setting);
+    }
 
-  if (this._setters[setting]) {
-    this._setters[setting].call(this, val)
+    this.settings[setting] = val;
+
+    if (typeof this.#setters[setting] === 'function') {
+      this.#setters[setting].call(this, val);
+    }
+
+    return this;
   }
 
-  return this
-}
+  get (setting) {
+    const val = this.settings[setting];
+    if (typeof val !== 'undefined') {
+      return val;
+    }
+    if (this.#parent) {
+      return this.#parent.get(setting);
+    }
+    return undefined;
+  }
 
-Settings.prototype.get = function (setting) {
-  var val = this.settings[setting]
-  return (typeof val !== 'undefined') ? val : (this.parent) ? this.parent.get(setting) : undefined
-}
+  enable (setting) {
+    return this.set(setting, true);
+  }
 
-Settings.prototype.enable = function (setting) {
-  return this.set(setting, true)
-}
+  disable (setting) {
+    return this.set(setting, false);
+  }
 
-Settings.prototype.disable = function (setting) {
-  return this.set(setting, false)
-}
+  enabled (setting) {
+    return !!this.get(setting);
+  }
 
-Settings.prototype.enabled = function (setting) {
-  return !!this.get(setting)
-}
+  disabled (setting) {
+    return !this.get(setting);
+  }
 
-Settings.prototype.disabled = function (setting) {
-  return !this.get(setting)
-}
+  unset (setting) {
+    this.settings[setting] = undefined;
+    return this;
+  }
 
-Settings.prototype.unset = function (setting) {
-  this.settings[setting] = undefined;
-  return this;
-}
-
-Settings.prototype.inheritFrom = function (parent) {
-  this.parent = parent
+  inheritFrom (parent) {
+    this.#parent = parent;
+  }
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,0 +1,52 @@
+'use strict'
+
+var Settings = module.exports = function Settings (opts) {
+  opts = opts || {}
+  this.parent = null
+  this.settings = Object.create(null)
+  this._setters = opts.setters || Object.create(null)
+}
+
+Settings.prototype.set = function (setting, val) {
+  if (arguments.length === 1) {
+    return this.get(setting)
+  }
+
+  this.settings[setting] = val
+
+  if (this._setters[setting]) {
+    this._setters[setting].call(this, val)
+  }
+
+  return this
+}
+
+Settings.prototype.get = function (setting) {
+  var val = this.settings[setting]
+  return (typeof val !== 'undefined') ? val : (this.parent) ? this.parent.get(setting) : undefined
+}
+
+Settings.prototype.enable = function (setting) {
+  return this.set(setting, true)
+}
+
+Settings.prototype.disable = function (setting) {
+  return this.set(setting, false)
+}
+
+Settings.prototype.enabled = function (setting) {
+  return !!this.get(setting)
+}
+
+Settings.prototype.disabled = function (setting) {
+  return !this.get(setting)
+}
+
+Settings.prototype.unset = function (setting) {
+  this.settings[setting] = undefined;
+  return this;
+}
+
+Settings.prototype.inheritFrom = function (parent) {
+  this.parent = parent
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cookie": "^0.7.1",
     "cookie-signature": "^1.2.1",
     "debug": "^4.4.0",
+    "depd": "^2.0.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -11,16 +11,14 @@ describe('app', function(){
       assert.strictEqual(typeof app.locals, 'object')
       assert.strictEqual(Object.getPrototypeOf(app.locals), null)
     })
+  })
 
-    describe('.settings', function () {
-      it('should contain app settings ', function () {
-        var app = express()
-        app.set('title', 'Express')
-        assert.ok(app.locals.settings)
-        assert.strictEqual(typeof app.locals.settings, 'object')
-        assert.strictEqual(app.locals.settings, app.settings)
-        assert.strictEqual(app.locals.settings.title, 'Express')
-      })
+  describe('.locals.settings', function(){
+    it('should expose app settings', function(){
+      var app = express();
+      app.set('title', 'House of Manny');
+      var obj = app.locals.settings;
+      assert.equal(obj.title, 'House of Manny');
     })
   })
 })

--- a/test/config.js
+++ b/test/config.js
@@ -19,12 +19,19 @@ describe('config', function () {
 
     it('should return the app', function () {
       var app = express();
-      assert.equal(app.settings.set('foo', 'bar'), app.settings);
+      assert.equal(app.set('foo', 'bar'), app);
+    })
+
+    it('should allow chaining setting calls', function () {
+      var app = express();
+      app.settings.set('foo', 'bar').enable('baz');
+      assert.equal(app.settings.get('foo'), 'bar');
+      assert.equal(app.settings.get('baz'), true);
     })
 
     it('should return the app when undefined', function () {
       var app = express();
-      assert.equal(app.settings.set('foo', undefined), app.settings);
+      assert.equal(app.set('foo', undefined), app);
     })
 
     it('should return set value', function () {
@@ -144,9 +151,17 @@ describe('config', function () {
   describe('.enable()', function(){
     it('should set the value to true', function(){
       var app = express();
-      assert.equal(app.settings.enable('tobi'), app.settings);
+      assert.equal(app.enable('tobi'), app);
+      assert.strictEqual(app.get('tobi'), true);
       assert.strictEqual(app.settings.get('tobi'), true);
     })
+
+    it('should set the value to true with settings.enable', function(){
+      var app = express();
+      app.settings.enable('tobi');
+      assert.strictEqual(app.get('tobi'), true);
+      assert.strictEqual(app.settings.get('tobi'), true);
+    });
 
     it('should set prototype values', function () {
       var app = express()
@@ -158,9 +173,17 @@ describe('config', function () {
   describe('.disable()', function(){
     it('should set the value to false', function(){
       var app = express();
-      assert.equal(app.settings.disable('tobi'), app.settings);
+      assert.equal(app.disable('tobi'), app);
+      assert.strictEqual(app.get('tobi'), false);
       assert.strictEqual(app.settings.get('tobi'), false);
     })
+
+    it('should set the value to false with settings.enable', function(){
+      var app = express();
+      app.settings.disable('tobi');
+      assert.strictEqual(app.get('tobi'), false);
+      assert.strictEqual(app.settings.get('tobi'), false);
+    });
 
     it('should set prototype values', function () {
       var app = express()

--- a/test/config.js
+++ b/test/config.js
@@ -7,48 +7,48 @@ describe('config', function () {
   describe('.set()', function () {
     it('should set a value', function () {
       var app = express();
-      app.set('foo', 'bar');
-      assert.equal(app.get('foo'), 'bar');
+      app.settings.set('foo', 'bar');
+      assert.equal(app.settings.get('foo'), 'bar');
     })
 
     it('should set prototype values', function () {
       var app = express()
-      app.set('hasOwnProperty', 42)
-      assert.strictEqual(app.get('hasOwnProperty'), 42)
+      app.settings.set('hasOwnProperty', 42)
+      assert.strictEqual(app.settings.get('hasOwnProperty'), 42)
     })
 
     it('should return the app', function () {
       var app = express();
-      assert.equal(app.set('foo', 'bar'), app);
+      assert.equal(app.settings.set('foo', 'bar'), app.settings);
     })
 
     it('should return the app when undefined', function () {
       var app = express();
-      assert.equal(app.set('foo', undefined), app);
+      assert.equal(app.settings.set('foo', undefined), app.settings);
     })
 
     it('should return set value', function () {
       var app = express()
-      app.set('foo', 'bar')
-      assert.strictEqual(app.set('foo'), 'bar')
+      app.settings.set('foo', 'bar')
+      assert.strictEqual(app.settings.set('foo'), 'bar')
     })
 
     it('should return undefined for prototype values', function () {
       var app = express()
-      assert.strictEqual(app.set('hasOwnProperty'), undefined)
+      assert.strictEqual(app.settings.set('hasOwnProperty'), undefined)
     })
 
     describe('"etag"', function(){
       it('should throw on bad value', function(){
         var app = express();
-        assert.throws(app.set.bind(app, 'etag', 42), /unknown value/);
+        assert.throws(app.settings.set.bind(app.settings, 'etag', 42), /unknown value/);
       })
 
       it('should set "etag fn"', function(){
         var app = express()
         var fn = function(){}
         app.set('etag', fn)
-        assert.equal(app.get('etag fn'), fn)
+        assert.equal(app.settings.get('etag fn'), fn)
       })
     })
 
@@ -56,8 +56,8 @@ describe('config', function () {
       it('should set "trust proxy fn"', function(){
         var app = express()
         var fn = function(){}
-        app.set('trust proxy', fn)
-        assert.equal(app.get('trust proxy fn'), fn)
+        app.settings.set('trust proxy', fn)
+        assert.equal(app.settings.get('trust proxy fn'), fn)
       })
     })
   })
@@ -65,18 +65,18 @@ describe('config', function () {
   describe('.get()', function(){
     it('should return undefined when unset', function(){
       var app = express();
-      assert.strictEqual(app.get('foo'), undefined);
+      assert.strictEqual(app.settings.get('foo'), undefined);
     })
 
     it('should return undefined for prototype values', function () {
       var app = express()
-      assert.strictEqual(app.get('hasOwnProperty'), undefined)
+      assert.strictEqual(app.settings.get('hasOwnProperty'), undefined)
     })
 
     it('should otherwise return the value', function(){
       var app = express();
       app.set('foo', 'bar');
-      assert.equal(app.get('foo'), 'bar');
+      assert.equal(app.settings.get('foo'), 'bar');
     })
 
     describe('when mounted', function(){
@@ -86,7 +86,7 @@ describe('config', function () {
 
         app.set('title', 'Express');
         app.use(blog);
-        assert.equal(blog.get('title'), 'Express');
+        assert.equal(blog.settings.get('title'), 'Express');
       })
 
       it('should given precedence to the child', function(){
@@ -97,7 +97,7 @@ describe('config', function () {
         app.set('title', 'Express');
         blog.set('title', 'Some Blog');
 
-        assert.equal(blog.get('title'), 'Some Blog');
+        assert.equal(blog.settings.get('title'), 'Some Blog');
       })
 
       it('should inherit "trust proxy" setting', function () {
@@ -106,14 +106,14 @@ describe('config', function () {
 
         function fn() { return false }
 
-        app.set('trust proxy', fn);
-        assert.equal(app.get('trust proxy'), fn);
-        assert.equal(app.get('trust proxy fn'), fn);
+        app.settings.set('trust proxy', fn);
+        assert.equal(app.settings.get('trust proxy'), fn);
+        assert.equal(app.settings.get('trust proxy fn'), fn);
 
         app.use(blog);
 
-        assert.equal(blog.get('trust proxy'), fn);
-        assert.equal(blog.get('trust proxy fn'), fn);
+        assert.equal(blog.settings.get('trust proxy'), fn);
+        assert.equal(blog.settings.get('trust proxy fn'), fn);
       })
 
       it('should prefer child "trust proxy" setting', function () {
@@ -124,19 +124,19 @@ describe('config', function () {
         function fn2() { return true }
 
         app.set('trust proxy', fn1);
-        assert.equal(app.get('trust proxy'), fn1);
-        assert.equal(app.get('trust proxy fn'), fn1);
+        assert.equal(app.settings.get('trust proxy'), fn1);
+        assert.equal(app.settings.get('trust proxy fn'), fn1);
 
         blog.set('trust proxy', fn2);
-        assert.equal(blog.get('trust proxy'), fn2);
-        assert.equal(blog.get('trust proxy fn'), fn2);
+        assert.equal(blog.settings.get('trust proxy'), fn2);
+        assert.equal(blog.settings.get('trust proxy fn'), fn2);
 
         app.use(blog);
 
-        assert.equal(app.get('trust proxy'), fn1);
-        assert.equal(app.get('trust proxy fn'), fn1);
-        assert.equal(blog.get('trust proxy'), fn2);
-        assert.equal(blog.get('trust proxy fn'), fn2);
+        assert.equal(app.settings.get('trust proxy'), fn1);
+        assert.equal(app.settings.get('trust proxy fn'), fn1);
+        assert.equal(blog.settings.get('trust proxy'), fn2);
+        assert.equal(blog.settings.get('trust proxy fn'), fn2);
       })
     })
   })
@@ -144,64 +144,64 @@ describe('config', function () {
   describe('.enable()', function(){
     it('should set the value to true', function(){
       var app = express();
-      assert.equal(app.enable('tobi'), app);
-      assert.strictEqual(app.get('tobi'), true);
+      assert.equal(app.settings.enable('tobi'), app.settings);
+      assert.strictEqual(app.settings.get('tobi'), true);
     })
 
     it('should set prototype values', function () {
       var app = express()
       app.enable('hasOwnProperty')
-      assert.strictEqual(app.get('hasOwnProperty'), true)
+      assert.strictEqual(app.settings.get('hasOwnProperty'), true)
     })
   })
 
   describe('.disable()', function(){
     it('should set the value to false', function(){
       var app = express();
-      assert.equal(app.disable('tobi'), app);
-      assert.strictEqual(app.get('tobi'), false);
+      assert.equal(app.settings.disable('tobi'), app.settings);
+      assert.strictEqual(app.settings.get('tobi'), false);
     })
 
     it('should set prototype values', function () {
       var app = express()
-      app.disable('hasOwnProperty')
-      assert.strictEqual(app.get('hasOwnProperty'), false)
+      app.settings.disable('hasOwnProperty')
+      assert.strictEqual(app.settings.get('hasOwnProperty'), false)
     })
   })
 
   describe('.enabled()', function(){
     it('should default to false', function(){
       var app = express();
-      assert.strictEqual(app.enabled('foo'), false);
+      assert.strictEqual(app.settings.enabled('foo'), false);
     })
 
     it('should return true when set', function(){
       var app = express();
-      app.set('foo', 'bar');
-      assert.strictEqual(app.enabled('foo'), true);
+      app.settings.set('foo', 'bar');
+      assert.strictEqual(app.settings.enabled('foo'), true);
     })
 
     it('should default to false for prototype values', function () {
       var app = express()
-      assert.strictEqual(app.enabled('hasOwnProperty'), false)
+      assert.strictEqual(app.settings.enabled('hasOwnProperty'), false)
     })
   })
 
   describe('.disabled()', function(){
     it('should default to true', function(){
       var app = express();
-      assert.strictEqual(app.disabled('foo'), true);
+      assert.strictEqual(app.settings.disabled('foo'), true);
     })
 
     it('should return false when set', function(){
       var app = express();
-      app.set('foo', 'bar');
-      assert.strictEqual(app.disabled('foo'), false);
+      app.settings.set('foo', 'bar');
+      assert.strictEqual(app.settings.disabled('foo'), false);
     })
 
     it('should default to true for prototype values', function () {
       var app = express()
-      assert.strictEqual(app.disabled('hasOwnProperty'), true)
+      assert.strictEqual(app.settings.disabled('hasOwnProperty'), true)
     })
   })
 })

--- a/test/config.js
+++ b/test/config.js
@@ -5,6 +5,12 @@ var express = require('..');
 
 describe('config', function () {
   describe('.set()', function () {
+    it('deprecated - should set a value', function () {
+      var app = express();
+      app.set('foo', 'bar');
+      assert.equal(app.get('foo'), 'bar');
+    })
+
     it('should set a value', function () {
       var app = express();
       app.settings.set('foo', 'bar');
@@ -17,7 +23,7 @@ describe('config', function () {
       assert.strictEqual(app.settings.get('hasOwnProperty'), 42)
     })
 
-    it('should return the app', function () {
+    it('deprecated - should return the app', function () {
       var app = express();
       assert.equal(app.set('foo', 'bar'), app);
     })
@@ -29,7 +35,7 @@ describe('config', function () {
       assert.equal(app.settings.get('baz'), true);
     })
 
-    it('should return the app when undefined', function () {
+    it('deprecated - should return the app when undefined', function () {
       var app = express();
       assert.equal(app.set('foo', undefined), app);
     })
@@ -84,6 +90,12 @@ describe('config', function () {
       var app = express();
       app.set('foo', 'bar');
       assert.equal(app.settings.get('foo'), 'bar');
+    })
+
+    it('deprecated - should get values assigned directly', function(){
+      var app = express();
+      app.settings.foo = 'bar';
+      assert.equal(app.get('foo'), 'bar');
     })
 
     describe('when mounted', function(){


### PR DESCRIPTION
Started as a `5.x` PR, this is the deprecation version for the `4.x` branch.  See: #3218

The only thing I am worried about this this is that the `app.settings` object has changed.  It used to be a plain object, and is now an instance of `Settings`.  I think some purists would call that a breaking change.  The problem is that there is no way to provide the new functionality without changing that object.

If we had a faster major release cadence, we could deprecate in `5.0` (breaking direct `.settings` access) and remove in `6.0`.  But that might be YEARS, and speeding up majors is a different topic, one which I think we should do.  So IMO I think we have two options:

1. Live with this as a breaking change in an undocumented api and release the deprecation warnings on the documented stuff
2. Only do this in `5.0`.

I am perfectly happy with either, but if I had a choice it would be 1 because it preps people who are using it for 5.0 and the churn on this api shouldn't be much and is worth it.