### PR TITLE
bump v5 router to beta.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,19 @@
 
 This incorporates all changes after 4.17.1 up to 4.17.2.
 
+  * deps: router@2.0.0-beta.1
+    - Add new `?`, `*`, and `+` parameter modifiers
+    - Internalize private `router.process_params` method
+    - Matching group expressions are only RegExp syntax
+    - Named matching groups no longer available by position in `req.params`
+    - Regular expressions can only be used in a matching group
+    - Remove `debug` dependency
+    - Special `*` path segment behavior removed
+    - deps: array-flatten@3.0.0
+    - deps: parseurl@~1.3.3
+    - deps: path-to-regexp@3.2.0
+    - deps: setprototypeof@1.2.0
+
 5.0.0-alpha.8 / 2020-03-25
 ==========================
 

--- a/examples/downloads/index.js
+++ b/examples/downloads/index.js
@@ -17,7 +17,7 @@ app.get('/', function(req, res){
 
 // /files/* is accessed via req.params[0]
 // but here we name it :file
-app.get('/files/:file(*)', function(req, res, next){
+app.get('/files/:file+', function (req, res, next) {
   var filePath = path.join(__dirname, 'files', req.params.file);
 
   res.download(filePath, function (err) {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "proxy-addr": "~2.0.7",
     "qs": "6.9.6",
     "range-parser": "~1.2.1",
-    "router": "2.0.0-alpha.1",
+    "router": "2.0.0-beta.1",
     "safe-buffer": "5.2.1",
     "send": "0.17.2",
     "serve-static": "1.14.2",

--- a/test/Router.js
+++ b/test/Router.js
@@ -344,24 +344,6 @@ describe('Router', function(){
       assert.equal(count, methods.length);
       done();
     })
-
-    it('should be called for any URL when "*"', function (done) {
-      var cb = after(4, done)
-      var router = new Router()
-
-      function no () {
-        throw new Error('should not be called')
-      }
-
-      router.all('*', function (req, res) {
-        res.end()
-      })
-
-      router.handle({ url: '/', method: 'GET' }, { end: cb }, no)
-      router.handle({ url: '/foo', method: 'GET' }, { end: cb }, no)
-      router.handle({ url: 'foo', method: 'GET' }, { end: cb }, no)
-      router.handle({ url: '*', method: 'GET' }, { end: cb }, no)
-    })
   })
 
   describe('.use', function() {

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -189,7 +189,7 @@ describe('app.router', function(){
       .expect('editing user 10', done);
     })
 
-    it.skip('should ensure regexp matches path prefix', function (done) {
+    it('should ensure regexp matches path prefix', function (done) {
       var app = express()
       var p = []
 
@@ -315,7 +315,7 @@ describe('app.router', function(){
       var app = express();
       var router = new express.Router({ mergeParams: true });
 
-      router.get('/*.*', function(req, res){
+      router.get('/(.*).(.*)', function (req, res) {
         var keys = Object.keys(req.params).sort();
         res.send(keys.map(function(k){ return [k, req.params[k]] }));
       });
@@ -331,7 +331,7 @@ describe('app.router', function(){
       var app = express();
       var router = new express.Router({ mergeParams: true });
 
-      router.get('/*', function(req, res){
+      router.get('/(.*)', function (req, res) {
         var keys = Object.keys(req.params).sort();
         res.send(keys.map(function(k){ return [k, req.params[k]] }));
       });
@@ -553,23 +553,6 @@ describe('app.router', function(){
     })
   })
 
-  it('should allow escaped regexp', function(done){
-    var app = express();
-
-    app.get('/user/\\d+', function(req, res){
-      res.end('woot');
-    });
-
-    request(app)
-    .get('/user/10')
-    .expect(200, function (err) {
-      if (err) return done(err)
-      request(app)
-      .get('/user/tj')
-      .expect(404, done);
-    });
-  })
-
   it('should allow literal "."', function(done){
     var app = express();
 
@@ -583,171 +566,6 @@ describe('app.router', function(){
     request(app)
     .get('/api/users/1..50')
     .expect('users from 1 to 50', done);
-  })
-
-  describe('*', function(){
-    it('should capture everything', function (done) {
-      var app = express()
-
-      app.get('*', function (req, res) {
-        res.end(req.params[0])
-      })
-
-      request(app)
-      .get('/user/tobi.json')
-      .expect('/user/tobi.json', done)
-    })
-
-    it('should decode the capture', function (done) {
-      var app = express()
-
-      app.get('*', function (req, res) {
-        res.end(req.params[0])
-      })
-
-      request(app)
-      .get('/user/tobi%20and%20loki.json')
-      .expect('/user/tobi and loki.json', done)
-    })
-
-    it('should denote a greedy capture group', function(done){
-      var app = express();
-
-      app.get('/user/*.json', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/user/tj.json')
-      .expect('tj', done);
-    })
-
-    it('should work with several', function(done){
-      var app = express();
-
-      app.get('/api/*.*', function(req, res){
-        var resource = req.params[0]
-          , format = req.params[1];
-        res.end(resource + ' as ' + format);
-      });
-
-      request(app)
-      .get('/api/users/foo.bar.json')
-      .expect('users/foo.bar as json', done);
-    })
-
-    it('should work cross-segment', function(done){
-      var app = express();
-
-      app.get('/api*', function(req, res){
-        res.send(req.params[0]);
-      });
-
-      request(app)
-      .get('/api')
-      .expect('', function(){
-        request(app)
-        .get('/api/hey')
-        .expect('/hey', done);
-      });
-    })
-
-    it('should allow naming', function(done){
-      var app = express();
-
-      app.get('/api/:resource(*)', function(req, res){
-        var resource = req.params.resource;
-        res.end(resource);
-      });
-
-      request(app)
-      .get('/api/users/0.json')
-      .expect('users/0.json', done);
-    })
-
-    it('should not be greedy immediately after param', function(done){
-      var app = express();
-
-      app.get('/user/:user*', function(req, res){
-        res.end(req.params.user);
-      });
-
-      request(app)
-      .get('/user/122')
-      .expect('122', done);
-    })
-
-    it('should eat everything after /', function(done){
-      var app = express();
-
-      app.get('/user/:user*', function(req, res){
-        res.end(req.params.user);
-      });
-
-      request(app)
-      .get('/user/122/aaa')
-      .expect('122', done);
-    })
-
-    it('should span multiple segments', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file/javascripts/jquery.js')
-      .expect('javascripts/jquery.js', done);
-    })
-
-    it('should be optional', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file/')
-      .expect('', done);
-    })
-
-    it('should require a preceding /', function(done){
-      var app = express();
-
-      app.get('/file/*', function(req, res){
-        res.end(req.params[0]);
-      });
-
-      request(app)
-      .get('/file')
-      .expect(404, done);
-    })
-
-    it('should keep correct parameter indexes', function(done){
-      var app = express();
-
-      app.get('/*/user/:id', function (req, res) {
-        res.send(req.params);
-      });
-
-      request(app)
-      .get('/1/user/2')
-      .expect(200, '{"0":"1","id":"2"}', done);
-    })
-
-    it('should work within arrays', function(done){
-      var app = express();
-
-      app.get(['/user/:id', '/foo/*', '/:bar'], function (req, res) {
-        res.send(req.params.bar);
-      });
-
-      request(app)
-      .get('/test')
-      .expect(200, 'test', done);
-    })
   })
 
   describe(':name', function(){
@@ -791,7 +609,7 @@ describe('app.router', function(){
       var app = express();
       var cb = after(2, done);
 
-      app.get('/user(s)?/:user/:op', function(req, res){
+      app.get('/user(s?)/:user/:op', function(req, res){
         res.end(req.params.op + 'ing ' + req.params.user + (req.params[0] ? ' (old)' : ''));
       });
 
@@ -859,6 +677,82 @@ describe('app.router', function(){
       request(app)
       .get('/user/tj/edit')
       .expect('editing tj', done);
+    })
+  })
+
+  describe(':name*', function () {
+    it('should match one segment', function (done) {
+      var app = express()
+
+      app.get('/user/:user*', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user/122')
+        .expect('122', done)
+    })
+
+    it('should match many segments', function (done) {
+      var app = express()
+
+      app.get('/user/:user*', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user/1/2/3/4')
+        .expect('1/2/3/4', done)
+    })
+
+    it('should match zero segments', function (done) {
+      var app = express()
+
+      app.get('/user/:user*', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user')
+        .expect('', done)
+    })
+  })
+
+  describe(':name+', function () {
+    it('should match one segment', function (done) {
+      var app = express()
+
+      app.get('/user/:user+', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user/122')
+        .expect(200, '122', done)
+    })
+
+    it('should match many segments', function (done) {
+      var app = express()
+
+      app.get('/user/:user+', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user/1/2/3/4')
+        .expect(200, '1/2/3/4', done)
+    })
+
+    it('should not match zero segments', function (done) {
+      var app = express()
+
+      app.get('/user/:user+', function (req, res) {
+        res.end(req.params.user)
+      })
+
+      request(app)
+        .get('/user')
+        .expect(404, done)
     })
   })
 
@@ -1199,7 +1093,7 @@ describe('app.router', function(){
     var app = express();
     var path = [];
 
-    app.get('*', function(req, res, next){
+    app.get('/:path+', function (req, res, next) {
       path.push(0);
       next();
     });
@@ -1219,7 +1113,7 @@ describe('app.router', function(){
       next();
     });
 
-    app.get('*', function(req, res, next){
+    app.get('/(.*)', function (req, res, next) {
       path.push(4);
       next();
     });


### PR DESCRIPTION
I went to test the new path-to-regexp behavior in 5.0.0-alpha.8 and realized that it relies on `router@alpha.1`, which doesn't have the new path-to-regexp behavior that's planned for v5. 

Not sure if this is intentional or not, so I wanted to open this PR as a reminder. 

I'm writing a blog post for work about changes in v5 and wanted folks to be able to try this part out. 