### PR TITLE
deps: setprototypeof@1.2.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -27,6 +27,7 @@ unreleased
     - deps: http-errors@1.8.1
     - deps: ms@2.1.3
     - pref: ignore empty http tokens
+  * deps: setprototypeof@1.2.0
 
 4.17.1 / 2019-05-25
 ===================

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "safe-buffer": "5.2.1",
     "send": "0.17.2",
     "serve-static": "1.14.1",
-    "setprototypeof": "1.1.1",
+    "setprototypeof": "1.2.0",
     "statuses": "~1.5.0",
     "type-is": "~1.6.18",
     "utils-merge": "1.0.1",


### PR DESCRIPTION
Update setprototypeof.  No impact here, but includes a fix for a possible prototype pollution in the fallback.  Can be ported to `5.x` as well.