### PR TITLE
Set CI fail-fast to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         name:
         - Node.js 0.10


### PR DESCRIPTION
Documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

This helps us understand if something is failing only on a particular configuration as opposed to us having only partial stats up until failure. Hence, I recommend setting it to false.