### PR TITLE
chore: Add Node.js version 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         - Node.js 16.x
         - Node.js 17.x
         - Node.js 18.x
+        - Node.js 19.x
 
         include:
         - name: Node.js 0.10
@@ -100,13 +101,16 @@ jobs:
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.17"
+          node-version: "16.19"
 
         - name: Node.js 17.x
           node-version: "17.9"
 
         - name: Node.js 18.x
-          node-version: "18.10"
+          node-version: "18.12"
+        
+        - name: Node.js 19.x
+          node-version: "19.3"
 
     steps:
     - uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,10 @@ environment:
     - nodejs_version: "13.14"
     - nodejs_version: "14.20"
     - nodejs_version: "15.14"
-    - nodejs_version: "16.17"
+    - nodejs_version: "16.19"
     - nodejs_version: "17.9"
-    - nodejs_version: "18.10"
+    - nodejs_version: "18.12"
+    - nodejs_version: "19.3"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
Multiples chores:
- Adding Node.js 19 version to the matrix to start testing against it
- Update Node.js 16 and 18 with newer versions 