### PR TITLE
Release 4.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
         - name: Node.js 6.x
           node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
+          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
 
         - name: Node.js 7.x
           node-version: "7.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         - Node.js 14.x
         - Node.js 15.x
         - Node.js 16.x
+        - Node.js 17.x
 
         include:
         - name: Node.js 0.10
@@ -97,6 +98,9 @@ jobs:
 
         - name: Node.js 16.x
           node-version: "16.14"
+
+        - name: Node.js 17.x
+          node-version: "17.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         - Node.js 15.x
         - Node.js 16.x
         - Node.js 17.x
+        - Node.js 18.x
 
         include:
         - name: Node.js 0.10
@@ -101,6 +102,9 @@ jobs:
 
         - name: Node.js 17.x
           node-version: "17.9"
+
+        - name: Node.js 18.x
+          node-version: "18.0"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         - Node.js 13.x
         - Node.js 14.x
         - Node.js 15.x
+        - Node.js 16.x
 
         include:
         - name: Node.js 0.10
@@ -93,6 +94,9 @@ jobs:
 
         - name: Node.js 15.x
           node-version: "15.14"
+
+        - name: Node.js 16.x
+          node-version: "16.14"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         - Node.js 12.x
         - Node.js 13.x
         - Node.js 14.x
+        - Node.js 15.x
 
         include:
         - name: Node.js 0.10
@@ -89,6 +90,9 @@ jobs:
 
         - name: Node.js 14.x
           node-version: "14.19"
+
+        - name: Node.js 15.x
+          node-version: "15.14"
 
     steps:
     - uses: actions/checkout@v2

--- a/Charter.md
+++ b/Charter.md
@@ -9,7 +9,7 @@ also easily visible to outsiders.
 
 ## Section 1: Scope
 
-Express is a http web server framework with a simple and expressive API
+Express is a HTTP web server framework with a simple and expressive API
 which is highly aligned with Node.js core. We aim to be the best in
 class for writing performant, spec compliant, and powerful web servers
 in Node.js. As one of the oldest and most popular web frameworks in
