### PR TITLE
feat: Add match method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -507,6 +507,29 @@ app.all = function all(path) {
   return this;
 };
 
+/**
+ * Register a route that responds to multiple HTTP verbs.
+ * 
+ * @param {Array} verbs
+ * @param {String} path
+ * @param {Function} ...
+ * @returns {app} for chaining
+ * @public
+ */
+app.match = function(verbs = [],path = '/') {
+  if(Array.isArray(verbs) && verbs.length === 0) {
+    verbs.push('get');
+  }
+  this.lazyrouter();
+  var route = this._router.route(path);
+  var args = slice.call(arguments, 2);
+  for (var i = 0; i < verbs.length; i++) {
+    route[verbs[i]].apply(route, args);
+  }
+  return this;
+};
+
+
 // del -> delete alias
 
 app.del = deprecate.function(app.delete, 'app.del: Use app.delete instead');


### PR DESCRIPTION
Sometimes you may need to register a route that responds to multiple HTTP verbs.
 You may do so using the match method. 
example : 
``
app.match(['get','post'], '/' ,function(req,res) {
  console.log(req.method);
 });
``