### PR TITLE
perf: add webpack

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+webpack.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage
 
 # Benchmarking
 benchmarks/graphs
+
+# webpack bundle
+bundled

--- a/lib/view.js
+++ b/lib/view.js
@@ -77,8 +77,10 @@ function View(name, options) {
     var mod = this.ext.substr(1)
     debug('require "%s"', mod)
 
+    console.log("DIOCARO")
+
     // default engine export
-    var fn = require(mod).__express
+    var fn = process.env.WEBPACKING ? __non_webpack_require__(mod).__express : require(mod).__express
 
     if (typeof fn !== 'function') {
       throw new Error('Module "' + mod + '" does not provide a view engine.')

--- a/package.json
+++ b/package.json
@@ -76,8 +76,12 @@
     "multiparty": "4.2.1",
     "pbkdf2-password": "1.2.1",
     "should": "13.2.3",
+    "shx": "^0.3.3",
     "supertest": "4.0.2",
-    "vhost": "~3.0.2"
+    "vhost": "~3.0.2",
+    "webpack": "^5.11.1",
+    "webpack-cli": "^4.3.0",
+    "webpack-node-externals": "^2.5.2"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -86,14 +90,18 @@
     "LICENSE",
     "History.md",
     "Readme.md",
-    "index.js",
-    "lib/"
+    "bundled"
   ],
   "scripts": {
+    "clean": "rm -rf bundled",
+    "prebundle": "npm run clean",
+    "bundle": "WEBPACKING=true webpack",
     "lint": "eslint .",
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
     "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
-    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
-  }
+    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+    "prepublishOnly": "npm test && npm run bundle"
+  },
+  "main": "bundled/index.js"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
+
+module.exports = {
+    mode: 'production',
+    target: 'node',
+    entry: {
+        index: path.resolve(__dirname, 'index.js')
+    },
+    externals: [nodeExternals()],
+    optimization: {
+        nodeEnv: false
+    },
+    plugins: [
+        new webpack.DefinePlugin({ 'process.env.WEBPACKING': 'true' })
+    ],
+    output: {
+        path: path.resolve(__dirname, 'bundled'),
+        filename: 'index.js',
+        library: 'webpack',
+        libraryTarget: 'umd',
+        globalObject: 'this',
+        umdNamedDefine: true
+    }
+}


### PR DESCRIPTION
The `lib` folder and the `index.js` weigh `98,2KB`. 

This code could be bundled through `webpack` in a unique `index.js` file. After adding webpack, all the code weigh `30,0KB`, which is more than three times lower than the unbundled package.

Only the `HISTORY` file, which is included in the published npm package, weigh `109KB`, but I think that adding a bundler is always an improvement.

Hence in this pullrequest I added webpack and the npm script to bundle the package.

Changes:
- Added `webpack` deps to the dev dependencies of `package.json`
- Added a `webpack.config.js`, adding it in the `.eslintignore`
- On `view.js`, I added a `__non_webpack_require__` where there was the dynamic `require(mod)`. This is because when you require a `var`, in order to keep it as a `require` after webpacking it, you should add `__non_webpack_require__`. This does not brake the code because it is used only if `process.env.WEBPACKING` is defined, which happens only when running webpack.
- On `package.json`, as for the code, in `files`, only the generated `bundled` folder is published. A script for cleaning and bundling is added and also the `prepublishOnly` script was added.
- On `package.json`, the `main` has been set to `bundled/index.js`


