### PR TITLE
Expanding the benchmark.

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,13 +1,17 @@
 
 all:
-	@./run 1 middleware
-	@./run 5 middleware
-	@./run 10 middleware
-	@./run 15 middleware
-	@./run 20 middleware
-	@./run 30 middleware
-	@./run 50 middleware
-	@./run 100 middleware
+	@./run 1 middleware 50
+	@./run 5 middleware 50
+	@./run 10 middleware 50
+	@./run 15 middleware 50
+	@./run 20 middleware 50
+	@./run 30 middleware 50
+	@./run 50 middleware 50
+	@./run 100 middleware 50
+	@./run 10 middleware 100
+	@./run 10 middleware 250
+	@./run 10 middleware 500
+	@./run 10 middleware 1000
 	@echo
 
 .PHONY: all

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -4,13 +4,15 @@ echo
 MW=$1 node $2 &
 pid=$!
 
+echo "  $3 connections"
+
 sleep 2
 
 wrk 'http://localhost:3333/?foo[bar]=baz' \
   -d 3 \
-  -c 50 \
+  -c $3 \
   -t 8 \
-  | grep 'Requests/sec' \
-  | awk '{ print "  " $2 }'
+  | grep 'Requests/sec\|Latency' \
+  | awk '{ print " " $2 }'
 
 kill $pid


### PR DESCRIPTION
This pull request expands the existing benchmark to also check for varying connections, and to also show average latency (instead of just reqs/sec).

This is a simple change but I think it is important since the existing benchmark is 8 years old and is lacking in a lot of ways. In the future it can be further expanded or be completely rewritten to provide a better view of Express's performance.