### PR TITLE
Move handling of special-cased headers to improve speed

### DIFF
--- a/lib/middleware/init.js
+++ b/lib/middleware/init.js
@@ -35,6 +35,7 @@ exports.init = function(app){
     setPrototypeOf(req, app.request)
     setPrototypeOf(res, app.response)
 
+    req.setSpecialCasedHeaders();
     res.locals = res.locals || Object.create(null);
 
     next();

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,8 +40,6 @@ module.exports = req
 /**
  * Return request header.
  *
- * The `Referrer` header field is special-cased,
- * both `Referrer` and `Referer` are interchangeable.
  *
  * Examples:
  *
@@ -73,15 +71,30 @@ req.header = function header(name) {
 
   var lc = name.toLowerCase();
 
-  switch (lc) {
-    case 'referer':
-    case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
-    default:
-      return this.headers[lc];
-  }
+  return this.headers[lc];
 };
+
+/**
+ * set special-cased headers
+ *
+ * The `Referrer` header field is special-cased,
+ * both `Referrer` and `Referer` are interchangeable.
+ * So for that reason they are being set as so.
+ * Following the logic (referrer || referer)
+ * that was previously used in the header method
+ *
+ * @public
+ */
+req.setSpecialCasedHeaders = function(){
+  if (!this.headers){
+    return;
+  }
+  if (this.headers.referrer){
+    this.headers.referer = this.headers.referrer;
+  } else if (this.headers.referer){
+    this.headers.referrer = this.headers.referer;
+  }
+}
 
 /**
  * To do: update docs.


### PR DESCRIPTION
By doing this less cycles will be wasted when the method .get on the Request class is called. It follows the the same previous logic of "referrer || referer" and passes all tests.