### PR TITLE
express-close-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 package-lock.json
 *.log
 *.gz
+.npmrc
 
 # Coveralls
 .nyc_output

--- a/lib/application.js
+++ b/lib/application.js
@@ -6,50 +6,50 @@
  * MIT Licensed
  */
 
-'use strict';
+"use strict";
 
 /**
  * Module dependencies.
  * @private
  */
 
-var finalhandler = require('finalhandler');
-var Router = require('./router');
-var methods = require('methods');
-var middleware = require('./middleware/init');
-var query = require('./middleware/query');
-var debug = require('debug')('express:application');
-var View = require('./view');
-var http = require('http');
-var compileETag = require('./utils').compileETag;
-var compileQueryParser = require('./utils').compileQueryParser;
-var compileTrust = require('./utils').compileTrust;
-var deprecate = require('depd')('express');
-var flatten = require('array-flatten');
-var merge = require('utils-merge');
-var resolve = require('path').resolve;
-var setPrototypeOf = require('setprototypeof')
+var finalhandler = require("finalhandler");
+var Router = require("./router");
+var methods = require("methods");
+var middleware = require("./middleware/init");
+var query = require("./middleware/query");
+var debug = require("debug")("express:application");
+var View = require("./view");
+var http = require("http");
+var compileETag = require("./utils").compileETag;
+var compileQueryParser = require("./utils").compileQueryParser;
+var compileTrust = require("./utils").compileTrust;
+var deprecate = require("depd")("express");
+var flatten = require("array-flatten");
+var merge = require("utils-merge");
+var resolve = require("path").resolve;
+var setPrototypeOf = require("setprototypeof");
 
 /**
  * Module variables.
  * @private
  */
 
-var hasOwnProperty = Object.prototype.hasOwnProperty
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 var slice = Array.prototype.slice;
 
 /**
  * Application prototype.
  */
 
-var app = exports = module.exports = {};
+var app = (exports = module.exports = {});
 
 /**
  * Variable for trust proxy inheritance back-compat
  * @private
  */
 
-var trustProxyDefaultSymbol = '@@symbol:trust_proxy_default';
+var trustProxyDefaultSymbol = "@@symbol:trust_proxy_default";
 
 /**
  * Initialize the server.
@@ -65,6 +65,7 @@ app.init = function init() {
   this.cache = {};
   this.engines = {};
   this.settings = {};
+  this.servers = new Map();
 
   this.defaultConfiguration();
 };
@@ -75,61 +76,65 @@ app.init = function init() {
  */
 
 app.defaultConfiguration = function defaultConfiguration() {
-  var env = process.env.NODE_ENV || 'development';
+  var env = process.env.NODE_ENV || "development";
 
   // default settings
-  this.enable('x-powered-by');
-  this.set('etag', 'weak');
-  this.set('env', env);
-  this.set('query parser', 'extended');
-  this.set('subdomain offset', 2);
-  this.set('trust proxy', false);
+  this.enable("x-powered-by");
+  this.set("etag", "weak");
+  this.set("env", env);
+  this.set("query parser", "extended");
+  this.set("subdomain offset", 2);
+  this.set("trust proxy", false);
 
   // trust proxy inherit back-compat
   Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
     configurable: true,
-    value: true
+    value: true,
   });
 
-  debug('booting in %s mode', env);
+  debug("booting in %s mode", env);
 
