### PR TITLE
Use object with null prototype for various app properties

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -61,9 +61,9 @@ var trustProxyDefaultSymbol = '@@symbol:trust_proxy_default';
 app.init = function init() {
   var router = null;
 
-  this.cache = {};
-  this.engines = {};
-  this.settings = {};
+  this.cache = Object.create(null);
+  this.engines = Object.create(null);
+  this.settings = Object.create(null);
 
   this.defaultConfiguration();
 

--- a/test/app.locals.js
+++ b/test/app.locals.js
@@ -5,10 +5,11 @@ var express = require('../')
 
 describe('app', function(){
   describe('.locals', function () {
-    it('should default object', function () {
+    it('should default object with null prototype', function () {
       var app = express()
       assert.ok(app.locals)
       assert.strictEqual(typeof app.locals, 'object')
+      assert.strictEqual(Object.getPrototypeOf(app.locals), null)
     })
 
     describe('.settings', function () {


### PR DESCRIPTION
See [discussion here](https://github.com/expressjs/express/pull/4835#discussion_r811355575).

`app.cache`, `app.engines`, and `app.settings` are now created with `Object.create(null)` instead of `{}`.

This also adds a test that `app.locals` is created the same way.