### PR TITLE
lib: fix typo ocurred -> occurred

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -524,7 +524,7 @@ res.sendfile = deprecate.function(res.sendfile,
  * Optionally providing an alternate attachment `filename`,
  * and optional callback `callback(err)`. The callback is invoked
  * when the data transfer is complete, or when an error has
- * ocurred. Be sure to check `res.headersSent` if you plan to respond.
+ * occurred. Be sure to check `res.headersSent` if you plan to respond.
  *
  * Optionally providing an `options` object to use with `res.sendFile()`.
  * This function will set the `Content-Disposition` header, overriding


### PR DESCRIPTION
- `lib/response.js`: ocurred -> **occurred**