### PR TITLE
Update path-to-regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "methods": "~1.1.2",
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "3.1.0",
     "proxy-addr": "~2.0.5",
     "qs": "6.7.0",
     "range-parser": "~1.2.1",


### PR DESCRIPTION
0.1.7 can not parse my expression: `/foo/bar-baz-*/(v*)?/`