### PR TITLE
Resolve path in sendFile

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -421,8 +421,9 @@ res.sendFile = function sendFile(path, options, callback) {
     opts = {};
   }
 
+  // Resolve the full path when no root dir
   if (!opts.root && !isAbsolute(path)) {
-    throw new TypeError('path must be absolute or specify root to res.sendFile');
+    path = resolve(path);
   }
 
   // create file stream
@@ -566,11 +567,8 @@ res.download = function download (path, filename, options, callback) {
   opts = Object.create(opts)
   opts.headers = headers
 
-  // Resolve the full path for sendFile
-  var fullPath = resolve(path);
-
   // send file
-  return this.sendFile(fullPath, opts, done)
+  return this.sendFile(path, opts, done)
 };
 
 /**


### PR DESCRIPTION
Currently only `res.download` resolves full file path and passes it to `sendFile` method. This commit moves the resolve function to the `sendFile`, allowing sending non-attachment files without providing full file path too.