### PR TITLE
App.listen() only accepting numbers

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -631,6 +631,10 @@ app.render = function render(name, options, callback) {
  */
 
 app.listen = function listen() {
+  var portNumber = arguments[0]; //port number
+  if(portNumber && !Number(portNumber)){
+    throw new TypeError('Param port must be a number')
+  }
   var server = http.createServer(this);
   return server.listen.apply(server, arguments);
 };

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -1,14 +1,22 @@
 'use strict'
 
 var express = require('../')
+var assert = require('assert')
 
 describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
     var app = express();
 
-    var server = app.listen(9999, function(){
+    var server = app.listen('1200', function(){
       server.close();
       done();
     });
+  })
+  it('should only accept numbers for port param', function(done){
+    var app = express();
+    assert.throws(function() { app.listen('foo', function(){
+      server.close();
+    }); }, TypeError);
+    done();
   })
 })

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -7,7 +7,7 @@ describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
     var app = express();
 
-    var server = app.listen('1200', function(){
+    var server = app.listen(9999, function(){
       server.close();
       done();
     });


### PR DESCRIPTION
Based on the network procotol: A port number is a 16-bit unsigned integer, thus ranging from 0 to 65535. So we cant use strings for ports. This PR fix this.

