### PR TITLE
Check for invalid or unknown http status codes.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -64,6 +64,14 @@ var charsetRegExp = /;\s*charset\s*=/;
  */
 
 res.status = function status(code) {
+
+  if (
+    !Object.keys(http.STATUS_CODES).find(
+      (statuscode) => statuscode == code
+    )
+  )
+    throw new TypeError(`${code} is not a valid http status code.`);	
+
   this.statusCode = code;
   return this;
 };

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -16,5 +16,14 @@ describe('res', function(){
       .expect('Created')
       .expect(201, done);
     })
+    it("should throw an error internal server error for invalid status code.", function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(209).end();
+      });
+
+      request(app).get("/").expect(500, done);
+    });
   })
 })


### PR DESCRIPTION
Nodejs http module does not throw any error for invalid ( undefined http response codes ) up to 999. Any typo ( like 209  instead of 208 [  Already Reported ] or 309 instead of 308 [ Permanent Redirect]  ) might causes inconvenience at the frontend. **An error message throw by express can prevent this.**

Code:
``` javascript
const express = require("express");

const app = express();
const PORT = 8000

app.get("/", (req, res) => {
  res.status(209).json({
    data:"test"
  });
});

app.listen(PORT, () => {
  console.log("App is running");
});
```

Before change 

![Before](https://user-images.githubusercontent.com/63335023/119265122-3b416f80-bc03-11eb-9ae0-99328a60e491.PNG)

1. The response data is passed.
2. Postman marks the status code as unknown

After change

![After](https://user-images.githubusercontent.com/63335023/119265163-5ca25b80-bc03-11eb-984b-fb47310b6498.png)

1. A 500 - Internal Server Error is thrown
2.  A error message is displayed (  TypeError: 209 is not a valid http status code.  )