### PR TITLE
clearCookie should probably only set one header per cookie name test case

### DIFF
--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -16,6 +16,20 @@ describe('res', function(){
       .expect('Set-Cookie', 'sid=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
       .expect(200, done)
     })
+
+    it.only('should not only output one setCookie header per cookie name', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.cookie('sid', 'foo');
+        res.clearCookie('sid').end();
+      });
+
+      request(app)
+        .get("/")
+        .expect("Set-Cookie", "sid=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+        .expect(200, done)
+    })
   })
 
   describe('.clearCookie(name, options)', function(){


### PR DESCRIPTION
While developing a session termination feature in our apps I noticed that a cookie set by our session middleware to maintain cookie expiration was kept in the response even though the clearCookie was set at a later request handler. This test case attempts to replicate this circumstances.

**According to https://tools.ietf.org/html/rfc6265#section-4.1.1:**
>    Servers SHOULD NOT include more than one Set-Cookie header field in
   the same response with the same cookie-name.  (See Section 5.2 for
   how user agents handle this case.)

Do you want filtration of setCookie-headers like this case to be handled within the expressjs framework, if so I could create a PR to fix that, or is this something that should be handled by expressjs users?