### PR TITLE
docs: request for triager role for Helio Frota

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -59,7 +59,7 @@ compromise among committers be the default resolution mechanism.
 ### List of Triagers
 
 * [gireeshpunathil](https://github.com/gireeshpunathil) - **Gireesh Punathil** &lt;gpunathi@in.ibm.com&gt; (he/him)
-
+* [helio-frota](https://github.com/helio-frota) - **Helio Frota** &lt;hesilva@redhat.com&gt; (he/him)
 
 # Becoming a Committer
 


### PR DESCRIPTION
I have read and understood the project's Contributing guide.
I also have read and understood the process and best practices around Express triaging.
I will help in any way and no particular preferred area of interest yet.

I request for a triager role for the below orgs:

jshttp
pillarjs
express
