### PR TITLE
Change var to let to limit scope

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -631,7 +631,7 @@ app.render = function render(name, options, callback) {
  */
 
 app.listen = function listen() {
-  var server = http.createServer(this);
+  let server = http.createServer(this);
   return server.listen.apply(server, arguments);
 };
 


### PR DESCRIPTION
Changing the keyword var to let to limit scope of the program and as let is used more widely now, it is more preferred than var.