### PR TITLE
Add examples summary page

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Express examples
+
+This page contains list of examples using Express.
+
+- [auth](./auth) - Authentication with login and password
+- [content-negotiation](./content-negotiation) - HTTP content negotiation
+- [cookie-sessions](./cookie-sessions) - Working with cookie-based session
+- [cookies](./cookies) - Working with cookies
+- [downloads](./downloads) - Transferring files to client
+- [ejs](./ejs) - Working with Embedded JavaScript templating (ejs)
+- [error-pages](./error-pages) - Creating error pages
+- [error](./error) - Working with error middleware
+- [hello-world](./hello-world) - Simple request handler
+- [markdown](./markdown) - Markdown as template engine
+- [multi-router](./multi-router) - Working with multiple express routers
+- [multipart](./multipart) - Accepting multipart-encoded forms
+- [mvc](./mvc) - MVC style controllers
+- [online](./online) - Tracking online user activity with `online` and `redis` packages
+- [params](./params) - Working with route parameters
+- [resource](./resource) - Multiple HTTP operations on the same resource
+- [route-map](./route-map) - Organizing routes using map
+- [route-middleware](./route-middleware) - Working with route middleware
+- [route-separation](./route-separation) - Organizing routes per each resource
+- [search](./search) - Search API
+- [session](./session) - User sessions
+- [static-files](./static-files) - Serving static files
+- [vhost](./vhost) - Working with virtual hosts
+- [view-constructor](./view-constructor) - Rendering views dynamically
+- [view-locals](./view-locals) - Saving data in request object between middleware calls
+- [web-service](./web-service) - Simple API service


### PR DESCRIPTION
Following https://github.com/expressjs/express/issues/4343#issuecomment-660586365 it was decided to move content from https://github.com/expressjs/expressjs.com/pull/1178 into main express repo as a first step in popularization examples to people.

/cc @dougwilson 