### PR TITLE
Add DT typing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "api"
   ],
   "dependencies": {
+    "@types/express": "~4.16.1",
     "accepts": "~1.3.7",
     "array-flatten": "1.1.1",
     "body-parser": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "api"
   ],
   "dependencies": {
-    "@types/express": "~4.16.1",
+    "@types/express": "^4.16.1",
     "accepts": "~1.3.7",
     "array-flatten": "1.1.1",
     "body-parser": "1.19.0",


### PR DESCRIPTION
Typing for Express should be granted by the DefinitelyTyped package, if not locally maintained.