@@ -24,7 +24,7 @@ Express is made of many modules spread between three GitHub Orgs:
   libraries
 - [pillarjs](http://github.com/pillarjs/): Components which make up
   Express but can also be used for other web frameworks
-- [jshttp](http://github.com/jshttp/): Low level http libraries
+- [jshttp](http://github.com/jshttp/): Low level HTTP libraries
 
 ### 1.2: Out-of-Scope
 

--- a/History.md
+++ b/History.md
@@ -37,6 +37,9 @@ unreleased
     - deps: statuses@2.0.1
   * deps: serve-static@1.15.0
     - deps: send@0.18.0
+  * deps: statuses@2.0.1
+    - Remove code 306
+    - Rename `425 Unordered Collection` to standard `425 Too Early`
 
 4.17.3 / 2022-02-16
 ===================

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add "root" option to `res.download`
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`

--- a/History.md
+++ b/History.md
@@ -19,6 +19,9 @@ unreleased
     - deps: on-finished@2.4.1
     - deps: qs@6.10.3
     - deps: raw-body@2.5.1
+  * deps: cookie@0.5.0
+    - Add `priority` option
+    - Fix `expires` option to reject invalid dates
   * deps: depd@2.0.0
     - Replace internal `eval` usage with `Function` constructor
     - Use instance methods on `process` to check for listeners

--- a/History.md
+++ b/History.md
@@ -5,6 +5,14 @@ unreleased
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`
+  * deps: send@0.18.0
+    - Fix emitted 416 error missing headers property
+    - Limit the headers removed for 304 response
+    - deps: depd@2.0.0
+    - deps: destroy@1.2.0
+    - deps: http-errors@2.0.0
+    - deps: on-finished@2.4.1
+    - deps: statuses@2.0.1
 
 4.17.3 / 2022-02-16
 ===================

--- a/History.md
+++ b/History.md
@@ -13,6 +13,8 @@ unreleased
     - deps: http-errors@2.0.0
     - deps: on-finished@2.4.1
     - deps: statuses@2.0.1
+  * deps: serve-static@1.15.0
+    - deps: send@0.18.0
 
 4.17.3 / 2022-02-16
 ===================

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`
 

--- a/History.md
+++ b/History.md
@@ -7,6 +7,9 @@ unreleased
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`
+  * deps: depd@2.0.0
+    - Replace internal `eval` usage with `Function` constructor
+    - Use instance methods on `process` to check for listeners
   * deps: finalhandler@1.2.0
     - Remove set content headers that break response
     - deps: on-finished@2.4.1

--- a/History.md
+++ b/History.md
@@ -26,6 +26,8 @@ unreleased
     - Remove set content headers that break response
     - deps: on-finished@2.4.1
     - deps: statuses@2.0.1
+  * deps: on-finished@2.4.1
+    - Prevent loss of async hooks context
   * deps: qs@6.10.3
   * deps: send@0.18.0
     - Fix emitted 416 error missing headers property

--- a/History.md
+++ b/History.md
@@ -8,6 +8,7 @@ unreleased
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`
+  * Use `http-errors` for `res.format` error
   * deps: depd@2.0.0
     - Replace internal `eval` usage with `Function` constructor
     - Use instance methods on `process` to check for listeners

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Add "root" option to `res.download`
+  * Allow `options` without `filename` in `res.download`
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`

--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
   * Allow `options` without `filename` in `res.download`
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
+  * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`
   * deps: finalhandler@1.2.0
     - Remove set content headers that break response

--- a/History.md
+++ b/History.md
@@ -9,6 +9,16 @@ unreleased
   * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`
   * Use `http-errors` for `res.format` error
+  * deps: body-parser@1.20.0
+    - Fix error message for json parse whitespace in `strict`
+    - Fix internal error when inflated body exceeds limit
+    - Prevent loss of async hooks context
+    - Prevent hanging when request already read
+    - deps: depd@2.0.0
+    - deps: http-errors@2.0.0
+    - deps: on-finished@2.4.1
+    - deps: qs@6.10.3
+    - deps: raw-body@2.5.1
   * deps: depd@2.0.0
     - Replace internal `eval` usage with `Function` constructor
     - Use instance methods on `process` to check for listeners

--- a/History.md
+++ b/History.md
@@ -5,6 +5,10 @@ unreleased
   * Deprecate string and non-integer arguments to `res.status`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`
+  * deps: finalhandler@1.2.0
+    - Remove set content headers that break response
+    - deps: on-finished@2.4.1
+    - deps: statuses@2.0.1
   * deps: send@0.18.0
     - Fix emitted 416 error missing headers property
     - Limit the headers removed for 304 response

--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ unreleased
   * Add "root" option to `res.download`
   * Allow `options` without `filename` in `res.download`
   * Deprecate string and non-integer arguments to `res.status`
+  * Fix behavior of `null`/`undefined` as `maxAge` in `res.cookie`
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`

--- a/History.md
+++ b/History.md
@@ -26,6 +26,7 @@ unreleased
     - Remove set content headers that break response
     - deps: on-finished@2.4.1
     - deps: statuses@2.0.1
+  * deps: qs@6.10.3
   * deps: send@0.18.0
     - Fix emitted 416 error missing headers property
     - Limit the headers removed for 304 response

--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
   * Allow `options` without `filename` in `res.download`
   * Deprecate string and non-integer arguments to `res.status`
   * Fix behavior of `null`/`undefined` as `maxAge` in `res.cookie`
+  * Fix handling very large stacks of sync middleware
   * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Invoke `default` with same arguments as types in `res.format`
   * Support proper 205 responses using `res.send`

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Ignore `Object.prototype` values in settings through `app.set`/`app.get`
   * Support proper 205 responses using `res.send`
 
 4.17.3 / 2022-02-16

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Support proper 205 responses using `res.send`
+
 4.17.3 / 2022-02-16
 ===================
 

--- a/Security.md
+++ b/Security.md
@@ -27,8 +27,7 @@ endeavor to keep you informed of the progress towards a fix and full
 announcement, and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining
-the module. You can also report a vulnerability through the
-[Node Security Project](https://nodesecurity.io/report).
+the module.
 
 ## Disclosure Policy
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
     - nodejs_version: "12.22"
     - nodejs_version: "13.14"
     - nodejs_version: "14.19"
+    - nodejs_version: "15.14"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,11 +71,11 @@ install:
   - ps: |
       # supertest for http calls
       # - use 2.0.0 for Node.js < 4
-      # - use 3.4.2 for Node.js < 6
+      # - use 3.4.2 for Node.js < 7
       # - use 6.1.6 for Node.js < 8
       if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
         npm install --silent --save-dev supertest@2.0.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 6) {
+      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 7) {
         npm install --silent --save-dev supertest@3.4.2
       } elseif ([int]$env:nodejs_version.split(".")[0] -lt 8) {
         npm install --silent --save-dev supertest@6.1.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   # Install Node.js
   - ps: >-
       try { Install-Product node $env:nodejs_version -ErrorAction Stop }
-      catch { Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) }
+      catch { Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64 }
   # Configure npm
   - ps: |
       npm config set loglevel error

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
     - nodejs_version: "15.14"
     - nodejs_version: "16.14"
     - nodejs_version: "17.9"
+    - nodejs_version: "18.0"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
     - nodejs_version: "14.19"
     - nodejs_version: "15.14"
     - nodejs_version: "16.14"
+    - nodejs_version: "17.9"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
     - nodejs_version: "13.14"
     - nodejs_version: "14.19"
     - nodejs_version: "15.14"
+    - nodejs_version: "16.14"
 cache:
   - node_modules
 install:

--- a/examples/auth/views/login.ejs
+++ b/examples/auth/views/login.ejs
@@ -6,12 +6,12 @@
 Try accessing <a href="/restricted">/restricted</a>, then authenticate with "tj" and "foobar".
 <form method="post" action="/login">
   <p>
-    <label>Username:</label>
-    <input type="text" name="username">
+    <label for="username">Username:</label>
+    <input type="text" name="username" id="username">
   </p>
   <p>
-    <label>Password:</label>
-    <input type="text" name="password">
+    <label for="password">Password:</label>
+    <input type="text" name="password" id="password">
   </p>
   <p>
     <input type="submit" value="Login">

--- a/examples/downloads/index.js
+++ b/examples/downloads/index.js
@@ -6,7 +6,6 @@
 
 var express = require('../../');
 var path = require('path');
-var resolvePath = require('resolve-path')
 
 var app = module.exports = express();
 
@@ -25,9 +24,7 @@ app.get('/', function(req, res){
 // /files/* is accessed via req.params[0]
 // but here we name it :file
 app.get('/files/:file(*)', function(req, res, next){
-  var filePath = resolvePath(FILES_DIR, req.params.file)
-
-  res.download(filePath, function (err) {
+  res.download(req.params.file, { root: FILES_DIR }, function (err) {
     if (!err) return; // file sent
     if (err.status !== 404) return next(err); // non-404 error
     // file for download not found

--- a/examples/params/index.js
+++ b/examples/params/index.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+var createError = require('http-errors')
 var express = require('../../');
 var app = module.exports = express();
 
@@ -16,14 +17,6 @@ var users = [
   , { name: 'jane' }
   , { name: 'bandit' }
 ];
-
-// Create HTTP error
-
-function createError(status, message) {
-  var err = new Error(message);
-  err.status = status;
-  return err;
-}
 
 // Convert :to and :from to integers
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -29,6 +29,13 @@ var flatten = require('array-flatten');
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var setPrototypeOf = require('setprototypeof')
+
+/**
+ * Module variables.
+ * @private
+ */
+
+var hasOwnProperty = Object.prototype.hasOwnProperty
 var slice = Array.prototype.slice;
 
 /**
@@ -352,7 +359,17 @@ app.param = function param(name, fn) {
 app.set = function set(setting, val) {
   if (arguments.length === 1) {
     // app.get(setting)
-    return this.settings[setting];
+    var settings = this.settings
+
+    while (settings && settings !== Object.prototype) {
+      if (hasOwnProperty.call(settings, setting)) {
+        return settings[setting]
+      }
+
+      settings = Object.getPrototypeOf(settings)
+    }
+
+    return undefined
   }
 
   debug('set "%s" to %o', setting, val);

--- a/lib/response.js
+++ b/lib/response.js
@@ -64,6 +64,9 @@ var charsetRegExp = /;\s*charset\s*=/;
  */
 
 res.status = function status(code) {
+  if ((typeof code === 'string' || Math.floor(code) !== code) && code > 99 && code < 1000) {
+    deprecate('res.status(' + JSON.stringify(code) + '): use res.status(' + Math.floor(code) + ') instead')
+  }
   this.statusCode = code;
   return this;
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -561,6 +561,13 @@ res.download = function download (path, filename, options, callback) {
     opts = null
   }
 
+  // support optional filename, where options may be in it's place
+  if (typeof filename === 'object' &&
+    (typeof options === 'function' || options === undefined)) {
+    name = null
+    opts = filename
+  }
+
   // set Content-Disposition when file is sent
   var headers = {
     'Content-Disposition': contentDisposition(name || path)

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,6 +14,7 @@
 
 var Buffer = require('safe-buffer').Buffer
 var contentDisposition = require('content-disposition');
+var createError = require('http-errors')
 var deprecate = require('depd')('express');
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
@@ -699,10 +700,9 @@ res.format = function(obj){
   } else if (obj.default) {
     obj.default(req, this, next)
   } else {
-    var err = new Error('Not Acceptable');
-    err.status = err.statusCode = 406;
-    err.types = normalizeTypes(keys).map(function(o){ return o.value });
-    next(err);
+    next(createError(406, {
+      types: normalizeTypes(keys).map(function (o) { return o.value })
+    }))
   }
 
   return this;

--- a/lib/response.js
+++ b/lib/response.js
@@ -213,6 +213,13 @@ res.send = function send(body) {
     chunk = '';
   }
 
+  // alter headers for 205
+  if (this.statusCode === 205) {
+    this.set('Content-Length', '0')
+    this.removeHeader('Transfer-Encoding')
+    chunk = ''
+  }
+
   if (req.method === 'HEAD') {
     // skip body for HEAD
     this.end();

--- a/lib/response.js
+++ b/lib/response.js
@@ -684,9 +684,8 @@ res.format = function(obj){
   var req = this.req;
   var next = req.next;
 
-  var fn = obj.default;
-  if (fn) delete obj.default;
-  var keys = Object.keys(obj);
+  var keys = Object.keys(obj)
+    .filter(function (v) { return v !== 'default' })
 
   var key = keys.length > 0
     ? req.accepts(keys)
@@ -697,8 +696,8 @@ res.format = function(obj){
   if (key) {
     this.set('Content-Type', normalizeType(key).value);
     obj[key](req, this, next);
-  } else if (fn) {
-    fn();
+  } else if (obj.default) {
+    obj.default(req, this, next)
   } else {
     var err = new Error('Not Acceptable');
     err.status = err.statusCode = 406;

--- a/lib/response.js
+++ b/lib/response.js
@@ -139,7 +139,7 @@ res.send = function send(body) {
 
     deprecate('res.send(status): Use res.sendStatus(status) instead');
     this.statusCode = chunk;
-    chunk = statuses[chunk]
+    chunk = statuses.message[chunk]
   }
 
   switch (typeof chunk) {
@@ -367,7 +367,7 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
-  var body = statuses[statusCode] || String(statusCode)
+  var body = statuses.message[statusCode] || String(statusCode)
 
   this.statusCode = statusCode;
   this.type('txt');
@@ -955,12 +955,12 @@ res.redirect = function redirect(url) {
   // Support text/{plain,html} by default
   this.format({
     text: function(){
-      body = statuses[status] + '. Redirecting to ' + address
+      body = statuses.message[status] + '. Redirecting to ' + address
     },
 
     html: function(){
       var u = escapeHtml(address);
-      body = '<p>' + statuses[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>'
+      body = '<p>' + statuses.message[status] + '. Redirecting to <a href="' + u + '">' + u + '</a></p>'
     },
 
     default: function(){

--- a/lib/response.js
+++ b/lib/response.js
@@ -868,9 +868,13 @@ res.cookie = function (name, value, options) {
     val = 's:' + sign(val, secret);
   }
 
-  if ('maxAge' in opts) {
-    opts.expires = new Date(Date.now() + opts.maxAge);
-    opts.maxAge /= 1000;
+  if (opts.maxAge != null) {
+    var maxAge = opts.maxAge - 0
+
+    if (!isNaN(maxAge)) {
+      opts.expires = new Date(Date.now() + maxAge)
+      opts.maxAge = Math.floor(maxAge / 1000)
+    }
   }
 
   if (opts.path == null) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -582,7 +582,9 @@ res.download = function download (path, filename, options, callback) {
   opts.headers = headers
 
   // Resolve the full path for sendFile
-  var fullPath = resolve(path);
+  var fullPath = !opts.root
+    ? resolve(path)
+    : path
 
   // send file
   return this.sendFile(fullPath, opts, done)

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -142,6 +142,7 @@ proto.handle = function handle(req, res, out) {
   var protohost = getProtohost(req.url) || ''
   var removed = '';
   var slashAdded = false;
+  var sync = 0
   var paramcalled = {};
 
   // store options for OPTIONS request
@@ -201,6 +202,11 @@ proto.handle = function handle(req, res, out) {
     if (idx >= stack.length) {
       setImmediate(done, layerError);
       return;
+    }
+
+    // max sync stack
+    if (++sync > 100) {
+      return setImmediate(next, err)
     }
 
     // get pathname of request
@@ -321,6 +327,8 @@ proto.handle = function handle(req, res, out) {
     } else {
       layer.handle_request(req, res, next);
     }
+
+    sync = 0
   }
 };
 

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -98,6 +98,8 @@ Route.prototype._options = function _options() {
 Route.prototype.dispatch = function dispatch(req, res, done) {
   var idx = 0;
   var stack = this.stack;
+  var sync = 0
+
   if (stack.length === 0) {
     return done();
   }
@@ -127,6 +129,11 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
       return done(err);
     }
 
+    // max sync stack
+    if (++sync > 100) {
+      return setImmediate(next, err)
+    }
+
     if (layer.method && layer.method !== method) {
       return next(err);
     }
@@ -136,6 +143,8 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
     } else {
       layer.handle_request(req, res, next);
     }
+
+    sync = 0
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "accepts": "~1.3.8",
     "array-flatten": "1.1.1",
-    "body-parser": "1.19.2",
+    "body-parser": "1.20.0",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "qs": "6.9.7",
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
-    "send": "0.17.2",
+    "send": "0.18.0",
     "serve-static": "1.14.2",
     "setprototypeof": "1.2.0",
     "statuses": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "http-errors": "2.0.0",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",
-    "on-finished": "~2.3.0",
+    "on-finished": "2.4.1",
     "parseurl": "~1.3.3",
     "path-to-regexp": "0.1.7",
     "proxy-addr": "~2.0.7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "parseurl": "~1.3.3",
     "path-to-regexp": "0.1.7",
     "proxy-addr": "~2.0.7",
-    "qs": "6.9.7",
+    "qs": "6.10.3",
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
     "send": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "send": "0.18.0",
     "serve-static": "1.15.0",
     "setprototypeof": "1.2.0",
-    "statuses": "~1.5.0",
+    "statuses": "2.0.1",
     "type-is": "~1.6.18",
     "utils-merge": "1.0.1",
     "vary": "~1.1.2"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "multiparty": "4.2.3",
     "nyc": "15.1.0",
     "pbkdf2-password": "1.2.1",
-    "resolve-path": "1.4.0",
     "supertest": "6.2.2",
     "vhost": "~3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
     "send": "0.18.0",
-    "serve-static": "1.14.2",
+    "serve-static": "1.15.0",
     "setprototypeof": "1.2.0",
     "statuses": "~1.5.0",
     "type-is": "~1.6.18",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",
-    "finalhandler": "~1.1.2",
+    "finalhandler": "1.2.0",
     "fresh": "0.5.2",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "body-parser": "1.20.0",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
-    "cookie": "0.4.2",
+    "cookie": "0.5.0",
     "cookie-signature": "1.0.6",
     "debug": "2.6.9",
     "depd": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "etag": "~1.8.1",
     "finalhandler": "1.2.0",
     "fresh": "0.5.2",
+    "http-errors": "2.0.0",
     "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",
     "on-finished": "~2.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cookie": "0.4.2",
     "cookie-signature": "1.0.6",
     "debug": "2.6.9",
-    "depd": "~1.1.2",
+    "depd": "2.0.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",

--- a/test/Route.js
+++ b/test/Route.js
@@ -13,6 +13,28 @@ describe('Route', function(){
     route.dispatch(req, {}, done)
   })
 
+  it('should not stack overflow with a large sync stack', function (done) {
+    this.timeout(5000) // long-running test
+
+    var req = { method: 'GET', url: '/' }
+    var route = new Route('/foo')
+
+    for (var i = 0; i < 6000; i++) {
+      route.all(function (req, res, next) { next() })
+    }
+
+    route.get(function (req, res, next) {
+      req.called = true
+      next()
+    })
+
+    route.dispatch(req, {}, function (err) {
+      if (err) return done(err)
+      assert.ok(req.called)
+      done()
+    })
+  })
+
   describe('.all', function(){
     it('should add handler', function(done){
       var req = { method: 'GET', url: '/' };

--- a/test/Router.js
+++ b/test/Router.js
@@ -76,6 +76,22 @@ describe('Router', function(){
     router.handle({ url: '/', method: 'GET' }, { end: done });
   });
 
+  it('should not stack overflow with a large sync stack', function (done) {
+    this.timeout(5000) // long-running test
+
+    var router = new Router()
+
+    for (var i = 0; i < 6000; i++) {
+      router.use(function (req, res, next) { next() })
+    }
+
+    router.use(function (req, res) {
+      res.end()
+    })
+
+    router.handle({ url: '/', method: 'GET' }, { end: done })
+  })
+
   describe('.handle', function(){
     it('should dispatch', function(done){
       var router = new Router();

--- a/test/Router.js
+++ b/test/Router.js
@@ -62,6 +62,8 @@ describe('Router', function(){
   })
 
   it('should not stack overflow with many registered routes', function(done){
+    this.timeout(5000) // long-running test
+
     var handler = function(req, res){ res.end(new Error('wrong handler')) };
     var router = new Router();
 

--- a/test/config.js
+++ b/test/config.js
@@ -11,6 +11,12 @@ describe('config', function () {
       assert.equal(app.get('foo'), 'bar');
     })
 
+    it('should set prototype values', function () {
+      var app = express()
+      app.set('hasOwnProperty', 42)
+      assert.strictEqual(app.get('hasOwnProperty'), 42)
+    })
+
     it('should return the app', function () {
       var app = express();
       assert.equal(app.set('foo', 'bar'), app);
@@ -19,6 +25,17 @@ describe('config', function () {
     it('should return the app when undefined', function () {
       var app = express();
       assert.equal(app.set('foo', undefined), app);
+    })
+
+    it('should return set value', function () {
+      var app = express()
+      app.set('foo', 'bar')
+      assert.strictEqual(app.set('foo'), 'bar')
+    })
+
+    it('should return undefined for prototype values', function () {
+      var app = express()
+      assert.strictEqual(app.set('hasOwnProperty'), undefined)
     })
 
     describe('"etag"', function(){
@@ -49,6 +66,11 @@ describe('config', function () {
     it('should return undefined when unset', function(){
       var app = express();
       assert.strictEqual(app.get('foo'), undefined);
+    })
+
+    it('should return undefined for prototype values', function () {
+      var app = express()
+      assert.strictEqual(app.get('hasOwnProperty'), undefined)
     })
 
     it('should otherwise return the value', function(){
@@ -125,6 +147,12 @@ describe('config', function () {
       assert.equal(app.enable('tobi'), app);
       assert.strictEqual(app.get('tobi'), true);
     })
+
+    it('should set prototype values', function () {
+      var app = express()
+      app.enable('hasOwnProperty')
+      assert.strictEqual(app.get('hasOwnProperty'), true)
+    })
   })
 
   describe('.disable()', function(){
@@ -132,6 +160,12 @@ describe('config', function () {
       var app = express();
       assert.equal(app.disable('tobi'), app);
       assert.strictEqual(app.get('tobi'), false);
+    })
+
+    it('should set prototype values', function () {
+      var app = express()
+      app.disable('hasOwnProperty')
+      assert.strictEqual(app.get('hasOwnProperty'), false)
     })
   })
 
@@ -146,6 +180,11 @@ describe('config', function () {
       app.set('foo', 'bar');
       assert.strictEqual(app.enabled('foo'), true);
     })
+
+    it('should default to false for prototype values', function () {
+      var app = express()
+      assert.strictEqual(app.enabled('hasOwnProperty'), false)
+    })
   })
 
   describe('.disabled()', function(){
@@ -158,6 +197,11 @@ describe('config', function () {
       var app = express();
       app.set('foo', 'bar');
       assert.strictEqual(app.disabled('foo'), false);
+    })
+
+    it('should default to true for prototype values', function () {
+      var app = express()
+      assert.strictEqual(app.disabled('hasOwnProperty'), true)
     })
   })
 })

--- a/test/express.raw.js
+++ b/test/express.raw.js
@@ -1,9 +1,14 @@
 'use strict'
 
 var assert = require('assert')
+var asyncHooks = tryRequire('async_hooks')
 var Buffer = require('safe-buffer').Buffer
 var express = require('..')
 var request = require('supertest')
+
+var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
+  ? describe
+  : describe.skip
 
 describe('express.raw()', function () {
   before(function () {
@@ -60,6 +65,36 @@ describe('express.raw()', function () {
       .expect(200, { buf: '' }, done)
   })
 
+  it('should 500 if stream not readable', function (done) {
+    var app = express()
+
+    app.use(function (req, res, next) {
+      req.on('end', next)
+      req.resume()
+    })
+
+    app.use(express.raw())
+
+    app.use(function (err, req, res, next) {
+      res.status(err.status || 500)
+      res.send('[' + err.type + '] ' + err.message)
+    })
+
+    app.post('/', function (req, res) {
+      if (Buffer.isBuffer(req.body)) {
+        res.json({ buf: req.body.toString('hex') })
+      } else {
+        res.json(req.body)
+      }
+    })
+
+    request(app)
+      .post('/')
+      .set('Content-Type', 'application/octet-stream')
+      .send('the user is tobi')
+      .expect(500, '[stream.not.readable] stream is not readable', done)
+  })
+
   it('should handle duplicated middleware', function (done) {
     var app = express()
 
@@ -102,6 +137,15 @@ describe('express.raw()', function () {
       test.expect(413, done)
     })
 
+    it('should 413 when inflated body over limit', function (done) {
+      var app = createApp({ limit: '1kb' })
+      var test = request(app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'application/octet-stream')
+      test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a14704040000', 'hex'))
+      test.expect(413, done)
+    })
+
     it('should accept number of bytes', function (done) {
       var buf = Buffer.alloc(1028, '.')
       var app = createApp({ limit: 1024 })
@@ -134,6 +178,15 @@ describe('express.raw()', function () {
       test.write(buf)
       test.expect(413, done)
     })
+
+    it('should not error when inflating', function (done) {
+      var app = createApp({ limit: '1kb' })
+      var test = request(app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'application/octet-stream')
+      test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a147040400', 'hex'))
+      test.expect(413, done)
+    })
   })
 
   describe('with inflate option', function () {
@@ -147,7 +200,7 @@ describe('express.raw()', function () {
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/octet-stream')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
-        test.expect(415, 'content encoding unsupported', done)
+        test.expect(415, '[encoding.unsupported] content encoding unsupported', done)
       })
     })
 
@@ -263,39 +316,143 @@ describe('express.raw()', function () {
     })
 
     it('should error from verify', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] === 0x00) throw new Error('no leading null')
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] === 0x00) throw new Error('no leading null')
+        }
+      })
 
       var test = request(app).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000102', 'hex'))
-      test.expect(403, 'no leading null', done)
+      test.expect(403, '[entity.verify.failed] no leading null', done)
     })
 
     it('should allow custom codes', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] !== 0x00) return
-        var err = new Error('no leading null')
-        err.status = 400
-        throw err
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] !== 0x00) return
+          var err = new Error('no leading null')
+          err.status = 400
+          throw err
+        }
+      })
 
       var test = request(app).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000102', 'hex'))
-      test.expect(400, 'no leading null', done)
+      test.expect(400, '[entity.verify.failed] no leading null', done)
     })
 
     it('should allow pass-through', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] === 0x00) throw new Error('no leading null')
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] === 0x00) throw new Error('no leading null')
+        }
+      })
 
       var test = request(app).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('0102', 'hex'))
       test.expect(200, { buf: '0102' }, done)
+    })
+  })
+
+  describeAsyncHooks('async local storage', function () {
+    before(function () {
+      var app = express()
+      var store = { foo: 'bar' }
+
+      app.use(function (req, res, next) {
+        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage.run(store, next)
+      })
+
+      app.use(express.raw())
+
+      app.use(function (req, res, next) {
+        var local = req.asyncLocalStorage.getStore()
+
+        if (local) {
+          res.setHeader('x-store-foo', String(local.foo))
+        }
+
+        next()
+      })
+
+      app.use(function (err, req, res, next) {
+        var local = req.asyncLocalStorage.getStore()
+
+        if (local) {
+          res.setHeader('x-store-foo', String(local.foo))
+        }
+
+        res.status(err.status || 500)
+        res.send('[' + err.type + '] ' + err.message)
+      })
+
+      app.post('/', function (req, res) {
+        if (Buffer.isBuffer(req.body)) {
+          res.json({ buf: req.body.toString('hex') })
+        } else {
+          res.json(req.body)
+        }
+      })
+
+      this.app = app
+    })
+
+    it('should presist store', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'application/octet-stream')
+        .send('the user is tobi')
+        .expect(200)
+        .expect('x-store-foo', 'bar')
+        .expect({ buf: '746865207573657220697320746f6269' })
+        .end(done)
+    })
+
+    it('should presist store when unmatched content-type', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'application/fizzbuzz')
+        .send('buzz')
+        .expect(200)
+        .expect('x-store-foo', 'bar')
+        .expect('{}')
+        .end(done)
+    })
+
+    it('should presist store when inflated', function (done) {
+      var test = request(this.app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'application/octet-stream')
+      test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
+      test.expect(200)
+      test.expect('x-store-foo', 'bar')
+      test.expect({ buf: '6e616d653de8aeba' })
+      test.end(done)
+    })
+
+    it('should presist store when inflate error', function (done) {
+      var test = request(this.app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'application/octet-stream')
+      test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad6080000', 'hex'))
+      test.expect(400)
+      test.expect('x-store-foo', 'bar')
+      test.end(done)
+    })
+
+    it('should presist store when limit exceeded', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'application/octet-stream')
+        .send('the user is ' + Buffer.alloc(1024 * 100, '.').toString())
+        .expect(413)
+        .expect('x-store-foo', 'bar')
+        .end(done)
     })
   })
 
@@ -356,12 +513,12 @@ describe('express.raw()', function () {
       test.expect(200, { buf: '6e616d653de8aeba' }, done)
     })
 
-    it('should fail on unknown encoding', function (done) {
+    it('should 415 on unknown encoding', function (done) {
       var test = request(this.app).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000000000000', 'hex'))
-      test.expect(415, 'unsupported content encoding "nulls"', done)
+      test.expect(415, '[encoding.unsupported] unsupported content encoding "nulls"', done)
     })
   })
 })
@@ -373,7 +530,9 @@ function createApp (options) {
 
   app.use(function (err, req, res, next) {
     res.status(err.status || 500)
-    res.send(String(err[req.headers['x-error-property'] || 'message']))
+    res.send(String(req.headers['x-error-property']
+      ? err[req.headers['x-error-property']]
+      : ('[' + err.type + '] ' + err.message)))
   })
 
   app.post('/', function (req, res) {
@@ -385,4 +544,12 @@ function createApp (options) {
   })
 
   return app
+}
+
+function tryRequire (name) {
+  try {
+    return require(name)
+  } catch (e) {
+    return {}
+  }
 }

--- a/test/express.text.js
+++ b/test/express.text.js
@@ -1,9 +1,14 @@
 'use strict'
 
 var assert = require('assert')
+var asyncHooks = tryRequire('async_hooks')
 var Buffer = require('safe-buffer').Buffer
 var express = require('..')
 var request = require('supertest')
+
+var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
+  ? describe
+  : describe.skip
 
 describe('express.text()', function () {
   before(function () {
@@ -56,6 +61,32 @@ describe('express.text()', function () {
       .expect(200, '""', done)
   })
 
+  it('should 500 if stream not readable', function (done) {
+    var app = express()
+
+    app.use(function (req, res, next) {
+      req.on('end', next)
+      req.resume()
+    })
+
+    app.use(express.text())
+
+    app.use(function (err, req, res, next) {
+      res.status(err.status || 500)
+      res.send('[' + err.type + '] ' + err.message)
+    })
+
+    app.post('/', function (req, res) {
+      res.json(req.body)
+    })
+
+    request(app)
+      .post('/')
+      .set('Content-Type', 'text/plain')
+      .send('user is tobi')
+      .expect(500, '[stream.not.readable] stream is not readable', done)
+  })
+
   it('should handle duplicated middleware', function (done) {
     var app = express()
 
@@ -75,16 +106,16 @@ describe('express.text()', function () {
 
   describe('with defaultCharset option', function () {
     it('should change default charset', function (done) {
-      var app = createApp({ defaultCharset: 'koi8-r' })
-      var test = request(app).post('/')
+      var server = createApp({ defaultCharset: 'koi8-r' })
+      var test = request(server).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('6e616d6520697320cec5d4', 'hex'))
       test.expect(200, '"name is нет"', done)
     })
 
     it('should honor content-type charset', function (done) {
-      var app = createApp({ defaultCharset: 'koi8-r' })
-      var test = request(app).post('/')
+      var server = createApp({ defaultCharset: 'koi8-r' })
+      var test = request(server).post('/')
       test.set('Content-Type', 'text/plain; charset=utf-8')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, '"name is 论"', done)
@@ -103,12 +134,21 @@ describe('express.text()', function () {
     })
 
     it('should 413 when over limit with chunked encoding', function (done) {
-      var buf = Buffer.alloc(1028, '.')
       var app = createApp({ limit: '1kb' })
+      var buf = Buffer.alloc(1028, '.')
       var test = request(app).post('/')
       test.set('Content-Type', 'text/plain')
       test.set('Transfer-Encoding', 'chunked')
       test.write(buf.toString())
+      test.expect(413, done)
+    })
+
+    it('should 413 when inflated body over limit', function (done) {
+      var app = createApp({ limit: '1kb' })
+      var test = request(app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'text/plain')
+      test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a14704040000', 'hex'))
       test.expect(413, done)
     })
 
@@ -136,14 +176,25 @@ describe('express.text()', function () {
     })
 
     it('should not hang response', function (done) {
-      var buf = Buffer.alloc(10240, '.')
       var app = createApp({ limit: '8kb' })
+      var buf = Buffer.alloc(10240, '.')
       var test = request(app).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(buf)
       test.write(buf)
       test.write(buf)
       test.expect(413, done)
+    })
+
+    it('should not error when inflating', function (done) {
+      var app = createApp({ limit: '1kb' })
+      var test = request(app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'text/plain')
+      test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a1470404', 'hex'))
+      setTimeout(function () {
+        test.expect(413, done)
+      }, 100)
     })
   })
 
@@ -158,7 +209,7 @@ describe('express.text()', function () {
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'text/plain')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
-        test.expect(415, 'content encoding unsupported', done)
+        test.expect(415, '[encoding.unsupported] content encoding unsupported', done)
       })
     })
 
@@ -278,36 +329,42 @@ describe('express.text()', function () {
     })
 
     it('should error from verify', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] === 0x20) throw new Error('no leading space')
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] === 0x20) throw new Error('no leading space')
+        }
+      })
 
       request(app)
         .post('/')
         .set('Content-Type', 'text/plain')
         .send(' user is tobi')
-        .expect(403, 'no leading space', done)
+        .expect(403, '[entity.verify.failed] no leading space', done)
     })
 
     it('should allow custom codes', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] !== 0x20) return
-        var err = new Error('no leading space')
-        err.status = 400
-        throw err
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] !== 0x20) return
+          var err = new Error('no leading space')
+          err.status = 400
+          throw err
+        }
+      })
 
       request(app)
         .post('/')
         .set('Content-Type', 'text/plain')
         .send(' user is tobi')
-        .expect(400, 'no leading space', done)
+        .expect(400, '[entity.verify.failed] no leading space', done)
     })
 
     it('should allow pass-through', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        if (buf[0] === 0x20) throw new Error('no leading space')
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          if (buf[0] === 0x20) throw new Error('no leading space')
+        }
+      })
 
       request(app)
         .post('/')
