### PR TITLE
CVE-2017-20165 Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.5.0",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.9",
+    "debug": "4.3.4",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
A vulnerability classified as problematic has been found in debug-js debug up to 3.0.x. This affects the function useColors of the file src/node.js. The manipulation of the argument str leads to inefficient regular expression complexity. Upgrading to version 3.1.0 is able to address this issue. The name of the patch is c38a0166c266a679c8de012d4eaccec3f944e685. It is recommended to upgrade the affected component. The identifier VDB-217665 was assigned to this vulnerability.

![image](https://user-images.githubusercontent.com/34398436/213716048-4ab85440-8317-4b67-a67a-33e370e68aa5.png)

Link to the CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-20165