### PR TITLE
router.param(): Fix an issue that only one name can be provided

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -124,7 +124,14 @@ proto.param = function param(name, fn) {
     throw new Error('invalid param() call for ' + name + ', got ' + fn);
   }
 
-  (this.params[name] = this.params[name] || []).push(fn);
+  name = (typeof name === 'string') ? [name] : name;
+  var nameLen = name.length;
+
+  for (var i = 0; i < nameLen; i++) {
+    var element = name[i];
+    (this.params[element] = this.params[element] || []).push(fn);
+  }
+
   return this;
 };
 


### PR DESCRIPTION
I found an issue that when I use `router.param(['name1', 'name2'], middleware);`, it doesn't work.