### PR TITLE
build: Node.js@16.18 and Node.js@18.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.17"
+          node-version: "16.18"
 
         - name: Node.js 17.x
           node-version: "17.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: "17.9"
 
         - name: Node.js 18.x
-          node-version: "18.10"
+          node-version: "18.12"
 
     steps:
     - uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
     - nodejs_version: "15.14"
     - nodejs_version: "16.18"
     - nodejs_version: "17.9"
-    - nodejs_version: "18.10"
+    - nodejs_version: "18.12"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     - nodejs_version: "13.14"
     - nodejs_version: "14.20"
     - nodejs_version: "15.14"
-    - nodejs_version: "16.17"
+    - nodejs_version: "16.18"
     - nodejs_version: "17.9"
     - nodejs_version: "18.10"
 cache:


### PR DESCRIPTION
At the date of the PR : 
- nodejs 16 last version is 16.18, see https://github.com/nodejs/node/releases/tag/v16.18.0
- nodejs 18 last version is 18.12, see https://github.com/nodejs/node/releases/tag/v18.12.0

Note : nodejs 19 update is purposely not included in this PR, see https://github.com/expressjs/express/pull/5028 for more context