### PR TITLE
Eliminating dependency on merge-descriptors.

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -14,7 +14,6 @@
 
 var bodyParser = require('body-parser')
 var EventEmitter = require('events').EventEmitter;
-var mixin = require('merge-descriptors');
 var proto = require('./application');
 var Router = require('router');
 var req = require('./request');
@@ -25,6 +24,22 @@ var res = require('./response');
  */
 
 exports = module.exports = createApplication;
+
+/**
+ * Merge the property descriptors of `src` into `dest`
+ *
+ * @param {object} dest Object to add descriptors to
+ * @param {object} src Object to clone descriptors from
+ * @api private
+ */
+
+function mixin(dest, src) {
+  Object.getOwnPropertyNames(src).forEach(function (name) {
+    if (!dest.hasOwnProperty(name)) {
+      Object.defineProperty(dest, name, Object.getOwnPropertyDescriptor(src, name))
+    }
+  })
+}
 
 /**
  * Create an express application.
@@ -38,8 +53,8 @@ function createApplication() {
     app.handle(req, res, next);
   };
 
-  mixin(app, EventEmitter.prototype, false);
-  mixin(app, proto, false);
+  mixin(app, EventEmitter.prototype);
+  mixin(app, proto);
 
   // expose the prototype that will get set on requests
   app.request = Object.create(req, {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "etag": "~1.8.1",
     "finalhandler": "~1.1.2",
     "fresh": "0.5.2",
-    "merge-descriptors": "1.0.1",
     "methods": "~1.1.2",
     "on-finished": "~2.3.0",
     "parseurl": "~1.3.3",


### PR DESCRIPTION
merge-descriptors only contains a single function and is only used once in the entire express project.

This PR removes the need for it as a separate dependency.