### PR TITLE
Increase timeout for mocha to 7500

### DIFF
--- a/test/Router.js
+++ b/test/Router.js
@@ -62,6 +62,8 @@ describe('Router', function(){
   })
 
   it('should not stack overflow with many registered routes', function(done){
+    this.timeout(5000) // long-running test
+
     var handler = function(req, res){ res.end(new Error('wrong handler')) };
     var router = new Router();
 


### PR DESCRIPTION
In order to fix some timeout issues in the CI on low-end hardware we increase
the timeout for mocha to 7500ms.

This is a proposed fix for https://github.com/expressjs/express/issues/4886