### PR TITLE
docs: use real-world example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,9 @@
 const http = require('http')
 const express = require('express')
 const server = express()
-const app = new express.Router()
+const app = express.Router()
 
-server.use(app)
+server.use('/', app)
 app.get('/', function (req, res) {
   res.send('Hello World')
 })

--- a/Readme.md
+++ b/Readme.md
@@ -7,14 +7,17 @@
   [![NPM Downloads][npm-downloads-image]][npm-downloads-url]
 
 ```js
+const http = require('http')
 const express = require('express')
-const app = express()
+const server = express()
+const app = new express.Router()
 
+server.use(app)
 app.get('/', function (req, res) {
   res.send('Hello World')
 })
 
-app.listen(3000)
+http.createServer(server).listen(3000)
 ```
 
 ## Installation


### PR DESCRIPTION
My assumption is that the example in the Readme was intended to be cute and as few lines as possible.

However, this really does a disservice to any novice encountering express for the first time (and it seems many seasoned devs still use the anti-patterns presented in that example).

## Use the standard `http` server

Wrapping the default `http` server is confusing because it abstracts something that has no more complexity than what it abstracts.

Using a wrapped server makes it non-obvious how to handle websockets, and how to work with other implementations of the http stack (granted, there are few).

## Use the standard `Router`

Most novices are not aware of the nuance of nested apps and how it effects state. Better to just show the simple example with the Router rather than using a shortcut that leads to unexpected behavior