### PR TITLE
Fixes issue with hbs and Yarn v3 PNP

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,14 @@
     "supertest": "6.3.0",
     "vhost": "~3.0.2"
   },
+  "peerDependencies": {
+    "hbs": "4.2.0",
+  },
+  "peerDependenciesMeta": {
+    "hbs": {
+      "optional": true
+    }
+  }
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Adds hbs as an optional peer dependency to appease yarn v3 pnp.