### PR TITLE
Fix regexp handing logic in router. Closes #4204

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix incorrect middleware execution with unanchored `RegExp`s
   * Fix `res.jsonp(obj, status)` deprecation message
   * Fix typo in `res.is` JSDoc
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -287,6 +287,12 @@ proto.handle = function handle(req, res, out) {
 
   function trim_prefix(layer, layerError, layerPath, path) {
     if (layerPath.length !== 0) {
+      // Validate path is a prefix match
+      if (layerPath !== path.substr(0, layerPath.length)) {
+        next(layerError)
+        return
+      }
+
       // Validate path breaks on a path separator
       var c = path[layerPath.length]
       if (c && c !== '/' && c !== '.') return next(layerError)

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -186,6 +186,35 @@ describe('app.router', function(){
       .get('/user/10/edit')
       .expect('editing user 10', done);
     })
+
+    it('should ensure regexp matches path prefix', function (done) {
+      var app = express()
+      var p = []
+
+      app.use(/\/api.*/, function (req, res, next) {
+        p.push('a')
+        next()
+      })
+      app.use(/api/, function (req, res, next) {
+        p.push('b')
+        next()
+      })
+      app.use(/\/test/, function (req, res, next) {
+        p.push('c')
+        next()
+      })
+      app.use(function (req, res) {
+        res.end()
+      })
+
+      request(app)
+        .get('/test/api/1234')
+        .expect(200, function (err) {
+          if (err) return done(err)
+          assert.deepEqual(p, ['c'])
+          done()
+        })
+    })
   })
 
   describe('case sensitivity', function(){


### PR DESCRIPTION
It closes #4204. When regexp matches path not from the beginning, `trim_prefx` validates if path breaks on a path separator in a wrong way.

Here is a small illustration of the problem:
```
path:       /test/api/123
layerPath:  /api/123
c:                  ^
```

after the fix:
```
path:       /test/api/123
startIndex:      ^
layerPath:       /api/123
c:                       ^
```
This PR fixes his behaviors by testing matched layerPath not from the begging of the path but from the start of the match.

I have also added a unit test to cover this case.

Existing logic should not be affected, because in case of a match from the beginning of the path, the `startIndex` variable will be 0 and we will end up an old logic.