### PR TITLE
remove duplicates

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -261,7 +261,7 @@ res.json = function json(obj) {
 
   // content-type
   if (!this.get('Content-Type')) {
-    this.set('Content-Type', 'application/json');
+    this.set('Content-Type', 'application/json; charset=utf-8');
   }
 
   return this.send(body);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -157,15 +157,13 @@ exports.compileETag = function(val) {
 
   switch (val) {
     case true:
+    case 'weak':	
       fn = exports.wetag;
       break;
     case false:
       break;
     case 'strong':
       fn = exports.etag;
-      break;
-    case 'weak':
-      fn = exports.wetag;
       break;
     default:
       throw new TypeError('unknown value for etag function: ' + val);
@@ -191,6 +189,7 @@ exports.compileQueryParser = function compileQueryParser(val) {
 
   switch (val) {
     case true:
+    case 'simple':
       fn = querystring.parse;
       break;
     case false:
@@ -198,9 +197,6 @@ exports.compileQueryParser = function compileQueryParser(val) {
       break;
     case 'extended':
       fn = parseExtendedQueryString;
-      break;
-    case 'simple':
-      fn = querystring.parse;
       break;
     default:
       throw new TypeError('unknown value for query parser function: ' + val);


### PR DESCRIPTION

lib/utils.js
The body of this case clause [:167] duplicates the body of this case clause [:159]. This may be caused by a copy-paste error. remove-duplicates

lib/response.js
Content-type application/json [:264] set in set [:264] does not specify a charset. Add charset=utf-8 or another charset.
