### PR TITLE
Webpack support

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -52,7 +52,12 @@ module.exports = View;
 function View(name, options) {
   var opts = options || {};
 
-  this.defaultEngine = opts.defaultEngine;
+  if (typeof opts.defaultEngine === 'string') {
+    this.defaultEngine = opts.defaultEngine;
+  } else {
+    this.defaultEngine = opts.defaultEngine.name;
+    this.req = opts.defaultEngine.req;
+  }
   this.ext = extname(name);
   this.name = name;
   this.root = opts.root;
@@ -74,17 +79,17 @@ function View(name, options) {
 
   if (!opts.engines[this.ext]) {
     // load engine
-    var mod = this.ext.substr(1)
-    debug('require "%s"', mod)
+    var mod = this.ext.substr(1);
+    debug('require "%s"', mod);
 
     // default engine export
-    var fn = require(mod).__express
+    var fn = this.req ? this.req.__express : require(mod).__express;
 
     if (typeof fn !== 'function') {
-      throw new Error('Module "' + mod + '" does not provide a view engine.')
+      throw new Error('Module "' + mod + '" does not provide a view engine.');
     }
 
-    opts.engines[this.ext] = fn
+    opts.engines[this.ext] = fn;
   }
 
   // store loaded engine


### PR DESCRIPTION
```js
Usage : 
// normal use == no changes
app.set('view engine', 'pug');
// webpack use
const view_engine = require('pug');
app.set('view engine', { name: 'pug', req: view_engine });
```