### PR TITLE
Update cookie-signature package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "content-disposition": "0.5.2",
     "content-type": "~1.0.4",
     "cookie": "0.3.1",
-    "cookie-signature": "1.0.6",
+    "cookie-signature": "1.1.0",
     "debug": "2.6.9",
     "depd": "~1.1.2",
     "encodeurl": "~1.0.2",


### PR DESCRIPTION
A security bug was detected by the Shieldfy in the "cookie-signature" package.

Infected version: 1.0.6
description:-
Affected versions of `cookie-signature` are vulnerable to timing attacks as a result of using a fail-early comparison instead of a constant-time comparison. Timing attacks remove the exponential increase in entropy gained from increased secret length, by providing per-character feedback on the correctness of a guess via miniscule timing differences. Under favorable network conditions, an attacker can exploit this to guess the secret in no more than `charset*length` guesses, instead of `charset^length` guesses required were the timing attack not present.  

detected by Shieldfy Team 
shieldfy.io