### PR TITLE
tests: make app.listen test shorter

### DIFF
--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -5,10 +5,6 @@ describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
     var app = express();
 
-    app.del('/tobi', function(req, res){
-      res.end('deleted tobi!');
-    });
-
     var server = app.listen(9999, function(){
       server.close();
       done();


### PR DESCRIPTION
The `app.del` endpoint is not necessary for this particular test.