### PR TITLE
refactor: shallow arr clone using fast path

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -259,10 +259,7 @@ req.is = function is(types) {
 
   // support flattened arguments
   if (!Array.isArray(types)) {
-    arr = new Array(arguments.length);
-    for (var i = 0; i < arr.length; i++) {
-      arr[i] = arguments[i];
-    }
+    arr = Array.from(arguments);
   }
 
   return typeis(this, arr);


### PR DESCRIPTION
Hi, 

This PR addresses the issue:
https://github.com/expressjs/express/issues/4141

I've opted for using the `Array.from` rather than the Spread operator for reasons such as:
1. https://github.com/eslint/eslint/issues/10307#issuecomment-386453017
2. Both have similar performance

(poc) benchmark:
http://jsben.ch/YCwrg

References:
[Speeding up spread elements](https://v8.dev/blog/spread-elements)
Ps. Notice how the current implementation is exactly like the one referenced on the blog post. [Here](https://v8.dev/blog/spread-elements#why-is-(or-were!)-spread-elements-slow%3F)