### PR TITLE
docs: request for triager role for gireeshpunathil

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -58,8 +58,7 @@ compromise among committers be the default resolution mechanism.
 
 ### List of Triagers
 
-* [gireeshpunathil](https://github.com/gireeshpunathil) -
-**Gireesh Punathil** &lt;gpunathi@in.ibm.com&gt; (he/him)
+* [gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil** &lt;gpunathi@in.ibm.com&gt; (he/him)
 
 
 # Becoming a Committer

--- a/Contributing.md
+++ b/Contributing.md
@@ -56,6 +56,12 @@ discuss pending contributions in order to find a resolution. It is expected that
 small minority of issues be brought to the TC for resolution and that discussion and
 compromise among committers be the default resolution mechanism.
 
+### List of Triagers
+
+* [gireeshpunathil](https://github.com/gireeshpunathil) -
+**Gireesh Punathil** &lt;gpunathi@in.ibm.com&gt; (he/him)
+
+
 # Becoming a Committer
 
 All contributors who land a non-trivial contribution should be on-boarded in a timely manner,


### PR DESCRIPTION
I have read and understood the project's Contributing guide.
I also have read and understood the process and best practices around Express triaging.

I request for a triager role for the below orgs:

 - jshttp
 - pillarjs
 - express