### PR TITLE
"merge params" option 

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -145,7 +145,8 @@ app.lazyrouter = function lazyrouter() {
   if (!this._router) {
     this._router = new Router({
       caseSensitive: this.enabled('case sensitive routing'),
-      strict: this.enabled('strict routing')
+      strict: this.enabled('strict routing'),
+      mergeParams: this.enabled('merge params')
     });
 
     this._router.use(query(this.get('query parser fn')));

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -397,138 +397,138 @@ describe('app.router', function(){
       .expect(200, '[["0","42"]]', done);
     })
 
-    describe('when "merge params" is enabled', function() {
-      it('should allow merging existing req.params', function(done){
-        var app = express();
-        var child = express();
+    describe('when "merge params" is enabled', function () {
+      it('should allow merging existing req.params', function (done) {
+        var app = express()
+        var child = express()
 
         child.enable('merge params')
 
-        child.get('/:action', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
-        });
+        child.get('/:action', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
+        })
 
-        app.use('/user/:user', child);
-
-        request(app)
-          .get('/user/tj/get')
-          .expect(200, '[["action","get"],["user","tj"]]', done);
-      })
-
-      it('should use params from child app', function(done){
-        var app = express();
-        var child = express();
-
-        child.enable('merge params');
-
-        child.get('/:thing', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
-        });
-
-        app.use('/user/:thing', child);
+        app.use('/user/:user', child)
 
         request(app)
           .get('/user/tj/get')
-          .expect(200, '[["thing","get"]]', done);
+          .expect(200, '[["action","get"],["user","tj"]]', done)
       })
 
-      it('should merge numeric indices req.params', function(done){
-        var app = express();
-        var child = express();
+      it('should use params from child app', function (done) {
+        var app = express()
+        var child = express()
 
-        child.enable('merge params');
+        child.enable('merge params')
 
-        child.get('/*.*', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
-        });
+        child.get('/:thing', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
+        })
 
-        app.use('/user/id:(\\d+)', child);
+        app.use('/user/:thing', child)
+
+        request(app)
+          .get('/user/tj/get')
+          .expect(200, '[["thing","get"]]', done)
+      })
+
+      it('should merge numeric indices req.params', function (done) {
+        var app = express()
+        var child = express()
+
+        child.enable('merge params')
+
+        child.get('/*.*', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
+        })
+
+        app.use('/user/id:(\\d+)', child)
 
         request(app)
           .get('/user/id:10/profile.json')
-          .expect(200, '[["0","10"],["1","profile"],["2","json"]]', done);
+          .expect(200, '[["0","10"],["1","profile"],["2","json"]]', done)
       })
 
-      it('should merge numeric indices req.params when more in parent', function(done){
-        var app = express();
-        var child = express();
+      it('should merge numeric indices req.params when more in parent', function (done) {
+        var app = express()
+        var child = express()
 
-        child.enable('merge params');
+        child.enable('merge params')
 
-        child.get('/*', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        child.get('/*', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
         });
 
-        app.use('/user/id:(\\d+)/name:(\\w+)', child);
+        app.use('/user/id:(\\d+)/name:(\\w+)', child)
 
         request(app)
           .get('/user/id:10/name:tj/profile')
-          .expect(200, '[["0","10"],["1","tj"],["2","profile"]]', done);
+          .expect(200, '[["0","10"],["1","tj"],["2","profile"]]', done)
       })
 
-      it('should merge numeric indices req.params when parent has same number', function(done){
-        var app = express();
-        var child = express();
+      it('should merge numeric indices req.params when parent has same number', function (done) {
+        var app = express()
+        var child = express()
 
-        child.enable('merge params');
+        child.enable('merge params')
 
-        child.get('/name:(\\w+)', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
-        });
+        child.get('/name:(\\w+)', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
+        })
 
-        app.use('/user/id:(\\d+)', child);
+        app.use('/user/id:(\\d+)', child)
 
         request(app)
           .get('/user/id:10/name:tj')
-          .expect(200, '[["0","10"],["1","tj"]]', done);
+          .expect(200, '[["0","10"],["1","tj"]]', done)
       })
 
-      it('should ignore invalid incoming req.params', function(done){
-        var app = express();
-        var child = express();
+      it('should ignore invalid incoming req.params', function (done) {
+        var app = express()
+        var child = express()
 
-        child.enable('merge params');
+        child.enable('merge params')
 
-        child.get('/:name', function(req, res){
-          var keys = Object.keys(req.params).sort();
-          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        child.get('/:name', function (req, res) {
+          var keys = Object.keys(req.params).sort()
+          res.send(keys.map(function (k) { return [k, req.params[k]] }))
         });
 
         app.use('/user/', function (req, res, next) {
-          req.params = 3; // wat?
-          child.handle(req, res, next);
-        });
+          req.params = 3 // wat?
+          child.handle(req, res, next)
+        })
 
         request(app)
           .get('/user/tj')
-          .expect(200, '[["name","tj"]]', done);
+          .expect(200, '[["name","tj"]]', done)
       })
 
-      it('should restore req.params', function(done){
-        var app = express();
-        var child = express();
+      it('should restore req.params', function (done) {
+        var app = express()
+        var child = express()
 
-        child.enable('merge params');
+        child.enable('merge params')
 
         child.get('/user:(\\w+)/*', function (req, res, next) {
-          next();
-        });
+          next()
+        })
 
         app.use('/user/id:(\\d+)', function (req, res, next) {
           child.handle(req, res, function (err) {
-            var keys = Object.keys(req.params).sort();
-            res.send(keys.map(function(k){ return [k, req.params[k]] }));
-          });
-        });
+            var keys = Object.keys(req.params).sort()
+            res.send(keys.map(function (k) { return [k, req.params[k]] }))
+          })
+        })
 
         request(app)
           .get('/user/id:42/user:tj/profile')
-          .expect(200, '[["0","42"]]', done);
+          .expect(200, '[["0","42"]]', done)
       })
     })
   })

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -396,6 +396,141 @@ describe('app.router', function(){
       .get('/user/id:42/user:tj/profile')
       .expect(200, '[["0","42"]]', done);
     })