-  this.on('mount', function onmount(parent) {
+  this.on("mount", function onmount(parent) {
     // inherit trust proxy
-    if (this.settings[trustProxyDefaultSymbol] === true
-      && typeof parent.settings['trust proxy fn'] === 'function') {
-      delete this.settings['trust proxy'];
-      delete this.settings['trust proxy fn'];
+    if (
+      this.settings[trustProxyDefaultSymbol] === true &&
+      typeof parent.settings["trust proxy fn"] === "function"
+    ) {
+      delete this.settings["trust proxy"];
+      delete this.settings["trust proxy fn"];
     }
 
     // inherit protos
-    setPrototypeOf(this.request, parent.request)
-    setPrototypeOf(this.response, parent.response)
-    setPrototypeOf(this.engines, parent.engines)
-    setPrototypeOf(this.settings, parent.settings)
+    setPrototypeOf(this.request, parent.request);
+    setPrototypeOf(this.response, parent.response);
+    setPrototypeOf(this.engines, parent.engines);
+    setPrototypeOf(this.settings, parent.settings);
   });
 
   // setup locals
   this.locals = Object.create(null);
 
   // top-most app is mounted at /
-  this.mountpath = '/';
+  this.mountpath = "/";
 
   // default locals
   this.locals.settings = this.settings;
 
   // default configuration
-  this.set('view', View);
-  this.set('views', resolve('views'));
-  this.set('jsonp callback name', 'callback');
+  this.set("view", View);
+  this.set("views", resolve("views"));
+  this.set("jsonp callback name", "callback");
 
-  if (env === 'production') {
-    this.enable('view cache');
+  if (env === "production") {
+    this.enable("view cache");
   }
 
-  Object.defineProperty(this, 'router', {
-    get: function() {
-      throw new Error('\'app.router\' is deprecated!\nPlease see the 3.x to 4.x migration guide for details on how to update your app.');
-    }
+  Object.defineProperty(this, "router", {
+    get: function () {
+      throw new Error(
+        "'app.router' is deprecated!\nPlease see the 3.x to 4.x migration guide for details on how to update your app."
+      );
+    },
   });
 };
 
@@ -144,11 +149,11 @@ app.defaultConfiguration = function defaultConfiguration() {
 app.lazyrouter = function lazyrouter() {
   if (!this._router) {
     this._router = new Router({
-      caseSensitive: this.enabled('case sensitive routing'),
-      strict: this.enabled('strict routing')
+      caseSensitive: this.enabled("case sensitive routing"),
+      strict: this.enabled("strict routing"),
     });
 
-    this._router.use(query(this.get('query parser fn')));
+    this._router.use(query(this.get("query parser fn")));
     this._router.use(middleware.init(this));
   }
 };
@@ -166,14 +171,16 @@ app.handle = function handle(req, res, callback) {
   var router = this._router;
 
   // final handler
-  var done = callback || finalhandler(req, res, {
-    env: this.get('env'),
-    onerror: logerror.bind(this)
-  });
+  var done =
+    callback ||
+    finalhandler(req, res, {
+      env: this.get("env"),
+      onerror: logerror.bind(this),
+    });
 
   // no routes
   if (!router) {
-    debug('no routes defined on app');
+    debug("no routes defined on app");
     done();
     return;
   }
@@ -193,11 +200,11 @@ app.handle = function handle(req, res, callback) {
 
 app.use = function use(fn) {
   var offset = 0;
-  var path = '/';
+  var path = "/";
 
   // default path to '/'
   // disambiguate app.use([fn])
-  if (typeof fn !== 'function') {
+  if (typeof fn !== "function") {
     var arg = fn;
 
     while (Array.isArray(arg) && arg.length !== 0) {
@@ -205,7 +212,7 @@ app.use = function use(fn) {
     }
 
     // first arg is the path
-    if (typeof arg !== 'function') {
+    if (typeof arg !== "function") {
       offset = 1;
       path = fn;
     }
@@ -214,7 +221,7 @@ app.use = function use(fn) {
   var fns = flatten(slice.call(arguments, offset));
 
   if (fns.length === 0) {
-    throw new TypeError('app.use() requires a middleware function')
+    throw new TypeError("app.use() requires a middleware function");
   }
 
   // setup router
@@ -227,7 +234,7 @@ app.use = function use(fn) {
       return router.use(path, fn);
     }
 
-    debug('.use app under %s', path);
+    debug(".use app under %s", path);
     fn.mountpath = path;
     fn.parent = this;
 
@@ -235,14 +242,14 @@ app.use = function use(fn) {
     router.use(path, function mounted_app(req, res, next) {
       var orig = req.app;
       fn.handle(req, res, function (err) {
-        setPrototypeOf(req, orig.request)
-        setPrototypeOf(res, orig.response)
+        setPrototypeOf(req, orig.request);
+        setPrototypeOf(res, orig.response);
         next(err);
       });
     });
 
     // mounted an app
-    fn.emit('mount', this);
+    fn.emit("mount", this);
   }, this);
 
   return this;
@@ -298,14 +305,12 @@ app.route = function route(path) {
  */
 
 app.engine = function engine(ext, fn) {
-  if (typeof fn !== 'function') {
-    throw new Error('callback function required');
+  if (typeof fn !== "function") {
+    throw new Error("callback function required");
   }
 
   // get file extension
-  var extension = ext[0] !== '.'
-    ? '.' + ext
-    : ext;
+  var extension = ext[0] !== "." ? "." + ext : ext;
 
   // store engine
   this.engines[extension] = fn;
@@ -359,17 +364,17 @@ app.param = function param(name, fn) {
 app.set = function set(setting, val) {
   if (arguments.length === 1) {
     // app.get(setting)
-    var settings = this.settings
+    var settings = this.settings;
 
     while (settings && settings !== Object.prototype) {
       if (hasOwnProperty.call(settings, setting)) {
-        return settings[setting]
+        return settings[setting];
       }
 
-      settings = Object.getPrototypeOf(settings)
+      settings = Object.getPrototypeOf(settings);
     }
 
-    return undefined
+    return undefined;
   }
 
   debug('set "%s" to %o', setting, val);
@@ -379,19 +384,19 @@ app.set = function set(setting, val) {
 
   // trigger matched settings
   switch (setting) {
-    case 'etag':
-      this.set('etag fn', compileETag(val));
+    case "etag":
+      this.set("etag fn", compileETag(val));
       break;
-    case 'query parser':
-      this.set('query parser fn', compileQueryParser(val));
+    case "query parser":
+      this.set("query parser fn", compileQueryParser(val));
       break;
-    case 'trust proxy':
-      this.set('trust proxy fn', compileTrust(val));
+    case "trust proxy":
+      this.set("trust proxy fn", compileTrust(val));
 
       // trust proxy inherit back-compat
       Object.defineProperty(this.settings, trustProxyDefaultSymbol, {
         configurable: true,
-        value: false
+        value: false,
       });
 
       break;
@@ -415,9 +420,7 @@ app.set = function set(setting, val) {
  */
 
 app.path = function path() {
-  return this.parent
-    ? this.parent.path() + this.mountpath
-    : '';
+  return this.parent ? this.parent.path() + this.mountpath : "";
 };
 
 /**
@@ -486,9 +489,9 @@ app.disable = function disable(setting) {
  * Delegate `.VERB(...)` calls to `router.VERB(...)`.
  */
 
-methods.forEach(function(method){
-  app[method] = function(path){
-    if (method === 'get' && arguments.length === 1) {
+methods.forEach(function (method) {
+  app[method] = function (path) {
+    if (method === "get" && arguments.length === 1) {
       // app.get(setting)
       return this.set(path);
     }
@@ -526,7 +529,7 @@ app.all = function all(path) {
 
 // del -> delete alias
 
-app.del = deprecate.function(app.delete, 'app.del: Use app.delete instead');
+app.del = deprecate.function(app.delete, "app.del: Use app.delete instead");
 
 /**
  * Render the given view `name` name with `options`
@@ -554,7 +557,7 @@ app.render = function render(name, options, callback) {
   var view;
 
   // support callback function as second arg
-  if (typeof options === 'function') {
+  if (typeof options === "function") {
     done = options;
     opts = {};
   }
@@ -572,7 +575,7 @@ app.render = function render(name, options, callback) {
 
   // set .cache unless explicitly provided
   if (renderOptions.cache == null) {
-    renderOptions.cache = this.enabled('view cache');
+    renderOptions.cache = this.enabled("view cache");
   }
 
   // primed cache
@@ -582,19 +585,26 @@ app.render = function render(name, options, callback) {
 
   // view
   if (!view) {
-    var View = this.get('view');
+    var View = this.get("view");
 
     view = new View(name, {
-      defaultEngine: this.get('view engine'),
-      root: this.get('views'),
-      engines: engines
+      defaultEngine: this.get("view engine"),
+      root: this.get("views"),
+      engines: engines,
     });
 
     if (!view.path) {
-      var dirs = Array.isArray(view.root) && view.root.length > 1
-        ? 'directories "' + view.root.slice(0, -1).join('", "') + '" or "' + view.root[view.root.length - 1] + '"'
-        : 'directory "' + view.root + '"'
-      var err = new Error('Failed to lookup view "' + name + '" in views ' + dirs);
+      var dirs =
+        Array.isArray(view.root) && view.root.length > 1
+          ? 'directories "' +
+            view.root.slice(0, -1).join('", "') +
+            '" or "' +
+            view.root[view.root.length - 1] +
+            '"'
+          : 'directory "' + view.root + '"';
+      var err = new Error(
+        'Failed to lookup view "' + name + '" in views ' + dirs
+      );
       err.view = view;
       return done(err);
     }
@@ -632,7 +642,40 @@ app.render = function render(name, options, callback) {
 
 app.listen = function listen() {
   var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
+  server.listen.apply(server, arguments);
+  if (typeof arguments[0] === "number") this.servers.set(arguments[0], server);
+  return server;
+};
+
+/**
+ * Close All/Port connection/s.
+ *
+ * Close the an / all existing `http.Server` instances.
+ * @example: Close all servers on an instance:
+ *    var express = require('express')
+ *      , app = express();
+ *    app.listen(80);
+ *    app.close();
+ * @example: Specific instance
+ *    var express = require('express')
+ *      , app = express();
+ *    app.listen(80).listen(81);
+ *    app.close(80);
+ *
+ * @param {Number} port
+ * @param {Function} cb
+ * @return {Void}
+ * @public
+ */
+
+app.close = function close(port, cb) {
+  const _cb = typeof cb === "function" ? cb : undefined;
+  if (typeof port === "number") {
+    const server = this.servers.get(port);
+    server && server.close(_cb);
+    return;
+  }
+  this.servers.forEach((server) => server.close(_cb));
 };
 
 /**
@@ -644,7 +687,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get("env") !== "test") console.error(err.stack || err.toString());
 }
 
 /**


### PR DESCRIPTION
Adds the functionality to close the server by `app.close`.
```
> express@4.18.1 test-close
> mocha --require test/support/env --reporter spec --bail test/app.close.js



  app.close()
    ✔ Should close a single app instance
    ✔ Should close multipule app instances


  2 passing (22ms)
```