### PR TITLE
Correct one app.head test based on test description

### DIFF
--- a/test/app.head.js
+++ b/test/app.head.js
@@ -26,7 +26,7 @@ describe('HEAD', function(){
     });
 
     request(app)
-    .get('/tobi')
+    .head('/tobi')
     .expect(200, function(err, res){
       if (err) return done(err);
       var headers = res.headers;


### PR DESCRIPTION
Happened to notice it while reading the tests (might just be a typo):
https://github.com/expressjs/express/blob/master/test/app.head.js#L29-L34

Based on the test description `should output the same headers as GET requests`, I think it should've been to validate the `head` requests and `get` requests have the same headers.