### PR TITLE
Fix cookie not clearing if maxAge is set. Closes #4252

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -799,7 +799,7 @@ res.get = function(field){
  */
 
 res.clearCookie = function clearCookie(name, options) {
-  var opts = merge({ expires: new Date(1), path: '/' }, options);
+  var opts = merge(options || {}, {maxAge: 0});
 
   return this.cookie(name, '', opts);
 };
@@ -846,7 +846,7 @@ res.cookie = function (name, value, options) {
   }
 
   if ('maxAge' in opts) {
-    opts.expires = new Date(Date.now() + opts.maxAge);
+    opts.expires = (opts.maxAge <= 0) ? new Date(1) : new Date(Date.now() + opts.maxAge);
     opts.maxAge /= 1000;
   }
 

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -13,7 +13,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Set-Cookie', 'sid=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+      .expect('Set-Cookie', 'sid=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
       .expect(200, done)
     })
   })
@@ -28,8 +28,34 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Set-Cookie', 'sid=; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+      .expect('Set-Cookie', 'sid=; Max-Age=0; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
       .expect(200, done)
     })
+
+    it('should override \'expires\' property', function(done) {
+      var app = express();
+
+      app.use(function(req, res) {
+        res.clearCookie('sid', {expires: new Date()}).end();
+      });
+
+      request(app)
+        .get('/')
+        .expect('Set-Cookie', 'sid=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+        .expect(200, done)
+    });
+
+    it('should override \'maxAge\' property', function(done) {
+      var app = express();
+
+      app.use(function(req, res) {
+        res.clearCookie('sid', {maxAge: 10000}).end();
+      });
+
+      request(app)
+        .get('/')
+        .expect('Set-Cookie', 'sid=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+        .expect(200, done)
+    });
   })
 })


### PR DESCRIPTION
Closes issue [#4252](https://github.com/expressjs/express/issues/4252).
Since maxAge takes precedence over expires, if maxAge was set the cookie would not expire.

- Changed merge parameters' orders so that the cookie's options are overrided by `{maxAge:0}`. Note `expires: new Date(1)` has been removed as it is now obsolete since when `maxAge` is set, `expires` will also be set.
- Also updated logic relating to setting `expires` property when `maxAge` is set. If `maxAge` is `<=0` it will set `expires` to a past date. Otherwise, set it to the current `Date() + maxAge`.
- Added appropriate tests checking the `expires` and `maxAge` properties are overriden by `clearCookie()`. Also updated existing tests so that they now expect a `Max-Age=0;` that is always set when a cookie is cleared now.