### PR TITLE
Use module.children instead !module.parent

### DIFF
--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -58,7 +58,7 @@ hash({ password: 'foobar' }, function (err, pass, salt, hash) {
 // Authenticate using our plain-object database of doom!
 
 function authenticate(name, pass, fn) {
-  if (module.children) console.log('authenticating %s:%s', name, pass);
+  if (require.main === module) console.log('authenticating %s:%s', name, pass);
   var user = users[name];
   // query the db for the given username
   if (!user) return fn(null, null)
@@ -127,7 +127,7 @@ app.post('/login', function (req, res, next) {
 });
 
 /* istanbul ignore next */
-if (module.children) {
+if (require.main === module) {
   app.listen(3000);
   console.log('Express started on port 3000');
 }

--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -58,7 +58,7 @@ hash({ password: 'foobar' }, function (err, pass, salt, hash) {
 // Authenticate using our plain-object database of doom!
 
 function authenticate(name, pass, fn) {
-  if (!module.parent) console.log('authenticating %s:%s', name, pass);
+  if (module.children) console.log('authenticating %s:%s', name, pass);
   var user = users[name];
   // query the db for the given username
   if (!user) return fn(null, null)
@@ -127,7 +127,7 @@ app.post('/login', function (req, res, next) {
 });
 
 /* istanbul ignore next */
-if (!module.parent) {
+if (module.children) {
   app.listen(3000);
   console.log('Express started on port 3000');
 }


### PR DESCRIPTION
According to the nodejs official documentation, module.parent is deprecated since: v14.6.0, v12.19.0。[module.parent](https://nodejs.org/docs/latest-v14.x/api/modules.html#modules_module_parent)

So i use use module.children instead !module.parent in this example。