+
+    describe('when "merge params" is enabled', function() {
+      it('should allow merging existing req.params', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params')
+
+        child.get('/:action', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/:user', child);
+
+        request(app)
+          .get('/user/tj/get')
+          .expect(200, '[["action","get"],["user","tj"]]', done);
+      })
+
+      it('should use params from child app', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/:thing', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/:thing', child);
+
+        request(app)
+          .get('/user/tj/get')
+          .expect(200, '[["thing","get"]]', done);
+      })
+
+      it('should merge numeric indices req.params', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/*.*', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/id:(\\d+)', child);
+
+        request(app)
+          .get('/user/id:10/profile.json')
+          .expect(200, '[["0","10"],["1","profile"],["2","json"]]', done);
+      })
+
+      it('should merge numeric indices req.params when more in parent', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/*', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/id:(\\d+)/name:(\\w+)', child);
+
+        request(app)
+          .get('/user/id:10/name:tj/profile')
+          .expect(200, '[["0","10"],["1","tj"],["2","profile"]]', done);
+      })
+
+      it('should merge numeric indices req.params when parent has same number', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/name:(\\w+)', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/id:(\\d+)', child);
+
+        request(app)
+          .get('/user/id:10/name:tj')
+          .expect(200, '[["0","10"],["1","tj"]]', done);
+      })
+
+      it('should ignore invalid incoming req.params', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/:name', function(req, res){
+          var keys = Object.keys(req.params).sort();
+          res.send(keys.map(function(k){ return [k, req.params[k]] }));
+        });
+
+        app.use('/user/', function (req, res, next) {
+          req.params = 3; // wat?
+          child.handle(req, res, next);
+        });
+
+        request(app)
+          .get('/user/tj')
+          .expect(200, '[["name","tj"]]', done);
+      })
+
+      it('should restore req.params', function(done){
+        var app = express();
+        var child = express();
+
+        child.enable('merge params');
+
+        child.get('/user:(\\w+)/*', function (req, res, next) {
+          next();
+        });
+
+        app.use('/user/id:(\\d+)', function (req, res, next) {
+          child.handle(req, res, function (err) {
+            var keys = Object.keys(req.params).sort();
+            res.send(keys.map(function(k){ return [k, req.params[k]] }));
+          });
+        });
+
+        request(app)
+          .get('/user/id:42/user:tj/profile')
+          .expect(200, '[["0","42"]]', done);
+      })
+    })
   })
 
   describe('trailing slashes', function(){


### PR DESCRIPTION
Added "merge params" option to application as discussed in #5006.

Note: I am not familiar with the suite, so I copy pasted mergeParams tests and adapted them a bit to the application where needed, but I just wanted to make sure that the behavior of the application is the same as the router. The tests should look the same for both however... Would it make sense to provide `[Router({mergerParams: true}), app.handle]` and run the same tests for them, or is it preferable to have these duplicated?