### PR TITLE
res.json & "json escape" should always return json

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Fix handling of `undefined` in `res.jsonp`
+  * Fix handling of `undefined` when `"json escape"` is enabled
   * Fix incorrect middleware execution with unanchored `RegExp`s
   * Fix `res.jsonp(obj, status)` deprecation message
   * Fix typo in `res.is` JSDoc

--- a/lib/response.js
+++ b/lib/response.js
@@ -1127,7 +1127,7 @@ function stringify (value, replacer, spaces, escape) {
     ? JSON.stringify(value, replacer, spaces)
     : JSON.stringify(value);
 
-  if (escape) {
+  if (escape && typeof json === 'string') {
     json = json.replace(/[<>&]/g, function (c) {
       switch (c.charCodeAt(0)) {
         case 0x3c:

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -122,6 +122,21 @@ describe('res', function(){
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect(200, '{"\\u0026":"\\u003cscript\\u003e"}', done)
       })
+
+      it('should not break undefined escape', function (done) {
+        var app = express()
+
+        app.enable('json escape')
+
+        app.use(function (req, res) {
+          res.json(undefined)
+        })
+
+        request(app)
+          .get('/')
+          .expect('Content-Type', 'application/json; charset=utf-8')
+          .expect(200, '', done)
+      })
     })
 
     describe('"json replacer" setting', function(){

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -266,6 +266,21 @@ describe('res', function(){
         .expect('Content-Type', 'text/javascript; charset=utf-8')
         .expect(200, /foo\({"\\u0026":"\\u2028\\u003cscript\\u003e\\u2029"}\)/, done)
       })
+
+      it('should not break undefined escape', function (done) {
+        var app = express()
+
+        app.enable('json escape')
+
+        app.use(function (req, res) {
+          res.jsonp(undefined)
+        })
+
+        request(app)
+          .get('/?callback=cb')
+          .expect('Content-Type', 'text/javascript; charset=utf-8')
+          .expect(200, /cb\(\)/, done)
+      })
     })
 
     describe('"json replacer" setting', function(){


### PR DESCRIPTION
When using the "json escape" setting, `res.json` was returning `text/html` response when being called with a falsy value such as `undefined`. `JSON.stringify()` can return `undefined` so this guards against that before using `String.replace()`.