### PR TITLE
docs: add Jon Church as triager

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -59,6 +59,7 @@ compromise among committers be the default resolution mechanism.
 ### List of Triagers
 
 * [gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil** &lt;gpunathi@in.ibm.com&gt; (he/him)
+* [jonchurch](https://github.com/jonchurch) - **Jon Church** &lt;jon@osiolabs.com&gt; (he/him)
 
 
 # Becoming a Committer


### PR DESCRIPTION
I have read and understood the project's Contributing guide.
I also have read and understood the process and best practices around Express triaging.

I request for a triager role for the below orgs:

jshttp
pillarjs
express