### PR TITLE
update version of array-flatten to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "accepts": "~1.3.7",
-    "array-flatten": "1.1.1",
+    "array-flatten": "3.0.0",
     "body-parser": "1.19.0",
     "content-disposition": "0.5.3",
     "content-type": "~1.0.4",


### PR DESCRIPTION
An express dependency, named array-flatten with version 1.1.1 is not in npm registry anymore. 
I updated the version of array-flatten to 3.0.0 (latest version)