### PR TITLE
chore(std bump): Updated debug's version to 4.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.4.2",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.9",
+    "debug": "4.3.3",
     "depd": "~1.1.2",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
There's an issue with debug showing different timestamp formats on different versions. As far as I'm aware it introduces no errors to upgrade.

https://github.com/debug-js/debug/issues/867

@Qix- asked to be mentioned