### PR TITLE
Fix issue #2832.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -78,7 +78,7 @@ function View(name, options) {
     debug('require "%s"', mod)
 
     // default engine export
-    var fn = require(mod).__express
+    var fn = variableRequire(mod).__express
 
     if (typeof fn !== 'function') {
       throw new Error('Module "' + mod + '" does not provide a view engine.')
@@ -179,4 +179,16 @@ function tryStat(path) {
   } catch (e) {
     return undefined;
   }
+}
+/**
+ * Return the expected module.
+ *
+ * @param {string} variablePath
+ * @return {Object}
+ * @private
+ */
+
+function variableRequire(variablePath) {
+  var r = typeof __webpack_require__ !== 'undefined' ? __webpack_require__ : eval('require');
+  r(variablePath);
 }


### PR DESCRIPTION
While require a module like `const x = require(variable);`, Webpack will
print this warning `Critical dependency: the request of a dependency is
an expression`.

Based on webpack/webpack#196 (comment).