### PR TITLE
Use https: protocol instead of deprecated git: protocol

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ $ npm start
   To view the examples, clone the Express repo and install the dependencies:
 
 ```console
-$ git clone git://github.com/expressjs/express.git --depth 1
+$ git clone https://github.com/expressjs/express.git --depth 1
 $ cd express
 $ npm install
 ```


### PR DESCRIPTION
👋 GitHub no longer supports the `git://` protocol for cloning, this will fail. Instead, use the HTTPS protocol. See the [GitHub blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for more information.