### PR TITLE
allow to send custom errors

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -268,6 +268,43 @@ res.json = function json(obj) {
 };
 
 /**
+ * Send Error as JSON response.
+ *
+ * Examples:
+ *
+ *     res.jsonError(null);
+ *     res.jsonError({ status: 403, user: 'tj', message: `You're not authrorized to view this resource` });
+ *     res.jsonError(new CustomErrorWithOverridenToJson({ status: 403, user: 'tj', message: `You're not authrorized to view this resource` }));
+ *
+ * @param {string|number|boolean|object} obj
+ * @public
+ */
+
+res.jsonError = function json(obj) {
+  var status = obj && (obj.status || obj.statusCode) || 500;
+
+  if (typeof status !== 'number' || http.STATUS_CODES[status] === undefined) {
+    throw new Error('The http status that you passed is not valid');
+  }
+
+  this.statusCode = status;
+
+  // settings
+  var app = this.app;
+  var escape = app.get('json escape')
+  var replacer = app.get('json replacer');
+  var spaces = app.get('json spaces');
+  var body = stringify(obj, replacer, spaces, escape)
+
+  // content-type
+  if (!this.get('Content-Type')) {
+    this.set('Content-Type', 'application/json');
+  }
+
+  return this.send(body);
+};
+
+/**
  * Send JSON response with JSONP callback support.
  *
  * Examples:

--- a/test/res.jsonError.js
+++ b/test/res.jsonError.js
@@ -1,0 +1,41 @@
+var express = require('../')
+  , request = require('supertest');
+
+describe('res', function(){
+  describe('.jsonError(Object)', function(){
+    it('should sendError as application/json', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonError({ name: 'tobi' });
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'application/json; charset=utf-8')
+      .expect(500, '{"name":"tobi"}', done)
+    })
+  })
+
+  describe('.jsonError(Error)', function(){
+    it('should allow to jsonError a custom Error instance', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonError(new ApiError(403, 'foo'));
+      });
+
+      request(app)
+      .get('/')
+      .expect(403, '{"text":"foo"}', done)
+    })
+  })
+})
+
+function ApiError(status, message) {
+  this.status = status
+  this.message = message
+  Error.call(this, message)
+}
+ApiError.prototype = Object.create(Error.prototype);
+ApiError.prototype.toJSON = function() { return { text: this.message } }


### PR DESCRIPTION
This allows to send errors in a more practical way, coupling status and message together

```js
// utils
class ApiError extends Error {
    constructor(status = 500, message = 'Something went wrong') {
        super(message);
        this.status = status;
    }
    toJSON() {
        return { text: this.message };
    }
}
const error = {
    notFound: (s = 'resource') => new ApiError(404, `${s} not found`),
    missingParams: (s = '') => new ApiError(400, `Missing parameters${s ? ': ' + s : ''}`),
    forbidden: () => new ApiError(403, 'Access forbidden'),
};

// routers
app.get('/foo', (req, res) => {
  if (typeof req.body.data !== 'object') {
    return res.send(error.missingParams('data'));
  }
  // ...
})
```
Of course it's possible to use `next(error.missingParams('data'))` and handle the logic in the final error handler middleware, but I think this little addition is helpful, for more complex cases than https://expressjs.com/en/api.html#res.sendStatus

This PR is backward compatible

~~There's just an issue with eslint which can't parse `class`, is it ok to update eslint? the version used here is very old~~