### PR TITLE
Limit the maxAge of cookies to prevent cookie errors

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -855,6 +855,7 @@ res.cookie = function (name, value, options) {
   var opts = merge({}, options);
   var secret = this.req.secret;
   var signed = opts.signed;
+  var maxAgeLimit = new Date('3000-01-01').getTime();
 
   if (signed && !secret) {
     throw new Error('cookieParser("secret") required for signed cookies');
@@ -872,6 +873,7 @@ res.cookie = function (name, value, options) {
     var maxAge = opts.maxAge - 0
 
     if (!isNaN(maxAge)) {
+      maxAge = Math.min(maxAge, maxAgeLimit)
       opts.expires = new Date(Date.now() + maxAge)
       opts.maxAge = Math.floor(maxAge / 1000)
     }


### PR DESCRIPTION
The `cookie` library [now validates expires to be valid dates](https://github.com/jshttp/cookie/commit/042073f1d679b9c7fb7d64660d3c6d372bd1f468). This PR helps prevent unexpected errors when someone sets the maxAge to some crazy high number.