### PR TITLE
query: deprecate extended query parser

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -143,7 +143,7 @@ app.lazyrouter = function lazyrouter() {
       strict: this.enabled('strict routing')
     });
 
-    const parser = this.get('query parser fn');
+    var parser = this.get('query parser fn');
     if (defaultExtendedQueryParser === 1 && parser && parser.name === 'parseExtendedQueryString') {
       deprecate('default extended query parser deprecated, set explicitly to override')
     }

--- a/lib/application.js
+++ b/lib/application.js
@@ -44,7 +44,7 @@ var app = exports = module.exports = {};
 
 var trustProxyDefaultSymbol = '@@symbol:trust_proxy_default';
 
-var defaultExtendedQueryParser = 0;
+var defaultExtendedQueryParser = false;
 
 /**
  * Initialize the server.
@@ -77,6 +77,7 @@ app.defaultConfiguration = function defaultConfiguration() {
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');
+  defaultExtendedQueryParser = true;
   this.set('subdomain offset', 2);
   this.set('trust proxy', false);
 
@@ -144,7 +145,7 @@ app.lazyrouter = function lazyrouter() {
     });
 
     var parser = this.get('query parser fn');
-    if (defaultExtendedQueryParser === 1 && parser && parser.name === 'parseExtendedQueryString') {
+    if (defaultExtendedQueryParser && parser && parser.name === 'parseExtendedQueryString') {
       deprecate('default extended query parser deprecated, set explicitly to override')
     }
 
@@ -374,7 +375,7 @@ app.set = function set(setting, val) {
       break;
     case 'query parser':
       this.set('query parser fn', compileQueryParser(val));
-      defaultExtendedQueryParser++;
+      defaultExtendedQueryParser = false;
       break;
     case 'trust proxy':
       this.set('trust proxy fn', compileTrust(val));

--- a/lib/application.js
+++ b/lib/application.js
@@ -44,6 +44,8 @@ var app = exports = module.exports = {};
 
 var trustProxyDefaultSymbol = '@@symbol:trust_proxy_default';
 
+var defaultExtendedQueryParser = 0;
+
 /**
  * Initialize the server.
  *
@@ -141,7 +143,12 @@ app.lazyrouter = function lazyrouter() {
       strict: this.enabled('strict routing')
     });
 
-    this._router.use(query(this.get('query parser fn')));
+    const parser = this.get('query parser fn');
+    if (defaultExtendedQueryParser === 1 && parser && parser.name === 'parseExtendedQueryString') {
+      deprecate('default extended query parser deprecated, set explicitly to override')
+    }
+
+    this._router.use(query(parser));
     this._router.use(middleware.init(this));
   }
 };
@@ -367,6 +374,7 @@ app.set = function set(setting, val) {
       break;
     case 'query parser':
       this.set('query parser fn', compileQueryParser(val));
+      defaultExtendedQueryParser++;
       break;
     case 'trust proxy':
       this.set('trust proxy fn', compileTrust(val));

--- a/lib/application.js
+++ b/lib/application.js
@@ -71,12 +71,12 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this.defaultExtendedQueryParser = false;
+  this._defaultExtendedQueryParser = true;
   this.enable('x-powered-by');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');
-  this.defaultExtendedQueryParser = true;
+  this._defaultExtendedQueryParser = true;
   this.set('subdomain offset', 2);
   this.set('trust proxy', false);
 
@@ -143,12 +143,11 @@ app.lazyrouter = function lazyrouter() {
       strict: this.enabled('strict routing')
     });
 
-    var parser = this.get('query parser fn');
-    if (this.defaultExtendedQueryParser && parser && parser.name === 'parseExtendedQueryString') {
+    if (this._defaultExtendedQueryParser) {
       deprecate('default extended query parser deprecated, set explicitly to override')
     }
 
-    this._router.use(query(parser));
+    this._router.use(query(this.get('query parser fn')));
     this._router.use(middleware.init(this));
   }
 };
@@ -374,7 +373,7 @@ app.set = function set(setting, val) {
       break;
     case 'query parser':
       this.set('query parser fn', compileQueryParser(val));
-      this.defaultExtendedQueryParser = false;
+      this._defaultExtendedQueryParser = false;
       break;
     case 'trust proxy':
       this.set('trust proxy fn', compileTrust(val));

--- a/lib/application.js
+++ b/lib/application.js
@@ -44,8 +44,6 @@ var app = exports = module.exports = {};
 
 var trustProxyDefaultSymbol = '@@symbol:trust_proxy_default';
 
-var defaultExtendedQueryParser = false;
-
 /**
  * Initialize the server.
  *
@@ -73,11 +71,12 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
+  this.defaultExtendedQueryParser = false;
   this.enable('x-powered-by');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');
-  defaultExtendedQueryParser = true;
+  this.defaultExtendedQueryParser = true;
   this.set('subdomain offset', 2);
   this.set('trust proxy', false);
 
@@ -145,7 +144,7 @@ app.lazyrouter = function lazyrouter() {
     });
 
     var parser = this.get('query parser fn');
-    if (defaultExtendedQueryParser && parser && parser.name === 'parseExtendedQueryString') {
+    if (this.defaultExtendedQueryParser && parser && parser.name === 'parseExtendedQueryString') {
       deprecate('default extended query parser deprecated, set explicitly to override')
     }
 
@@ -375,7 +374,7 @@ app.set = function set(setting, val) {
       break;
     case 'query parser':
       this.set('query parser fn', compileQueryParser(val));
-      defaultExtendedQueryParser = false;
+      this.defaultExtendedQueryParser = false;
       break;
     case 'trust proxy':
       this.set('trust proxy fn', compileTrust(val));

--- a/lib/application.js
+++ b/lib/application.js
@@ -71,12 +71,12 @@ app.defaultConfiguration = function defaultConfiguration() {
   var env = process.env.NODE_ENV || 'development';
 
   // default settings
-  this._defaultExtendedQueryParser = true;
+  this._defaultExtendedQueryParser = true
   this.enable('x-powered-by');
   this.set('etag', 'weak');
   this.set('env', env);
   this.set('query parser', 'extended');
-  this._defaultExtendedQueryParser = true;
+  this._defaultExtendedQueryParser = true
   this.set('subdomain offset', 2);
   this.set('trust proxy', false);
 
@@ -373,7 +373,7 @@ app.set = function set(setting, val) {
       break;
     case 'query parser':
       this.set('query parser fn', compileQueryParser(val));
-      this._defaultExtendedQueryParser = false;
+      this._defaultExtendedQueryParser = false
       break;
     case 'trust proxy':
       this.set('trust proxy fn', compileTrust(val));

--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -15,7 +15,7 @@
 var merge = require('utils-merge')
 var parseUrl = require('parseurl');
 var qs = require('qs');
-var deprecate = require('depd')('query');
+var deprecate = require('depd')('express');
 
 /**
  * @param {Object} options
@@ -24,7 +24,9 @@ var deprecate = require('depd')('query');
  */
 
 module.exports = function query(options) {
-  deprecate('default extended query parser is deprecated, set explicitly to override');
+  if (options && options.name === 'parseExtendedQueryString') {
+    deprecate('default extended query parser is deprecated, set explicitly to override');
+  }
   var opts = merge({}, options)
   var queryparse = qs.parse;
 

--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -15,7 +15,6 @@
 var merge = require('utils-merge')
 var parseUrl = require('parseurl');
 var qs = require('qs');
-var deprecate = require('depd')('express');
 
 /**
  * @param {Object} options
@@ -24,9 +23,6 @@ var deprecate = require('depd')('express');
  */
 
 module.exports = function query(options) {
-  if (options && options.name === 'parseExtendedQueryString') {
-    deprecate('default extended query parser is deprecated, set explicitly to override');
-  }
   var opts = merge({}, options)
   var queryparse = qs.parse;
 

--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -15,6 +15,7 @@
 var merge = require('utils-merge')
 var parseUrl = require('parseurl');
 var qs = require('qs');
+var deprecate = require('depd')('query');
 
 /**
  * @param {Object} options
@@ -23,6 +24,7 @@ var qs = require('qs');
  */
 
 module.exports = function query(options) {
+  deprecate('default extended query parser is deprecated, set explicitly to override');
   var opts = merge({}, options)
   var queryparse = qs.parse;
 


### PR DESCRIPTION
Refs: https://github.com/expressjs/express/pull/3621

 - I thought about checking the parser type before throwing deprecation, but then found that it wasn't necessary, as we are hard-coding it to `extended`
 - the `query` part in `var deprecate = require('depd')('query');` is my assumption about how it should be, let me know if that is not the case
 - feel free to propose changes to the message.

thanks!