### PR TITLE
docs: fix typo: http -> HTTP

### DIFF
--- a/Charter.md
+++ b/Charter.md
@@ -9,7 +9,7 @@ also easily visible to outsiders.
 
 ## Section 1: Scope
 
-Express is a http web server framework with a simple and expressive API
+Express is a HTTP web server framework with a simple and expressive API
 which is highly aligned with Node.js core. We aim to be the best in
 class for writing performant, spec compliant, and powerful web servers
 in Node.js. As one of the oldest and most popular web frameworks in
@@ -24,7 +24,7 @@ Express is made of many modules spread between three GitHub Orgs:
   libraries
 - [pillarjs](http://github.com/pillarjs/): Components which make up
   Express but can also be used for other web frameworks
-- [jshttp](http://github.com/jshttp/): Low level http libraries
+- [jshttp](http://github.com/jshttp/): Low level HTTP libraries
 
 ### 1.2: Out-of-Scope
 


### PR DESCRIPTION
Noticed this while going through the docs and code. Apologies if this is a non-trivial one.
I hope to be able to make a meaningful contribution should I come across anything while trying
to understand expressjs's internals.

Cheers! 😄