### PR TITLE
Fixing the express error handling for async functions

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -98,7 +98,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     * otherwise obj is undefined and the fn errors can normally
     * be catched in a try/catch block.
     */
-    const obj = fn(req, res, next);
+    var obj = fn(req, res, next);
     if(obj && typeof obj.catch === 'function') {
       obj.catch((err) => { // Promise <rejected>
         next(err)

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -92,7 +92,18 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next);
+    /*
+    * if it is an async function it will return a Promise and
+    * the error must be handled with a Promise.catch method,
+    * otherwise obj is undefined and the fn errors can normally
+    * be catched in a try/catch block.
+    */, 
+    const obj = fn(req, res, next);
+    if(obj && typeof obj.catch === 'function') {
+      obj.catch((err) => { // Promise <rejected>
+        next(err)
+      })
+    }
   } catch (err) {
     next(err);
   }

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -100,8 +100,8 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     */
     var obj = fn(req, res, next);
     if(obj && typeof obj.catch === 'function') {
-      obj.catch((err) => { // Promise <rejected>
-        next(err)
+      obj.catch(function callback(err) { // Promise <rejected>
+        next(err);
       })
     }
   } catch (err) {

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -97,7 +97,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     * the error must be handled with a Promise.catch method,
     * otherwise obj is undefined and the fn errors can normally
     * be catched in a try/catch block.
-    */, 
+    */
     const obj = fn(req, res, next);
     if(obj && typeof obj.catch === 'function') {
       obj.catch((err) => { // Promise <rejected>


### PR DESCRIPTION
The try/catch block does not handle errors of async functions and they cannot be forwarded (next) to the proper error middleware, as done with sync functions. Instead, if an exception is thrown from an async function, this exception will be returned as a <rejected> Promise, that must be handled on a Promise.catch() method.

We cannot simply await async functions to handle it synchronous in this section of code to only enable try/catch block to handle async exceptions, it would not make sense.