@@ -317,14 +374,110 @@ describe('express.text()', function () {
     })
 
     it('should 415 on unknown charset prior to verify', function (done) {
-      var app = createApp({ verify: function (req, res, buf) {
-        throw new Error('unexpected verify call')
-      } })
+      var app = createApp({
+        verify: function (req, res, buf) {
+          throw new Error('unexpected verify call')
+        }
+      })
 
       var test = request(app).post('/')
       test.set('Content-Type', 'text/plain; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
-      test.expect(415, 'unsupported charset "X-BOGUS"', done)
+      test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
+    })
+  })
+
+  describeAsyncHooks('async local storage', function () {
+    before(function () {
+      var app = express()
+      var store = { foo: 'bar' }
+
+      app.use(function (req, res, next) {
+        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage.run(store, next)
+      })
+
+      app.use(express.text())
+
+      app.use(function (req, res, next) {
+        var local = req.asyncLocalStorage.getStore()
+
+        if (local) {
+          res.setHeader('x-store-foo', String(local.foo))
+        }
+
+        next()
+      })
+
+      app.use(function (err, req, res, next) {
+        var local = req.asyncLocalStorage.getStore()
+
+        if (local) {
+          res.setHeader('x-store-foo', String(local.foo))
+        }
+
+        res.status(err.status || 500)
+        res.send('[' + err.type + '] ' + err.message)
+      })
+
+      app.post('/', function (req, res) {
+        res.json(req.body)
+      })
+
+      this.app = app
+    })
+
+    it('should presist store', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('user is tobi')
+        .expect(200)
+        .expect('x-store-foo', 'bar')
+        .expect('"user is tobi"')
+        .end(done)
+    })
+
+    it('should presist store when unmatched content-type', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'application/fizzbuzz')
+        .send('buzz')
+        .expect(200)
+        .expect('x-store-foo', 'bar')
+        .expect('{}')
+        .end(done)
+    })
+
+    it('should presist store when inflated', function (done) {
+      var test = request(this.app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'text/plain')
+      test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
+      test.expect(200)
+      test.expect('x-store-foo', 'bar')
+      test.expect('"name is 论"')
+      test.end(done)
+    })
+
+    it('should presist store when inflate error', function (done) {
+      var test = request(this.app).post('/')
+      test.set('Content-Encoding', 'gzip')
+      test.set('Content-Type', 'text/plain')
+      test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b0000', 'hex'))
+      test.expect(400)
+      test.expect('x-store-foo', 'bar')
+      test.end(done)
+    })
+
+    it('should presist store when limit exceeded', function (done) {
+      request(this.app)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('user is ' + Buffer.alloc(1024 * 100, '.').toString())
+        .expect(413)
+        .expect('x-store-foo', 'bar')
+        .end(done)
     })
   })
 
