### PR TITLE
docs: request for triager role for chasingSublimity

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -71,6 +71,7 @@ compromise among committers be the default resolution mechanism.
 * [jonchurch](https://github.com/jonchurch) - **Jon Church** &lt;jon@osiolabs.com&gt; (he/him)
 * [mirawlings](https://github.com/mirawlings) - **Michael Rawlings** &lt;mlrawlings@gmail.com&gt; (he/him)
 * [helio-frota](https://github.com/helio-frota) - **Helio Frota** &lt;hesilva@redhat.com&gt; (he/him)
+* [chasingSublimity](https://github.com/chasingSublimity) - **Blake Sager** &lt;blakemsager@gmail.com&gt; (he/him)
 
 # Becoming a Committer
 


### PR DESCRIPTION
Hey there!

I recently watched @wesleytodd's talk at Node+JS Interactive and would love to help out as a triager. I see that quite a few people have already been added as triagers, so I understand if there are no more roles to fill.

Thanks!


I have read and understood the project's Contributing guide.
I also have read and understood the process and best practices around Express triaging.

I request for a triager role for the below orgs:

pillarjs
express