### PR TITLE
Typo in example CSS

### DIFF
--- a/examples/ejs/public/stylesheets/style.css
+++ b/examples/ejs/public/stylesheets/style.css
@@ -1,4 +1,4 @@
 body {
   padding: 50px 80px;
-  font: 14px "Helvetica Nueue", "Lucida Grande", Arial, sans-serif;
+  font: 14px "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
 }


### PR DESCRIPTION
Fixed the spelling of `Helvetica Neue`.