### PR TITLE
docs: replace "sentHeader" with "headersSent" in jsdoc

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -364,7 +364,7 @@ res.sendStatus = function sendStatus(statusCode) {
  *
  * Automatically sets the _Content-Type_ response header field.
  * The callback `callback(err)` is invoked when the transfer is complete
- * or when an error occurs. Be sure to check `res.sentHeader`
+ * or when an error occurs. Be sure to check `res.headersSent`
  * if you wish to attempt responding, as the header and some data
  * may have already been transferred.
  *
@@ -446,7 +446,7 @@ res.sendFile = function sendFile(path, options, callback) {
  *
  * Automatically sets the _Content-Type_ response header field.
  * The callback `callback(err)` is invoked when the transfer is complete
- * or when an error occurs. Be sure to check `res.sentHeader`
+ * or when an error occurs. Be sure to check `res.headersSent`
  * if you wish to attempt responding, as the header and some data
  * may have already been transferred.
  *


### PR DESCRIPTION
When I use res.sendFile, I want to return json information on error. The code ran fine for months, but one day the code suddenly crashed and said "Cannot set headers after they are sent to the client" because I didn't check res.headersSent.