### PR TITLE
Feature/app.close

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -662,9 +662,9 @@ app.listen = function listen() {
  */
 
 app.close = function close(port, cb) {
-  const _cb = typeof cb === "function" ? cb : undefined;
+  var _cb = typeof cb === "function" ? cb : undefined;
   if (typeof port === "number") {
-    const server = this.servers.get(port);
+    var server = this.servers.get(port);
     server && server.close(_cb);
     return;
   }

--- a/lib/application.js
+++ b/lib/application.js
@@ -65,7 +65,7 @@ app.init = function init() {
   this.cache = {};
   this.engines = {};
   this.settings = {};
-  this.servers = new Map();
+  this.servers = {};
 
   this.defaultConfiguration();
 };
@@ -634,7 +634,7 @@ app.render = function render(name, options, callback) {
 app.listen = function listen() {
   var server = http.createServer(this);
   server.listen.apply(server, arguments);
-  if (typeof arguments[0] === "number") this.servers.set(arguments[0], server);
+  if (typeof arguments[0] === "number") this.servers[arguments[0]] = server;
   return server;
 };
 
@@ -664,11 +664,14 @@ app.listen = function listen() {
 app.close = function close(port, cb) {
   var _cb = typeof cb === "function" ? cb : undefined;
   if (typeof port === "number") {
-    var server = this.servers.get(port);
+    var server = this.servers[port];
     server && server.close(_cb);
     return;
   }
-  this.servers.forEach((server) => server.close(_cb));
+  var _servers = this.servers;
+  Object.keys(this.servers).forEach(function (port) {
+    _servers[port].close(_cb);
+  });
 };
 
 /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -65,6 +65,7 @@ app.init = function init() {
   this.cache = {};
   this.engines = {};
   this.settings = {};
+  this.servers = new Map();
 
   this.defaultConfiguration();
 };
@@ -632,7 +633,42 @@ app.render = function render(name, options, callback) {
 
 app.listen = function listen() {
   var server = http.createServer(this);
-  return server.listen.apply(server, arguments);
+  server.listen.apply(server, arguments);
+  if (typeof arguments[0] === "number") this.servers.set(arguments[0], server);
+  return server;
+};
+
+/**
+ * Close All/Port connection/s.
+ *
+ * Close the an / all existing `http.Server` instances.
+ * Specify port to close a specific `http.server` instance, or leave it blank to close all `http.server` instances.
+ * Specify cb to run the function one the server `emit` a close message.
+ * @example: Close all servers on an instance:
+ *    var express = require('express')
+ *      , app = express();
+ *    app.listen(80);
+ *    app.close();
+ * @example: Specific instance
+ *    var express = require('express')
+ *      , app = express();
+ *    app.listen(80).listen(81);
+ *    app.close(80);
+ *
+ * @param {Number} port
+ * @param {Function} cb
+ * @return {Void}
+ * @public
+ */
+
+app.close = function close(port, cb) {
+  const _cb = typeof cb === "function" ? cb : undefined;
+  if (typeof port === "number") {
+    const server = this.servers.get(port);
+    server && server.close(_cb);
+    return;
+  }
+  this.servers.forEach((server) => server.close(_cb));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
-    "test-close": "mocha --require test/support/env --reporter spec --bail test/app.close.js",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test",
     "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+    "test-close": "mocha --require test/support/env --reporter spec --bail test/app.close.js",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test",
     "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"

--- a/test/app.close.js
+++ b/test/app.close.js
@@ -1,7 +1,6 @@
 "use strict";
 
-var express = require("../"),
-  request = require("supertest");
+var express = require("../");
 
 describe("app.close()", function () {
   it("Should close a single app instance", function (done) {
@@ -16,7 +15,7 @@ describe("app.close()", function () {
     app.listen(9998);
     app.listen(9999);
     var i = 0;
-    app.close(null, () => {
+    app.close(null, function () {
       if (++i === 2) done();
     });
   });

--- a/test/app.close.js
+++ b/test/app.close.js
@@ -11,6 +11,17 @@ describe("app.close()", function () {
       res.end("hi!");
     });
 
+    app.listen();
+    app.close(null, done);
+  });
+
+  it("Should close a single app instance", function (done) {
+    var app = express();
+
+    app.get("/greet", function (req, res) {
+      res.end("hi!");
+    });
+
     app.listen(9999);
     app.close(null, done);
   });
@@ -24,7 +35,7 @@ describe("app.close()", function () {
 
     app.listen(9998);
     app.listen(9999);
-    let i = 0;
+    var i = 0;
     app.close(null, () => {
       if (++i === 2) done();
     });

--- a/test/app.close.js
+++ b/test/app.close.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var express = require("../"),
+  request = require("supertest");
+
+describe("app.close()", function () {
+  it("Should close a single app instance", function (done) {
+    var app = express();
+
+    app.get("/greet", function (req, res) {
+      res.end("hi!");
+    });
+
+    app.listen(9999);
+    app.close(null, done);
+  });
+
+  it("Should close multipule app instances", function (done) {
+    var app = express();
+
+    app.get("/greet", function (req, res) {
+      res.end("hi!");
+    });
+
+    app.listen(9998);
+    app.listen(9999);
+    let i = 0;
+    app.close(null, () => {
+      if (++i === 2) done();
+    });
+  });
+});

--- a/test/app.close.js
+++ b/test/app.close.js
@@ -6,32 +6,12 @@ var express = require("../"),
 describe("app.close()", function () {
   it("Should close a single app instance", function (done) {
     var app = express();
-
-    app.get("/greet", function (req, res) {
-      res.end("hi!");
-    });
-
-    app.listen();
-    app.close(null, done);
-  });
-
-  it("Should close a single app instance", function (done) {
-    var app = express();
-
-    app.get("/greet", function (req, res) {
-      res.end("hi!");
-    });
-
     app.listen(9999);
     app.close(null, done);
   });
 
   it("Should close multipule app instances", function (done) {
     var app = express();
-
-    app.get("/greet", function (req, res) {
-      res.end("hi!");
-    });
 
     app.listen(9998);
     app.listen(9999);


### PR DESCRIPTION
# Breif 
Currently inorder to close an express app (server) the developer needs to capture the returning `http.server` from `app.listen`. This practice is not documented by express, and requires the developers figure it out by reading the underlying` app.listen` code.

# Solution / Expected Result
I propose to make an explicit `app.close` funtion.
Calling `app.close` should close all the running servers, or specify a single port to close.
One useful example is when creating a mock server that opened and closed during a test.

# Content
Adds functionality to close the server by `app.close()`.

# Tests
```
> express@4.18.1 test-close
> mocha --require test/support/env --reporter spec --bail test/app.close.js



  app.close()
    ✔ Should close a single app instance
    ✔ Should close multiple app instances


  2 passing (22ms)
```