### PR TITLE
[FEATURE] Adding True After middlewares to ExpressJS framework.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -105,10 +105,12 @@ res.links = function(links){
  *     res.send('<p>some html</p>');
  *
  * @param {string|number|boolean|object|Buffer} body
+ * @param {function} afterCallback
+ * @param {*} args (list)
  * @public
  */
 
-res.send = function send(body) {
+res.send = function send(body, afterCallback, ...args) {
   var chunk = body;
   var encoding;
   var req = this.req;
@@ -232,6 +234,9 @@ res.send = function send(body) {
     this.end(chunk, encoding);
   }
 
+  // True after middlewares
+  ((afterCallback, response, ...args) => { afterCallback(response, ...args); })(afterCallback, this, ...args);
+
   return this;
 };
 
@@ -244,10 +249,12 @@ res.send = function send(body) {
  *     res.json({ user: 'tj' });
  *
  * @param {string|number|boolean|object} obj
+ * @param {function} afterCallback
+ * @param {*} args (list)
  * @public
  */
 
-res.json = function json(obj) {
+res.json = function json(obj, afterCallback, ...args) {
   var val = obj;
 
   // allow status / body
@@ -275,7 +282,7 @@ res.json = function json(obj) {
     this.set('Content-Type', 'application/json');
   }
 
-  return this.send(body);
+  return this.send(body, afterCallback, ...args);
 };
 
 /**
@@ -287,10 +294,12 @@ res.json = function json(obj) {
  *     res.jsonp({ user: 'tj' });
  *
  * @param {string|number|boolean|object} obj
+ * @param {function} afterCallback
+ * @param {*} args (list)
  * @public
  */
 
-res.jsonp = function jsonp(obj) {
+res.jsonp = function jsonp(obj, afterCallback, ...args) {
   var val = obj;
 
   // allow status / body
@@ -348,7 +357,7 @@ res.jsonp = function jsonp(obj) {
     body = '/**/ typeof ' + callback + ' === \'function\' && ' + callback + '(' + body + ');';
   }
 
-  return this.send(body);
+  return this.send(body, afterCallback, ...args);
 };
 
 /**
@@ -363,16 +372,18 @@ res.jsonp = function jsonp(obj) {
  *     res.sendStatus(200);
  *
  * @param {number} statusCode
+ * @param {function} afterCallback
+ * @param {*} args (list)
  * @public
  */
 
-res.sendStatus = function sendStatus(statusCode) {
+res.sendStatus = function sendStatus(statusCode, afterCallback, ...args) {
   var body = statuses.message[statusCode] || String(statusCode)
 
   this.statusCode = statusCode;
   this.type('txt');
 
-  return this.send(body);
+  return this.send(body, afterCallback, ...args);
 };
 
 /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -235,6 +235,7 @@ res.send = function send(body, afterCallback, ...args) {
   }
 
   // True after middlewares
+  if (!afterCallback || afterCallback !== "function") { afterCallback = (r, ...a) => {} }
   ((afterCallback, response, ...args) => { afterCallback(response, ...args); })(afterCallback, this, ...args);
 
   return this;

--- a/lib/response.js
+++ b/lib/response.js
@@ -34,6 +34,7 @@ var extname = path.extname;
 var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
+var flatten = require('array-flatten');
 
 /**
  * Response prototype.
@@ -105,12 +106,12 @@ res.links = function(links){
  *     res.send('<p>some html</p>');
  *
  * @param {string|number|boolean|object|Buffer} body
- * @param {function} afterCallback
- * @param {*} args (list)
+ * @param {function} afterSend
+ * @param {*} arguments (list)
  * @public
  */
 
-res.send = function send(body, afterCallback, ...args) {
+res.send = function send(body, afterSend) {
   var chunk = body;
   var encoding;
   var req = this.req;
@@ -121,15 +122,21 @@ res.send = function send(body, afterCallback, ...args) {
 
   // allow status / body
   if (arguments.length === 2) {
+    
     // res.send(body, status) backwards compat
     if (typeof arguments[0] !== 'number' && typeof arguments[1] === 'number') {
       deprecate('res.send(body, status): Use res.status(status).send(body) instead');
       this.statusCode = arguments[1];
+    } else if (typeof arguments[0] !== 'number' && typeof arguments[1] === 'function') {
+      // [1]. checking if the usage is not res.send(status, function)
+      // [2]. checking if the usage is res.send(body, function)
+      chunk = arguments[0];
     } else {
       deprecate('res.send(status, body): Use res.status(status).send(body) instead');
       this.statusCode = arguments[0];
       chunk = arguments[1];
     }
+    
   }
 
   // disambiguate res.send(status) and res.send(status, num)
@@ -235,8 +242,7 @@ res.send = function send(body, afterCallback, ...args) {
   }
 
   // True after middlewares
-  if (!afterCallback || typeof afterCallback !== "function") { afterCallback = (r, ...a) => {} }
-  ((afterCallback, response, ...args) => { afterCallback(response, ...args); })(afterCallback, this, ...args);
+  if (!!afterSend && typeof afterSend === "function") ((afterSend, response) => { afterSend(response, flatten(arguments)); })(afterSend, this, flatten(arguments));
 
   return this;
 };
@@ -250,12 +256,12 @@ res.send = function send(body, afterCallback, ...args) {
  *     res.json({ user: 'tj' });
  *
  * @param {string|number|boolean|object} obj
- * @param {function} afterCallback
- * @param {*} args (list)
+ * @param {function} afterSend
+ * @param {*} arguments (list)
  * @public
  */
 
-res.json = function json(obj, afterCallback, ...args) {
+res.json = function json(obj, afterSend) {
   var val = obj;
 
   // allow status / body
@@ -283,7 +289,7 @@ res.json = function json(obj, afterCallback, ...args) {
     this.set('Content-Type', 'application/json');
   }
 
-  return this.send(body, afterCallback, ...args);
+  return this.send(body, afterSend, arguments.slice(2, arguments.length));
 };
 
 /**
@@ -295,12 +301,12 @@ res.json = function json(obj, afterCallback, ...args) {
  *     res.jsonp({ user: 'tj' });
  *
  * @param {string|number|boolean|object} obj
- * @param {function} afterCallback
- * @param {*} args (list)
+ * @param {function} afterSend
+ * @param {*} arguments (list)
  * @public
  */
 
-res.jsonp = function jsonp(obj, afterCallback, ...args) {
+res.jsonp = function jsonp(obj, afterSend) {
   var val = obj;
 
   // allow status / body
@@ -358,7 +364,7 @@ res.jsonp = function jsonp(obj, afterCallback, ...args) {
     body = '/**/ typeof ' + callback + ' === \'function\' && ' + callback + '(' + body + ');';
   }
 
-  return this.send(body, afterCallback, ...args);
+  return this.send(body, afterSend, arguments.slice(2, arguments.length));
 };
 
 /**
@@ -373,18 +379,18 @@ res.jsonp = function jsonp(obj, afterCallback, ...args) {
  *     res.sendStatus(200);
  *
  * @param {number} statusCode
- * @param {function} afterCallback
- * @param {*} args (list)
+ * @param {function} afterSend
+ * @param {*} arguments (list)
  * @public
  */
 
-res.sendStatus = function sendStatus(statusCode, afterCallback, ...args) {
+res.sendStatus = function sendStatus(statusCode, afterSend) {
   var body = statuses.message[statusCode] || String(statusCode)
 
   this.statusCode = statusCode;
   this.type('txt');
 
-  return this.send(body, afterCallback, ...args);
+  return this.send(body, afterSend, arguments.slice(2, arguments.length));
 };
 
 /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -235,7 +235,7 @@ res.send = function send(body, afterCallback, ...args) {
   }
 
   // True after middlewares
-  if (!afterCallback || afterCallback !== "function") { afterCallback = (r, ...a) => {} }
+  if (!afterCallback || typeof afterCallback !== "function") { afterCallback = (r, ...a) => {} }
   ((afterCallback, response, ...args) => { afterCallback(response, ...args); })(afterCallback, this, ...args);
 
   return this;


### PR DESCRIPTION
Adding `True After middlewares` to ExpressJS framework.

1. The following commit do not change anything in the code logic but `impacts the code request-response lifcycle/ flow`.
2. The arguments of the `res.send` function that takes only response body as its arguments.
3. A callback called `afterCallback` has been added that modifies the function to take a callback that can be executed after a response has been sent.
4. The previous code lifecycle/ flow was `Request -> Before Middlewares -> APILogic -> Response`
5. The new code lifecycle/ flow will `Request -> Before Middlewares -> APILogic -> Response -> After Middleware`
6. NOTE: The code does not allow for mutliple after callbacks like the middlewares. It adds only one callback function to avoid complexity of future changes and testing issues to the framework. One function called afterCallback is a developer tradeoff to manage and test their own code base for the after middleware (afterCallback) that can combine multiple after middlewares into one after middleware.

Pull requests (Changes mentioned below):
FILENAME: [https://github.com/expressjs/express/blob/master/lib/response.js](https://github.com/expressjs/express/blob/master/lib/response.js)

Code Changes below:

[A]:
```
res.send(body) => res.send(body, afterCallback, ...args)
```
      Modified Lines:
      1. Line 113: `res.send = function send(body, afterCallback, ...args) {`
      2. Line 237: `// True after middlewares`
      3. Line 238: `if (!afterCallback || afterCallback !== "function") { afterCallback = (r, ...a) => {} }`
      4. Line 239: `((afterCallback, response, ...args) => { afterCallback(response, ...args); })(afterCallback, this, ...args);`

[B]:
```
res.json(obj) => res.json(obj, afterCallback, ...args)
```
	Modified Lines:
	1. Line 302: `res.json = function json(obj, afterCallback, ...args) {`
	2. Line 285: `return this.send(body, afterCallback, ...args);`

[C]:
```
res.jsonp(obj) => res.jsonp(obj, afterCallback, ...args)
```
	Modified Lines:
	1. Line 302: `res.jsonp = function jsonp(obj, afterCallback, ...args) {`
	2. Line 360: `return this.send(body, afterCallback, ...args);`