### PR TITLE
append async function error catch

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -68,7 +68,12 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    // catch async function
+    if (fn.constructor.toLocaleString().includes("AsyncFunction")) {
+      fn(req, res, next).catch(next);
+    } else {
+      fn(req, res, next);
+    }
   } catch (err) {
     next(err);
   }

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -67,15 +67,15 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
     return next(error);
   }
 
-  try {
-    // catch async function
-    if (fn.constructor.toLocaleString().includes("AsyncFunction")) {
-      fn(req, res, next).catch(next);
-    } else {
+  // catch async function
+  if (Object.prototype.toString.call(fn) === '[object AsyncFunction]') {
+    fn(req, res, next).catch(next);
+  } else {  
+    try {
       fn(req, res, next);
+    } catch (err) {
+      next(err);
     }
-  } catch (err) {
-    next(err);
   }
 };
 


### PR DESCRIPTION
Solve the problem that asynchronous functions can't intercept errors.