### PR TITLE
replace wierd syntax with clear expression

### DIFF
--- a/examples/web-service/index.js
+++ b/examples/web-service/index.js
@@ -34,7 +34,7 @@ app.use('/api', function(req, res, next){
   if (!key) return next(error(400, 'api key required'));
 
   // key is invalid
-  if (!~apiKeys.indexOf(key)) return next(error(401, 'invalid api key'));
+  if (apiKeys.indexOf(key) === -1) return next(error(401, 'invalid api key'))
 
   // all good, store req.key for route access
   req.key = key;


### PR DESCRIPTION
The use of `!~` hides the completely understandable `apiKeys.indexOf(key) < 0` or `if(!apiKeys.includes(key))`.
Since this is example code, this should be crisp and clean. 
I don't see any advantage or improvement in the use of a "bitwise negation of -1 is 0 and thus falsy, so I can use a boolean not on it for my if statement" to replace a straight "result is less than 0". I even would consider it is slower than a simple compare, since it's two operations. The newer API (includes) is even more literate in coding style. 
I suggest this is fixed.