### PR TITLE
Install node on different OS is now conditional

### DIFF
--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -85,7 +85,7 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
     displayName: "[Windows] Install Node $(NODE_VERSION)"
-- ${{ if or(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
+- ${{ if and(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
   - script: |
       echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.
       exit 1

--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -1,5 +1,6 @@
 # Template file to install node using NVM on linux and manual install on windows
 steps:
+- ${{ if eq(parameters.OS, 'unix')  }}:
   - script: |
       curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh -o install.sh
       bash install.sh
@@ -15,8 +16,7 @@ steps:
       # make the new set path to be available in subsequent steps
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: " [Unix] Install Node $(NODE_VERSION)"
-    condition: eq(variables['AGENT.OS'], 'Linux')
-
+- ${{ if eq(parameters.OS, 'windows')  }}:
   - powershell: |
       $nodeVersion = "$(NODE_VERSION)"
       if($nodeVersion.ToLower().EndsWith(".x")) {
@@ -85,4 +85,8 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
     displayName: "[Windows] Install Node $(NODE_VERSION)"
-    condition: eq(variables['AGENT.OS'], 'Windows_NT')
+- ${{ if or(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
+  - script: |
+      echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.
+      exit 1
+    displayName: Invalid operating system

--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -1,0 +1,88 @@
+# Template file to install node using NVM on linux and manual install on windows
+steps:
+  - script: |
+      curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh -o install.sh
+      bash install.sh
+      export NVM_DIR="$HOME/.nvm"
+      
+      # crude version selector since nvm doesn't support it
+      nodeVersion=`echo ${{ parameters.NODE_VERSION }} | sed -e 's/\.x$//g'`
+
+      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" 
+      nvm install "$nodeVersion" || (echo "npm install failed"; exit 1)
+      nvm use "$nodeVersion"
+
+      # make the new set path to be available in subsequent steps
+      echo "##vso[task.setvariable variable=PATH;]$PATH"
+    displayName: " [Unix] Install Node $(NODE_VERSION)"
+    condition: eq(variables['AGENT.OS'], 'Linux')
+
+  - powershell: |
+      $nodeVersion = "$(NODE_VERSION)"
+      if($nodeVersion.ToLower().EndsWith(".x")) {
+        $nodeVersion = $nodeVersion.Substring(0, $nodeVersion.Length -1)
+      }
+      $targetDir = "c:\myiojs"
+      $iojsValues = '1.8','2.5','3.3'
+      if ("$nodeVersion" -In $iojsValues)
+      {
+        $distJsonUrl = "https://iojs.org/dist/index.json"
+        $baseName = "iojs"
+        $baseURL = "https://iojs.org/dist/"
+        $folderName = "iojs"
+        $isIOJS = $true
+      } else {
+        $distJsonUrl = "https://nodejs.org/dist/index.json"
+        $baseName = "node"
+        $baseURL = "https://nodejs.org/dist"
+        $folderName = "nodejs"
+      }
+
+      # Get Latest Version
+      $versionsList = Invoke-WebRequest -Uri $distJsonUrl
+      $versionsListObject = ConvertFrom-Json -InputObject $versionsList
+
+      $matchValues = $versionsListObject | Where-Object {$_.version -match "v$nodeVersion"}
+      $ver = $matchValues[0].version
+
+      Write-Output "Using version $ver"
+
+      if ("$ver".StartsWith("v0.10`.") -or "$ver".StartsWith("v0.12`."))
+      {
+        $msi = "$baseName-$ver-x86.msi"
+      }
+      else
+      {
+        $msi = "$baseName-$ver-x64.msi"
+      }
+
+      # Download MSI
+      $file = Join-Path "$(agent.tempDirectory)" "$msi"
+
+      $nodeUrl = "$baseURL/$ver/$msi"
+
+      Write-Output "Downloading $nodeUrl to $file"
+
+      Invoke-WebRequest -Uri $nodeUrl -OutFile $file
+      
+      # extract files from MSI
+      $MSIArguments = @("/a", "$file", "/qn", "TARGETDIR=$targetDir")
+      Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -NoNewWindow
+
+      $nodejsDir = Join-Path "$targetDir" "$folderName"
+      $newPath = "$nodejsDir;$env:Path"
+      $installPath = $nodejsDir
+
+      # copy the file from iojs.exe to node.exe since everybody expects node to exist
+      if($isIOJS) {
+        $oldexe = Join-Path "$nodejsDir" "iojs.exe"
+        $newexe = Join-Path "$nodejsDir" "node.exe"
+        copy "$oldexe" "$newexe"
+      }
+
+      Write-Host "##vso[task.setvariable variable=PATH;]$newPath";
+      Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_CACHE;]$installPath")
+      Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
+      
+    displayName: "[Windows] Install Node $(NODE_VERSION)"
+    condition: eq(variables['AGENT.OS'], 'Windows_NT')

--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -15,7 +15,7 @@ steps:
 
       # make the new set path to be available in subsequent steps
       echo "##vso[task.setvariable variable=PATH;]$PATH"
-    displayName: " [Unix] Install Node $(NODE_VERSION)"
+    displayName: "Install Node $(NODE_VERSION)"
 - ${{ if eq(parameters.OS, 'windows')  }}:
   - powershell: |
       $nodeVersion = "$(NODE_VERSION)"
@@ -84,7 +84,7 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_CACHE;]$installPath")
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
-    displayName: "[Windows] Install Node $(NODE_VERSION)"
+    displayName: "Install Node $(NODE_VERSION)"
 - ${{ if and(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
   - script: |
       echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -1,0 +1,64 @@
+steps:
+- powershell: |
+    $nodeVersion = "$(NODE_VERSION)"
+    $nodeMajorVersion = $nodeVersion.split(".")[0]
+    Write-Output ("##vso[task.setvariable variable=NodeMajorVersion;]$nodeMajorVersion")
+  displayName: "Get Major Version Number of NodeJS Using PowerShell"
+
+- template: azure-pipelines-install-node.yml
+  parameters:
+    NODE_VERSION : $(NODE_VERSION)
+
+#Start The Before Install Tasks 
+- script: |
+    node --version
+    npm config set shrinkwrap false
+  displayName: 'Skip updating shrinkwrap / lock'
+
+- script: |
+    npm rm --silent --save-dev connect-redis
+  displayName: 'Remove all non-test dependencies'
+
+- script: |
+    npm install --silent --save-dev mocha@3.5.3
+  displayName: 'Setup Node.js version-specific dependencies: mocha for testing: use 3.x for Node.js < 6'
+  condition: lt(variables['NodeMajorVersion'], 6)
+
+- script: |
+    npm install --silent --save-dev supertest@2.0.0
+  displayName: 'Setup Node.js version-specific dependencies: supertest for http calls: use 2.0.0 for Node.js < 4'
+  condition: lt(variables['NodeMajorVersion'], 4)
+  
+- powershell: |
+    # Prune & rebuild node_modules
+    if (Test-Path -Path node_modules) {
+        npm prune
+        npm rebuild
+      }
+  displayName: 'Update Node.js modules'
+
+#Finish With Before Install Tasks. Time to install dependencies
+- script: |
+    npm install
+  displayName: 'npm install'
+  
+#Testing
+- script: |
+    npm run test-ci
+  displayName: 'Run test script'
+
+- script: |
+    npm run lint
+  displayName: 'Run linting'
+
+- template: azure-pipelines-install-node.yml
+  parameters:
+    NODE_VERSION : 9.x
+
+- script: |
+    npm install --save-dev coveralls@2.10.0
+    node_modules/.bin/coveralls < ./coverage/lcov.info
+  displayName: 'Upload coverage to coveralls'
+  env:
+    COVERALLS_REPO_TOKEN: $(coveralls.key.mickey)
+    COVERALLS_SERVICE_NAME: 'AzureDevOps'

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -60,5 +60,5 @@ steps:
     node_modules/.bin/coveralls < ./coverage/lcov.info
   displayName: 'Upload coverage to coveralls'
   env:
-    COVERALLS_REPO_TOKEN: $(coveralls.key.mickey)
+    COVERALLS_REPO_TOKEN: $(coveralls.key.express)
     COVERALLS_SERVICE_NAME: 'AzureDevOps'

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -8,6 +8,8 @@ steps:
 - template: azure-pipelines-install-node.yml
   parameters:
     NODE_VERSION : $(NODE_VERSION)
+    OS: ${{ parameters.OS }}
+
 
 #Start The Before Install Tasks 
 - script: |
@@ -54,6 +56,7 @@ steps:
 - template: azure-pipelines-install-node.yml
   parameters:
     NODE_VERSION : 9.x
+    OS: ${{ parameters.OS }}
 
 - script: |
     npm install --save-dev coveralls@2.10.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ jobs:
   - template: "azure-pipelines-steps.yml"
     parameters:
       NODE_VERSION: $(NODE_VERSION)
+      OS: unix
 
 - job: Windows 
   strategy:
@@ -70,3 +71,4 @@ jobs:
   - template: "azure-pipelines-steps.yml"
     parameters:
       NODE_VERSION: $(NODE_VERSION)
+      OS: windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,72 @@
+jobs:
+- job: Linux 
+  strategy:
+    matrix:
+      Node.js 0.10:
+        NODE_VERSION: '0.10'
+      Node.js 0.12:
+        NODE_VERSION: '0.12'
+      Node.js 1.8:
+        NODE_VERSION: '1.8'
+      Node.js 2.5:
+        NODE_VERSION: '2.5'
+      Node.js 3.3:
+        NODE_VERSION: '3.3'
+      Node.js 4.9:
+        NODE_VERSION: '4.9'
+      Node.js 5.12:
+        NODE_VERSION: '5.12'
+      Node.js 6.14:
+        NODE_VERSION: '6.14'
+      Node.js 7.10:
+        NODE_VERSION: '7.10'
+      Node.js 8.12:
+        NODE_VERSION: '8.12'
+      Node.js 9:
+        NODE_VERSION: '9'
+      Node.js 10:
+        NODE_VERSION: '10'
+  continueOnError: false
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - template: "azure-pipelines-steps.yml"
+    parameters:
+      NODE_VERSION: $(NODE_VERSION)
+
+- job: Windows 
+  strategy:
+    matrix:
+      Node.js 0.10:
+        NODE_VERSION: '0.10'
+      Node.js 0.12:
+        NODE_VERSION: '0.12'
+      Node.js 1.8:
+        NODE_VERSION: '1.8'
+      Node.js 2.5:
+        NODE_VERSION: '2.5'
+      Node.js 3.3:
+        NODE_VERSION: '3.3'
+      Node.js 4.9:
+        NODE_VERSION: '4.9'
+      Node.js 5.12:
+        NODE_VERSION: '5.12'
+      Node.js 6.14:
+        NODE_VERSION: '6.14'
+      Node.js 7.10:
+        NODE_VERSION: '7.10'
+      Node.js 8.12:
+        NODE_VERSION: '8.12'
+      Node.js 9:
+        NODE_VERSION: '9'
+      Node.js 10:
+        NODE_VERSION: '10'
+  continueOnError: false
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  steps:
+  - template: "azure-pipelines-steps.yml"
+    parameters:
+      NODE_VERSION: $(NODE_VERSION)


### PR DESCRIPTION
The step only runs on the right os, so we don't have always have to steps (one executed other skipped) one for each OS.

the logs are now cleaner (at the expense of a parameter)