### PR TITLE
Use object with null prototype for settings

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -32,7 +32,6 @@ var setPrototypeOf = require('setprototypeof')
  * @private
  */
 
-var hasOwnProperty = Object.prototype.hasOwnProperty
 var slice = Array.prototype.slice;
 
 /**
@@ -63,7 +62,7 @@ app.init = function init() {
 
   this.cache = {};
   this.engines = {};
-  this.settings = {};
+  this.settings = Object.create(null);
 
   this.defaultConfiguration();
 
@@ -353,17 +352,7 @@ app.param = function param(name, fn) {
 app.set = function set(setting, val) {
   if (arguments.length === 1) {
     // app.get(setting)
-    var settings = this.settings
-
-    while (settings && settings !== Object.prototype) {
-      if (hasOwnProperty.call(settings, setting)) {
-        return settings[setting]
-      }
-
-      settings = Object.getPrototypeOf(settings)
-    }
-
-    return undefined
+    return this.settings[setting];
   }
 
   debug('set "%s" to %o', setting, val);


### PR DESCRIPTION
`express().settings` is now an object with a `null` prototype. This simplifies the code.