### PR TITLE
Expose path on Layer

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -41,7 +41,7 @@ function Layer(path, options, fn) {
   this.handle = fn;
   this.name = fn.name || '<anonymous>';
   this.params = undefined;
-  this.path = undefined;
+  this.path = path;
   this.regexp = pathRegexp(path, this.keys = [], opts);
 
   // set fast path flags


### PR DESCRIPTION
For introspecting routes more easily than with `regexp` prop