### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           node-version: "11.15"
 
         - name: Node.js 12.x
-          node-version: "12.18"
+          node-version: "12.22"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           npm-i: mocha@7.2.0
 
         - name: Node.js 10.x
-          node-version: "10.23"
+          node-version: "10.24"
 
         - name: Node.js 11.x
           node-version: "11.15"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - nodejs_version: "5.12"
     - nodejs_version: "6.17"
     - nodejs_version: "7.10"
-    - nodejs_version: "8.16"
+    - nodejs_version: "8.17"
     - nodejs_version: "9.11"
     - nodejs_version: "10.23"
     - nodejs_version: "11.15"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     - nodejs_version: "9.11"
     - nodejs_version: "10.24"
     - nodejs_version: "11.15"
-    - nodejs_version: "12.18"
+    - nodejs_version: "12.22"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - nodejs_version: "7.10"
     - nodejs_version: "8.17"
     - nodejs_version: "9.11"
-    - nodejs_version: "10.23"
+    - nodejs_version: "10.24"
     - nodejs_version: "11.15"
     - nodejs_version: "12.18"
 cache:


### PR DESCRIPTION
- Update 12 series to Node.js@12.22
- Update 10 series to Node.js@10.24
- Fix missing Node.js@8.17 in AppVeyor (Travis CI was using 8.17 but AppVeyor was using 8.16)

Signed-off-by: Aravind Nair <22199259+aravindvnair99@users.noreply.github.com>