### PR TITLE
docs: replace "replaces" with "replacer" in jsdoc

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1113,7 +1113,7 @@ function sendfile(res, file, options, callback) {
  * ability to escape characters that can trigger HTML sniffing.
  *
  * @param {*} value
- * @param {function} replaces
+ * @param {function} replacer
  * @param {number} spaces
  * @param {boolean} escape
  * @returns {string}


### PR DESCRIPTION
I hope it helps.