### PR TITLE
Don't automatically add Expires in res.cookie if expires option is explicitly set to 0

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -872,7 +872,9 @@ res.cookie = function (name, value, options) {
     var maxAge = opts.maxAge - 0
 
     if (!isNaN(maxAge)) {
-      opts.expires = new Date(Date.now() + maxAge)
+      if (opts.expires !== 0) {
+        opts.expires = new Date(Date.now() + maxAge)
+      }
       opts.maxAge = Math.floor(maxAge / 1000)
     }
   }


### PR DESCRIPTION
This addresses https://github.com/expressjs/express/issues/5150

Those who wish to exclude `Expires` (but still keep `Max-Age` from the final `Set-Cookie` statement cannot do so if `maxAge` option is passed to `res.cookie`).

This proposed solution allows one to exclude Expires if `expires: 0` option is passed to `res.cookie`.