### PR TITLE
docs(examples): add links to sql database examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,4 +34,4 @@ The following list contains some ready-to-run examples that show how to use Expr
 - [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) - Fullstack app with Next.js
 - [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) - GraphQL API with `express-graphql`
 - [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) - REST API with Express in TypeScript
-- [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express): REST API with Express in JavaScript
+- [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) - REST API with Express in JavaScript

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,6 @@ This page contains list of examples using Express.
 The following list contains some ready-to-run examples that show how to use Express with a **SQL database** using [Prisma](https://github.com/prisma/prisma) as an ORM:
 
 - [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) - Fullstack app with Next.js
-- [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express): GraphQL API with `express-graphql`
+- [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) - GraphQL API with `express-graphql`
 - [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) - REST API with Express in TypeScript
 - [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express): REST API with Express in JavaScript

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,3 +28,10 @@ This page contains list of examples using Express.
 - [view-constructor](./view-constructor) - Rendering views dynamically
 - [view-locals](./view-locals) - Saving data in request object between middleware calls
 - [web-service](./web-service) - Simple API service
+
+The following list contains some ready-to-run examples that show how to use Express with a **SQL database** using [Prisma](https://github.com/prisma/prisma) as an ORM:
+
+- [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express): Fullstack app with Next.js
+- [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express): GraphQL API with `express-graphql`
+- [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express): REST API with Express in TypeScript
+- [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express): REST API with Express in JavaScript

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ This page contains list of examples using Express.
 
 The following list contains some ready-to-run examples that show how to use Express with a **SQL database** using [Prisma](https://github.com/prisma/prisma) as an ORM:
 
-- [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express): Fullstack app with Next.js
+- [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) - Fullstack app with Next.js
 - [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express): GraphQL API with `express-graphql`
 - [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express): REST API with Express in TypeScript
 - [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express): REST API with Express in JavaScript

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,5 +33,5 @@ The following list contains some ready-to-run examples that show how to use Expr
 
 - [fullstack](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) - Fullstack app with Next.js
 - [express-graphql](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express): GraphQL API with `express-graphql`
-- [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express): REST API with Express in TypeScript
+- [rest-api-ts](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) - REST API with Express in TypeScript
 - [rest-api-js](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express): REST API with Express in JavaScript

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,0 +1,9 @@
+# Database
+
+This page contains a list of ready-to-run examples that show how to use Express with SQL databases using [Prisma](https://github.com/prisma/prisma) as an ORM.
+
+- [Fullstack app with Next.js](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) (TypeScript)
+- [GraphQL API with Nexus (code-first)](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) (TypeScript)
+- [GraphQL API with `makeExecutableSchema` from `graphql-tools` (SDL-first)](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) (TypeScript)
+- [REST API](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) (TypeScript)
+- [REST API](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) (JavaScript)

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,9 +1,0 @@
-# Database
-
-This page contains a list of ready-to-run examples that show how to use Express with SQL databases using [Prisma](https://github.com/prisma/prisma) as an ORM.
-
-- [Fullstack app with Next.js](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-nextjs-express) (TypeScript)
-- [GraphQL API with Nexus (code-first)](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) (TypeScript)
-- [GraphQL API with `makeExecutableSchema` from `graphql-tools` (SDL-first)](https://github.com/prisma/prisma-examples/tree/latest/typescript/graphql-express) (TypeScript)
-- [REST API](https://github.com/prisma/prisma-examples/tree/latest/typescript/rest-express) (TypeScript)
-- [REST API](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) (JavaScript)


### PR DESCRIPTION
I'd love to add some examples to the repo that show how to use Express with a database in different scenarios, e.g. for building fullstack apps or REST and GraphQL APIs.

At Prisma, we created a number of ready-to-run [examples](https://github.com/prisma/prisma-examples/) that show how to use Express in these different scenarios. I was wondering whether I should be duplicating the examples but I think it makes more sense to just link out to them ([that's e.g. also what the Next.js folks are doing](https://github.com/vercel/next.js/tree/canary/examples/with-prisma)) because we make sure these examples are maintained, functional and als update their dependencies using renovate.

Would love to hear some thoughts on whether linking out to an external example is fine in this case or whether it's preferred to duplicate the examples?