### PR TITLE
Add CloudFront-Forwarded-Proto support

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -294,7 +294,7 @@ defineGetter(req, 'protocol', function protocol(){
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  var header = this.get('X-Forwarded-Proto') || proto
+  var header = this.get('X-Forwarded-Proto') || this.get('CloudFront-Forwarded-Proto') || proto
   var index = header.indexOf(',')
 
   return index !== -1

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -32,6 +32,21 @@ describe('req', function(){
         .expect('https', done);
       })
 
+      it('should respect CloudFront-Forwarded-Proto', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('CloudFront-Forwarded-Proto', 'https')
+        .expect('https', done);
+      })
+
       it('should default to the socket addr if X-Forwarded-Proto not present', function(done){
         var app = express();
 

--- a/test/req.secure.js
+++ b/test/req.secure.js
@@ -96,5 +96,82 @@ describe('req', function(){
         })
       })
     })
+
+    describe('when CloudFront-Forwarded-Proto is present', function(){
+      it('should return false when http', function(done){
+        var app = express();
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('CloudFront-Forwarded-Proto', 'https')
+        .expect('no', done)
+      })
+
+      it('should return true when "trust proxy" is enabled', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('CloudFront-Forwarded-Proto', 'https')
+        .expect('yes', done)
+      })
+
+      it('should return false when initial proxy is http', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('CloudFront-Forwarded-Proto', 'http, https')
+        .expect('no', done)
+      })
+
+      it('should return true when initial proxy is https', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.get('/', function(req, res){
+          res.send(req.secure ? 'yes' : 'no');
+        });
+
+        request(app)
+        .get('/')
+        .set('CloudFront-Forwarded-Proto', 'https, http')
+        .expect('yes', done)
+      })
+
+      describe('when "trust proxy" trusting hop count', function () {
+        it('should respect CloudFront-Forwarded-Proto', function (done) {
+          var app = express();
+
+          app.set('trust proxy', 1);
+
+          app.get('/', function (req, res) {
+            res.send(req.secure ? 'yes' : 'no');
+          });
+
+          request(app)
+          .get('/')
+          .set('CloudFront-Forwarded-Proto', 'https')
+          .expect('yes', done)
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Hi,

I know it is not a very standard header to support to, but it has been very hard to patch expressjs every time we need to use CloudFront in front of a bare express app. I am not sure why AWS does not stick to the standard headers in the first place.

Would it be possible to add support for the `CloudFront-Forwarded-Proto` header as I have demonstrated in this pull request?