### PR TITLE
Allow to bypass middleware to last layer with next('last')

### DIFF
--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -122,6 +122,12 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
       return done(err)
     }
 
+    // bypass middleware to last layer
+    if (err && err === 'last' && idx < stack.length) {
+      idx = stack.length;
+      return stack[idx - 1].handle_request(req, res, next);
+    }
+
     var layer = stack[idx++];
     if (!layer) {
       return done(err);


### PR DESCRIPTION
It adds a built-in way to skip to the final route of a layers stack (see this closed issue #1662).

Based on my experience, i was thinking it could be interesting to have this simple feature available.

Example :

```
function middleware1 (req, res, next) { next('last'); // will call lastMiddleware }
function middleware2 (req, res, next) { next('last'); // will call lastMiddleware }
function middleware3 (req, res, next) { next('last'); // will call lastMiddleware }
function middleware4 (req, res, next) { next('last'); // will call lastMiddleware }
function lastMiddleware (req, res, next) { next('last'); // will call the next error middleware }

app.get('/my_path', middleware1, middleware2, middleware3, middleware4, lastMiddleware);
```

In case of errors, this can allow to break the middleware cycle and jump to the last middleware of the route directly without the need to put a condition `if (res.locals.err)` in each middleware to jump to the next one, or to call an error-handling middleware with `next(err);` and to manage everything there, as redirection, render, controller call depending of the error, or to use `next('route')` with a route duplication each time... (which are three solutions not always very convenient).

(maybe there is already a way to do that ? I didn't find it yet. See [this question](https://stackoverflow.com/questions/24840545/is-it-possible-to-skip-route-middleware-in-node-express) and [my own question](https://stackoverflow.com/questions/52470387/express-node-right-way-to-send-error-messages-through-middleware-cycle))


Let me know your thoughts about it.