### PR TITLE
Identify Framework is Express

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -58,7 +58,7 @@ app.init = function init() {
   this.cache = {};
   this.engines = {};
   this.settings = {};
-
+  this.framework = 'express';
   this.defaultConfiguration();
 };
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -35,7 +35,9 @@ var slice = Array.prototype.slice;
  * Application prototype.
  */
 
-var app = exports = module.exports = {};
+var app = exports = module.exports = {
+  name: 'express'
+};
 
 /**
  * Variable for trust proxy inheritance back-compat

--- a/lib/application.js
+++ b/lib/application.js
@@ -35,9 +35,7 @@ var slice = Array.prototype.slice;
  * Application prototype.
  */
 
-var app = exports = module.exports = {
-  name: 'express'
-};
+var app = exports = module.exports = {};
 
 /**
  * Variable for trust proxy inheritance back-compat

--- a/lib/application.js
+++ b/lib/application.js
@@ -59,6 +59,7 @@ app.init = function init() {
   this.engines = {};
   this.settings = {};
   this.framework = 'express';
+
   this.defaultConfiguration();
 };
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -35,7 +35,7 @@ exports = module.exports = createApplication;
  */
 
 function createApplication() {
-  var app = function(req, res, next) {
+  var app = function express(req, res, next) {
     app.handle(req, res, next);
   };
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -35,7 +35,7 @@ exports = module.exports = createApplication;
  */
 
 function createApplication() {
-  var app = function (req, res, next) {
+  var app = function app(req, res, next) {
     app.handle(req, res, next);
   };
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -35,7 +35,7 @@ exports = module.exports = createApplication;
  */
 
 function createApplication() {
-  var app = function express(req, res, next) {
+  var app = function (req, res, next) {
     app.handle(req, res, next);
   };
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -35,7 +35,7 @@ exports = module.exports = createApplication;
  */
 
 function createApplication() {
-  var app = function app(req, res, next) {
+  var app = function (req, res, next) {
     app.handle(req, res, next);
   };
 

--- a/test/app.js
+++ b/test/app.js
@@ -8,6 +8,7 @@ describe('app', function(){
     var app = express();
     assert.equal(app.name, 'express');
   })
+ 
   it('should inherit from event emitter', function(done){
     var app = express();
     app.on('foo', done);

--- a/test/app.js
+++ b/test/app.js
@@ -4,11 +4,11 @@ var express = require('..')
 var request = require('supertest')
 
 describe('app', function(){
-  it('should have the name "express"', function(done){
+  it('should have the name "express"', function(){
     var app = express();
     assert.equal(app.name, 'express');
   })
- 
+
   it('should inherit from event emitter', function(done){
     var app = express();
     app.on('foo', done);

--- a/test/app.js
+++ b/test/app.js
@@ -4,6 +4,10 @@ var express = require('..')
 var request = require('supertest')
 
 describe('app', function(){
+  it('should have the name "express"', function(done){
+    var app = express();
+    assert.equal(app.name, 'express');
+  })
   it('should inherit from event emitter', function(done){
     var app = express();
     app.on('foo', done);

--- a/test/app.js
+++ b/test/app.js
@@ -6,7 +6,7 @@ var request = require('supertest')
 describe('app', function(){
   it('should have the name "express"', function(){
     var app = express();
-    assert.equal(app.name, 'express');
+    assert.equal(app.framework, 'express');
   })
 
   it('should inherit from event emitter', function(done){


### PR DESCRIPTION
Adding a `name` property to the express application will enable libraries which take in `app`s from a number of different frameworks to easily identify which framework is running and take appropriate action. Alternatively, the property could be called `framework` and be an explicit property set in `init` or during the `app` variable declaration.