### PR TITLE
Use es6 template literal syntax for logging errors

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -109,7 +109,7 @@ var removedMiddlewares = [
 removedMiddlewares.forEach(function (name) {
   Object.defineProperty(exports, name, {
     get: function () {
-      throw new Error('Most middleware (like ' + name + ') is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.');
+      throw new Error(`Most middleware (like ${name}) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.`);
     },
     configurable: true
   });


### PR DESCRIPTION
I have changed the code from using the old style of concatenating strings using + and have used es6 string literals.