@@ -366,7 +519,7 @@ describe('express.text()', function () {
       var test = request(this.app).post('/')
       test.set('Content-Type', 'text/plain; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
-      test.expect(415, 'unsupported charset "X-BOGUS"', done)
+      test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
     })
   })
 
@@ -414,12 +567,12 @@ describe('express.text()', function () {
       test.expect(200, '"name is 论"', done)
     })
 
-    it('should fail on unknown encoding', function (done) {
+    it('should 415 on unknown encoding', function (done) {
       var test = request(this.app).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('000000000000', 'hex'))
-      test.expect(415, 'unsupported content encoding "nulls"', done)
+      test.expect(415, '[encoding.unsupported] unsupported content encoding "nulls"', done)
     })
   })
 })
@@ -431,7 +584,9 @@ function createApp (options) {
 
   app.use(function (err, req, res, next) {
     res.status(err.status || 500)
-    res.send(err.message)
+    res.send(String(req.headers['x-error-property']
+      ? err[req.headers['x-error-property']]
+      : ('[' + err.type + '] ' + err.message)))
   })
 
   app.post('/', function (req, res) {
@@ -439,4 +594,12 @@ function createApp (options) {
   })
 
   return app
+}
+
+function tryRequire (name) {
+  try {
+    return require(name)
+  } catch (e) {
+    return {}
+  }
 }

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -67,6 +67,21 @@ describe('res', function(){
       .expect(200, done)
     })
 
+    describe('expires', function () {
+      it('should throw on invalid date', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { expires: new Date(NaN) })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /option expires is invalid/, done)
+      })
+    })
+
     describe('maxAge', function(){
       it('should set relative expires', function(done){
         var app = express();
@@ -152,6 +167,63 @@ describe('res', function(){
         request(app)
           .get('/')
           .expect(500, /option maxAge is invalid/, done)
+      })
+    })
+
+    describe('priority', function () {
+      it('should set low priority', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { priority: 'low' })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect('Set-Cookie', /Priority=Low/)
+          .expect(200, done)
+      })
+
+      it('should set medium priority', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { priority: 'medium' })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect('Set-Cookie', /Priority=Medium/)
+          .expect(200, done)
+      })
+
+      it('should set high priority', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { priority: 'high' })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect('Set-Cookie', /Priority=High/)
+          .expect(200, done)
+      })
+
+      it('should throw with invalid priority', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { priority: 'foobar' })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /option priority is invalid/, done)
       })
     })
 

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -111,6 +111,36 @@ describe('res', function(){
         .expect(200, optionsCopy, done)
       })
 
