### PR TITLE
Improve 404 response message language in web-service example

### DIFF
--- a/examples/web-service/index.js
+++ b/examples/web-service/index.js
@@ -105,7 +105,7 @@ app.use(function(err, req, res, next){
 // invoke next() and do not respond.
 app.use(function(req, res){
   res.status(404);
-  res.send({ error: "Lame, can't find that" });
+  res.send({ error: "Sorry, can't find that" })
 });
 
 /* istanbul ignore next */

--- a/test/acceptance/web-service.js
+++ b/test/acceptance/web-service.js
@@ -97,9 +97,9 @@ describe('web-service', function(){
   describe('when requesting an invalid route', function(){
     it('should respond with 404 json', function(done){
       request(app)
-      .get('/api/something?api-key=bar')
-      .expect('Content-Type', /json/)
-      .expect(404, '{"error":"Lame, can\'t find that"}', done)
+        .get('/api/something?api-key=bar')
+        .expect('Content-Type', /json/)
+        .expect(404, '{"error":"Sorry, can\'t find that"}', done)
     })
   })
 })


### PR DESCRIPTION
This is a minor improvement to the language of one of the error responses (404) from the [web-service](https://github.com/expressjs/express/tree/master/examples/web-service) example, which also makes the message clearer:

```
Sorry, can't find that
```