### PR TITLE
deps: debug@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.5.0",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.9",
+    "debug": "3.1.0",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
Demo library version 2.6.9 has vulnerability issues and we should update it to at least version 3.1.0
Here is the link for more information: https://vulners.com/osv/OSV:GHSA-9VVW-CC9W-F27H
![image](https://user-images.githubusercontent.com/60115295/217830856-fa411ad2-5d51-4bc6-ad1b-b4f5155d2074.png)

All tests passed without issues
![image](https://user-images.githubusercontent.com/60115295/217830973-017542c7-7d4f-445d-b628-8c69df49bd8b.png)