+      it('should not throw on null', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { maxAge: null })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Set-Cookie', 'name=tobi; Path=/')
+          .end(done)
+      })
+
+      it('should not throw on undefined', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { maxAge: undefined })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Set-Cookie', 'name=tobi; Path=/')
+          .end(done)
+      })
+
       it('should throw an error with invalid maxAge', function (done) {
         var app = express()
 

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -3,8 +3,11 @@
 var after = require('after');
 var Buffer = require('safe-buffer').Buffer
 var express = require('..');
+var path = require('path')
 var request = require('supertest');
 var utils = require('./support/utils')
+
+var FIXTURES_PATH = path.join(__dirname, 'fixtures')
 
 describe('res', function(){
   describe('.download(path)', function(){
@@ -176,6 +179,77 @@ describe('res', function(){
         .expect('Content-Type', 'text/x-custom')
         .expect('Content-Disposition', 'attachment; filename="document"')
         .end(done)
+      })
+    })
+
+    describe('with "root" option', function () {
+      it('should allow relative path', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.download('name.txt', 'document', {
+            root: FIXTURES_PATH
+          })
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Content-Disposition', 'attachment; filename="document"')
+          .expect(utils.shouldHaveBody(Buffer.from('tobi')))
+          .end(done)
+      })
+
+      it('should allow up within root', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.download('fake/../name.txt', 'document', {
+            root: FIXTURES_PATH
+          })
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Content-Disposition', 'attachment; filename="document"')
+          .expect(utils.shouldHaveBody(Buffer.from('tobi')))
+          .end(done)
+      })
+
+      it('should reject up outside root', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          var p = '..' + path.sep +
+            path.relative(path.dirname(FIXTURES_PATH), path.join(FIXTURES_PATH, 'name.txt'))
+
+          res.download(p, 'document', {
+            root: FIXTURES_PATH
+          })
+        })
+
+        request(app)
+          .get('/')
+          .expect(403)
+          .expect(utils.shouldNotHaveHeader('Content-Disposition'))
+          .end(done)
+      })
+
+      it('should reject reading outside root', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.download('../name.txt', 'document', {
+            root: FIXTURES_PATH
+          })
+        })
+
+        request(app)
+          .get('/')
+          .expect(403)
+          .expect(utils.shouldNotHaveHeader('Content-Disposition'))
+          .end(done)
       })
     })
   })

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -50,7 +50,12 @@ var app3 = express();
 app3.use(function(req, res, next){
   res.format({
     text: function(){ res.send('hey') },
-    default: function(){ res.send('default') }
+    default: function (a, b, c) {
+      assert(req === a)
+      assert(res === b)
+      assert(next === c)
+      res.send('default')
+    }
   })
 });
 
