### PR TITLE
docs: request for triager role for g-rath

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -71,6 +71,7 @@ compromise among committers be the default resolution mechanism.
 * [jonchurch](https://github.com/jonchurch) - **Jon Church** &lt;jon@osiolabs.com&gt; (he/him)
 * [mirawlings](https://github.com/mirawlings) - **Michael Rawlings** &lt;mlrawlings@gmail.com&gt; (he/him)
 * [helio-frota](https://github.com/helio-frota) - **Helio Frota** &lt;hesilva@redhat.com&gt; (he/him)
+* [g-rath](https://github.com/g-rath) - **Gareth Jones** &lt;jones258@gmail.com&gt; (he/him)
 
 # Becoming a Committer
 


### PR DESCRIPTION
I have read and understood the project's Contributing guide.
I also have read and understood the process and best practices around Express triaging.

I request for a triager role for the below orgs:

jshttp
pillarjs
express