### PR TITLE
build : add Node.js@19.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         - Node.js 16.x
         - Node.js 17.x
         - Node.js 18.x
+        - Node.js 19.x
 
         include:
         - name: Node.js 0.10
@@ -107,6 +108,9 @@ jobs:
 
         - name: Node.js 18.x
           node-version: "18.14"
+
+        - name: Node.js 19.x
+          node-version: "19.7"
 
     steps:
     - uses: actions/checkout@v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
     - nodejs_version: "16.19"
     - nodejs_version: "17.9"
     - nodejs_version: "18.14"
+    - nodejs_version: "19.7"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
- Node.js 19.7.0 has been published on 21/02/2023, see https://github.com/nodejs/node/releases/tag/v19.7.0
- Node.js 18 is now 18.14.12, see https://github.com/nodejs/node/releases/tag/v18.14.2
- Node.js 16 is now 16.19.1, see https://github.com/nodejs/node/releases/tag/v16.19.1
- body-parser is updated to version 1.20.2, see https://github.com/expressjs/body-parser/releases/tag/1.20.2

for nodejs version available in Github Actions, see https://github.com/actions/node-versions/releases
nodejs versions available in appveyor are slightly different, see https://www.appveyor.com/docs/linux-images-software/#node-js