@@ -117,6 +122,28 @@ describe('res', function(){
         .get('/')
         .set('Accept', '*/*')
         .expect('hey', done);
+      })
+
+      it('should be able to invoke other formatter', function (done) {
+        var app = express()
+
+        app.use(function (req, res, next) {
+          res.format({
+            json: function () { res.send('json') },
+            default: function () {
+              res.header('x-default', '1')
+              this.json()
+            }
+          })
+        })
+
+        request(app)
+          .get('/')
+          .set('Accept', 'text/plain')
+          .expect(200)
+          .expect('x-default', '1')
+          .expect('json')
+          .end(done)
       })
     })
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -283,6 +283,22 @@ describe('res', function(){
     })
   })
 
+  describe('when .statusCode is 205', function () {
+    it('should strip Transfer-Encoding field and body, set Content-Length', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.status(205).set('Transfer-Encoding', 'chunked').send('foo')
+      })
+
+      request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
+        .expect('Content-Length', '0')
+        .expect(205, '', done)
+    })
+  })
+
   describe('when .statusCode is 304', function(){
     it('should strip Content-* fields, Transfer-Encoding field, and body', function(done){
       var app = express();

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -747,7 +747,7 @@ describe('res', function(){
       })
 
       describe('when cacheControl: false', function () {
-        it('shold not send cache-control', function (done) {
+        it('should not send cache-control', function (done) {
           var app = express()
 
           app.use(function (req, res) {

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -1,21 +1,202 @@
 'use strict'
 
 var express = require('../')
-  , request = require('supertest');
+var request = require('supertest')
 
-describe('res', function(){
-  describe('.status(code)', function(){
-    it('should set the response .statusCode', function(done){
-      var app = express();
+var isIoJs = process.release
+  ? process.release.name === 'io.js'
+  : ['v1.', 'v2.', 'v3.'].indexOf(process.version.slice(0, 3)) !== -1
 
-      app.use(function(req, res){
-        res.status(201).end('Created');
-      });
+describe('res', function () {
+  describe('.status(code)', function () {
+    describe('when "code" is undefined', function () {
+      it('should raise error for invalid status code', function (done) {
+        var app = express()
 
-      request(app)
-      .get('/')
-      .expect('Created')
-      .expect(201, done);
+        app.use(function (req, res) {
+          res.status(undefined).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
+    })
+
+    describe('when "code" is null', function () {
+      it('should raise error for invalid status code', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(null).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
+    })
+
+    describe('when "code" is 201', function () {
+      it('should set the response status code to 201', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(201).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(201, done)
+      })
+    })
+
+    describe('when "code" is 302', function () {
+      it('should set the response status code to 302', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(302).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(302, done)
+      })
+    })
+
+    describe('when "code" is 403', function () {
+      it('should set the response status code to 403', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(403).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(403, done)
+      })
+    })
+
+    describe('when "code" is 501', function () {
+      it('should set the response status code to 501', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(501).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(501, done)
+      })
+    })
+
+    describe('when "code" is "410"', function () {
+      it('should set the response status code to 410', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status('410').end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(410, done)
+      })
+    })
+
+    describe('when "code" is 410.1', function () {
+      it('should set the response status code to 410', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(410.1).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(410, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
+    })
+
+    describe('when "code" is 1000', function () {
+      it('should raise error for invalid status code', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(1000).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
+    })
+
+    describe('when "code" is 99', function () {
+      it('should raise error for invalid status code', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(99).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
+    })
+
+    describe('when "code" is -401', function () {
+      it('should raise error for invalid status code', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(-401).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, function (err) {
+            if (isIoJs) {
+              done(err ? null : new Error('expected error'))
+            } else {
+              done(err)
+            }
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
This is a tracking issue for release 4.18.

**Please keep feature requests in their own issues**

If you want to make a comment on a particular change, please make the comment in the "Files changed" tab so comments are not lost during a rebase.

List of changes for release:
- [x] Add "root" option to `res.download` #4834 #4855 
- [x] Allow `options` without `filename` in `res.download`
- [x] Deprecate non-integer status codes in `res.status` #4223
- [x] Fix behavior of non-number `maxAge` in `res.cookie` #3935 #3936
- [x] Fix handling very large stacks of sync middleware #4891 
- [x] Ignore `Object.prototype` values in settings through `app.set`/`app.get` #4802 #4803
- [x] Invoke default with same arguments as types in `res.format` #3587
- [x] Support Node.js 15.x #4767
- [x] Support Node.js 16.x #4767
- [x] Support Node.js 17.x
- [x] Support Node.js 18.x
- [x] Support proper 205 responses using `res.send` #4592 #4596
- [x] Use `http-errors` for `res.format` error
- [x] Upgrade `body-parser` to 1.20.0
- [x] Upgrade `cookie` to 0.5.0
- [x] Upgrade `depd` to 2.0.0 #4174
- [x] Upgrade `finalhandler` to 1.2.0
- [x] Upgrade `send` to 0.18.0
- [x] Upgrade `serve-static` to 1.15.0
- [x] Upgrade `statuses` to 2.0.1 #4336

**Testing this release**

If you want to try out this release, you can install it with the following commands:

``` bash
$ npm cache clean express
$ npm install expressjs/express#4.18
```

Owners/collaborators: please do not merge this PR :)