### PR TITLE
resolve mime.lookup is not a function error

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -30,7 +30,7 @@ var setCharset = require('./utils').setCharset;
 var cookie = require('cookie');
 var send = require('send');
 var extname = path.extname;
-var mime = send.mime;
+var mime = require('mime-types');
 var resolve = path.resolve;
 var vary = require('vary');
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fresh": "0.5.2",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",
+    "mime-types": "^2.1.24",
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.3",
     "path-to-regexp": "0.1.7",


### PR DESCRIPTION
Dependency hell? Getting an error where mime is calling `.lookup` but the version of `mime` requires `getType`. Switching to `mime-types` appears to be a drop-in replacement. Though, it may be possible to simply upgrade all references from `.lookup` to `.getType` 

Installed via `yarn add express --flat` though I don't think that matters. Git blame for usage of `send.mime` is from 2015.  Since 2017 the 'fix' for this is either to rollback to pre-version 2 for `mime` or, potentially, use `mime-types` As in ticket https://github.com/lorenwest/monitor-dashboard/issues/41 


1. https://github.com/jshttp/mime-types
2. https://github.com/broofa/node-mime#readme
