### PR TITLE
Changed count of arguments for custom error handler

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -62,7 +62,7 @@ function Layer(path, options, fn) {
 Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   var fn = this.handle;
 
-  if (fn.length !== 4) {
+  if (fn.length !== 3) {
     // not a standard error handler
     return next(error);
   }


### PR DESCRIPTION
In my case, if route throwing error, I try to catch it via my custom error handler middleware.

```js
router.get((req, res, next) => {
  try {
    // api logic...
    // throwing simple error for example
    throw new Error('Unhandled rejection')
  } catch (err) {
    next(err);
  }
});

// middleware is not calling, but if I pass 4 arguments, it will work
router.use((error, req, res) => {
  res.status(500).json({ error: 'Unknown error' });
});
```

Problem in [`Layer.prototype.handle_error`](https://github.com/expressjs/express/blob/3ed5090ca91f6a387e66370d57ead94d886275e1/lib/router/layer.js#L62) because [it needs four arguments](https://github.com/expressjs/express/blob/3ed5090ca91f6a387e66370d57ead94d886275e1/lib/router/layer.js#L65) for detect custom error handler middleware.

So, why I must pass four arguments if I'm not using `next` function in middleware?


