### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -108,8 +108,8 @@ proto.param = function param(name, fn) {
   var ret;
 
   if (name[0] === ':') {
-    deprecate('router.param(' + JSON.stringify(name) + ', fn): Use router.param(' + JSON.stringify(name.substr(1)) + ', fn) instead');
-    name = name.substr(1);
+    deprecate('router.param(' + JSON.stringify(name) + ', fn): Use router.param(' + JSON.stringify(name.slice(1)) + ', fn) instead')
+    name = name.slice(1)
   }
 
   for (var i = 0; i < len; ++i) {
@@ -180,14 +180,14 @@ proto.handle = function handle(req, res, out) {
 
     // remove added slash
     if (slashAdded) {
-      req.url = req.url.substr(1);
+      req.url = req.url.slice(1)
       slashAdded = false;
     }
 
     // restore altered req.url
     if (removed.length !== 0) {
       req.baseUrl = parentUrl;
-      req.url = protohost + removed + req.url.substr(protohost.length);
+      req.url = protohost + removed + req.url.slice(protohost.length)
       removed = '';
     }
 
@@ -288,7 +288,7 @@ proto.handle = function handle(req, res, out) {
   function trim_prefix(layer, layerError, layerPath, path) {
     if (layerPath.length !== 0) {
       // Validate path is a prefix match
-      if (layerPath !== path.substr(0, layerPath.length)) {
+      if (layerPath !== path.slice(0, layerPath.length)) {
         next(layerError)
         return
       }
@@ -301,7 +301,7 @@ proto.handle = function handle(req, res, out) {
       // middleware (.use stuff) needs to have the path stripped
       debug('trim prefix (%s) from url %s', layerPath, req.url);
       removed = layerPath;
-      req.url = protohost + req.url.substr(protohost.length + removed.length);
+      req.url = protohost + req.url.slice(protohost.length + removed.length)
 
       // Ensure leading slash
       if (!protohost && req.url[0] !== '/') {
@@ -547,10 +547,10 @@ function getProtohost(url) {
   var pathLength = searchIndex !== -1
     ? searchIndex
     : url.length
-  var fqdnIndex = url.substr(0, pathLength).indexOf('://')
+  var fqdnIndex = url.slice(0, pathLength).indexOf('://')
 
   return fqdnIndex !== -1
-    ? url.substr(0, url.indexOf('/', 3 + fqdnIndex))
+    ? url.substring(0, url.indexOf('/', 3 + fqdnIndex))
     : undefined
 }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -74,7 +74,7 @@ function View(name, options) {
 
   if (!opts.engines[this.ext]) {
     // load engine
-    var mod = this.ext.substr(1)
+    var mod = this.ext.slice(1)
     debug('require "%s"', mod)
 
     // default engine export


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.