### PR TITLE
correction to override set header values in jsonp responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -303,22 +303,50 @@ res.jsonp = function jsonp(obj) {
   var body = stringify(val, replacer, spaces, escape)
   var callback = this.req.query[app.get('jsonp callback name')];
 
-  // content-type
-  if (!this.get('Content-Type')) {
-    this.set('X-Content-Type-Options', 'nosniff');
-    this.set('Content-Type', 'application/json');
-  }
-
   // fixup callback
   if (Array.isArray(callback)) {
+    /*
+     * FIXME: This use the "first" behaviour is bad practice.
+     * Instead Exception handling to identify and provide an appropriate Error
+     * response to the request is a much better solution.
+     * This should be standard procedure for the next major release version
+     * IE v5.x
+     */
     callback = callback[0];
   }
 
+  /*
+   * Checking typeof string is problematic as Object String wrappers fail in
+   * this senario. IE typeof new String('hello'); // 'object'
+   * Instead check that when coarsing the value to a string it is a "valid"
+   * javascript identifier.
+   */
   // jsonp
-  if (typeof callback === 'string' && callback.length !== 0) {
-    this.set('X-Content-Type-Options', 'nosniff');
-    this.set('Content-Type', 'text/javascript');
+  if (callback && /^[a-z_$]/i.test(callback)) {
+    /*
+     * DO NOT EVER overwrite any previously set header.
+     *
+     * TODO: The text/javascript was an experimantal only mime type that was
+     * obsolete in 2006 by RFC 4329 and replaced with the current standard
+     * application/javascript and application/ecmascript.
+     * These standards should be the default for the next major release version
+     * IE v5.x
+     *
+     * SEE https://tools.ietf.org/html/rfc4329
+     */
+    if (!this.get('Content-Type')) {
+      this.set('X-Content-Type-Options', 'nosniff');
+      this.set('Content-Type', 'text/javascript');
+    }
 
+    /*
+     * FIXME: This sanitization behaviour is bad practice.
+     * Instead Exception handling to identify and provide an appropriate Error
+     * response to the request is a much better solution. This should be
+     * standard procedure for the next major release version IE v5.x
+     *
+     * SEE https://mathiasbynens.be/notes/javascript-identifiers-es6
+     */
     // restrict callback charset
     callback = callback.replace(/[^\[\]\w$.]/g, '');
 
@@ -330,6 +358,17 @@ res.jsonp = function jsonp(obj) {
     // the /**/ is a specific security mitigation for "Rosetta Flash JSONP abuse"
     // the typeof check is just to reduce client error noise
     body = '/**/ typeof ' + callback + ' === \'function\' && ' + callback + '(' + body + ');';
+  }
+
+  /*
+   * TODO: This is left for backward compatability, however the senario when
+   * the REQUIRED callback parameter is not valid should be an error condition
+   * and not return a successful response.
+   */
+  // content-type
+  if (!this.get('Content-Type')) {
+    this.set('X-Content-Type-Options', 'nosniff');
+    this.set('Content-Type', 'application/json');
   }
 
   return this.send(body);

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -141,18 +141,18 @@ describe('res', function(){
       .expect(200, '{"hello":"world"}', done);
     })
 
-    it('should override previous Content-Types with callback', function(done){
+    it('should not override previous Content-Types with callback', function(done){
       var app = express();
 
       app.get('/', function(req, res){
-        res.type('application/vnd.example+json');
+        res.type('application/javascript');
         res.jsonp({ hello: 'world' });
       });
 
       request(app)
       .get('/?callback=cb')
-      .expect('Content-Type', 'text/javascript; charset=utf-8')
-      .expect('X-Content-Type-Options', 'nosniff')
+      .expect('Content-Type', 'application/javascript; charset=utf-8')
+      .expect(utils.shouldNotHaveHeader('X-Content-Type-Options'))
       .expect(200, /cb\(\{"hello":"world"\}\);$/, done);
     })
 


### PR DESCRIPTION
PR to address the opinionated `Content-Type` headers set by `res.jsonp` mentioned in Issue [#3892](https://github.com/expressjs/express/issues/3892)

----
Copied from #3892

As the tag/value of express is 

> Fast, unopinionated, minimalist web framework for node.

It appears a few requests have been made in the past to change the `Content-Type` header for jsonp responses.

- [#3028](https://github.com/expressjs/express/issues/3028) quickly dismissed and ignored.

- [#2094](https://github.com/expressjs/express/pull/2094) bad resolution that does not apply to jsonp responses.

I would suggest that the next major version 5.x should default to the correct [IANA mime/type](https://www.iana.org/assignments/media-types/media-types.xhtml) of `application/javascript` or `application/ecmascript`

The goal here is to make the framework unopinionated and allow the user/developer to set the appropriate headers for the response. However, the current implementation of `res.jsonp` overwrites the `Content-Type` header to `text/javascript`.

The proposal for the current version 4.x of express should be to modify this behavior so that it can be defined and set on the response by the developer while maintaining the current behavior for backward compatibility.

This is especially useful when the request is specifically asking for `application/javascript` and not `text/javascript` via the `Accept` header which could and rightfully should cause confusion and errors with other frameworks, modules, libraries, developers, browsers, etc. that check they received the document in the format they requested.

This should be used in conjunction with the `res.format` and/or `res.accepts` to perform content negotiation that can be understood by both the sender and the receiver.

```javascript
const jsonp = () => {
  res.status(code).jsonp(data);
};

res.format({
  'application/javascript': jsonp,
  'application/ecmascript': jsonp,
  'text/javascript': jsonp,
  'text/ecmascript': jsonp,
});
```