### PR TITLE
add keyword 'http' to increase visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "framework",
     "sinatra",
     "web",
+    "http",
     "rest",
     "restful",
     "router",


### PR DESCRIPTION
Reason:
if you search for http framework, express is not listed.