### PR TITLE
Pass file reference back when using res.sendFile

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -435,6 +435,8 @@ res.sendFile = function sendFile(path, options, callback) {
       next(err);
     }
   });
+  //return file handle to access send
+  return file;
 };
 
 /**


### PR DESCRIPTION
This will allow access to the send library can be obtained.