### PR TITLE
Add support for encrypted cookies

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -34,6 +34,7 @@ var extname = path.extname;
 var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
+var encrypt = require('symmetric-cipher.js').encrypt
 
 /**
  * Response prototype.
@@ -854,17 +855,21 @@ res.clearCookie = function clearCookie(name, options) {
 res.cookie = function (name, value, options) {
   var opts = merge({}, options);
   var secret = this.req.secret;
+  var secretEncoding = this.req.secretEncoding || 'utf8';
   var signed = opts.signed;
+  var encrypted = opts.encrypted || false;
 
-  if (signed && !secret) {
-    throw new Error('cookieParser("secret") required for signed cookies');
+  if ((signed || encrypted) && !secret) {
+    throw new Error('cookieParser("secret") required for signed or encrypted cookies');
   }
 
   var val = typeof value === 'object'
     ? 'j:' + JSON.stringify(value)
     : String(value);
 
-  if (signed) {
+  if (encrypted) {
+    val = 'e:' + sign(encrypt(val, secret, secretEncoding), secret);
+  } else if (signed) {
     val = 's:' + sign(val, secret);
   }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -34,7 +34,7 @@ var extname = path.extname;
 var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
-var encrypt = require('symmetric-cipher.js').encrypt
+var cipher = require('symmetric-cipher.js')
 
 /**
  * Response prototype.
@@ -868,7 +868,7 @@ res.cookie = function (name, value, options) {
     : String(value);
 
   if (encrypted) {
-    val = 'e:' + sign(encrypt(val, secret, secretEncoding), secret);
+    val = 'e:' + sign(cipher.encrypt(val, secret, secretEncoding), secret);
   } else if (signed) {
     val = 's:' + sign(val, secret);
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "serve-static": "1.15.0",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
-    "symmetric-cipher.js": "^1.0.0",
+    "symmetric-cipher.js": "^2.0.0-dev",
     "type-is": "~1.6.18",
     "utils-merge": "1.0.1",
     "vary": "~1.1.2"
@@ -77,7 +77,7 @@
     "multiparty": "4.2.3",
     "nyc": "15.1.0",
     "pbkdf2-password": "1.2.1",
-    "set-cookie-parser": "^2.6.0",
+    "set-cookie-parser": "2.6.0",
     "supertest": "6.3.0",
     "vhost": "~3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "multiparty": "4.2.3",
     "nyc": "15.1.0",
     "pbkdf2-password": "1.2.1",
-    "set-cookie-parser": "2.6.0",
     "supertest": "6.3.0",
     "vhost": "~3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "serve-static": "1.15.0",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
-    "symmetric-cipher.js": "^2.0.0-dev",
+    "symmetric-cipher.js": "2.0.0",
     "type-is": "~1.6.18",
     "utils-merge": "1.0.1",
     "vary": "~1.1.2"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "serve-static": "1.15.0",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
+    "symmetric-cipher.js": "^1.0.0",
     "type-is": "~1.6.18",
     "utils-merge": "1.0.1",
     "vary": "~1.1.2"
@@ -76,6 +77,7 @@
     "multiparty": "4.2.3",
     "nyc": "15.1.0",
     "pbkdf2-password": "1.2.1",
+    "set-cookie-parser": "^2.6.0",
     "supertest": "6.3.0",
     "vhost": "~3.0.2"
   },

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -278,7 +278,7 @@ describe('res', function(){
           .expect(function(res) {
             var secret = 'super secret key';
             var cookies = setCookieParser.parse(res, { decodeValues: true, map: true });
-            if (cookies.user.value.match(/^e:[0-9a-f]{32}:[0-9a-f]+\.(.*)$/) === null) {
+            if (cookies.user.value.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
               throw new Error('invalid encrypted cookie format')
             }
             if (decrypt(unsign(cookies.user.value.slice(2), secret), secret) !== 'foobar') {
@@ -302,7 +302,7 @@ describe('res', function(){
           .expect(function(res) {
             var secret = 'super secret key';
             var cookies = setCookieParser.parse(res, { decodeValues: true, map: true });
-            if (cookies.user.value.match(/^e:[0-9a-f]{32}:[0-9a-f]+\.(.*)$/) === null) {
+            if (cookies.user.value.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
               throw new Error('invalid encrypted cookie format')
             }
             if (decrypt(unsign(cookies.user.value.slice(2), secret), secret) !== 'j:{"name":"tobi"}') {

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -4,7 +4,7 @@ var express = require('../')
   , request = require('supertest')
   , cookieParser = require('cookie-parser')
 var merge = require('utils-merge');
-var setCookieParser = require('set-cookie-parser');
+var cookie = require('cookie');
 var decrypt = require('symmetric-cipher.js').decrypt;
 var unsign = require('cookie-signature').unsign;
 
@@ -277,12 +277,12 @@ describe('res', function(){
           .get('/')
           .expect(function(res) {
             var secret = 'super secret key';
-            var cookies = setCookieParser.parse(res, { decodeValues: true, map: true });
-            if (cookies.user.value.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
-              throw new Error('invalid encrypted cookie format')
+            var cookies = cookie.parse(res.headers['set-cookie'][0]);
+            if (cookies.user.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
+              throw new Error('invalid encrypted cookie format');
             }
-            if (decrypt(unsign(cookies.user.value.slice(2), secret), secret) !== 'foobar') {
-              throw new Error('encrypted cookie does not decrypt back to original text')
+            if (decrypt(unsign(cookies.user.slice(2), secret), secret) !== 'foobar') {
+              throw new Error('encrypted cookie does not decrypt back to original text');
             }
           })
           .expect(200, done)
@@ -301,12 +301,12 @@ describe('res', function(){
           .get('/')
           .expect(function(res) {
             var secret = 'super secret key';
-            var cookies = setCookieParser.parse(res, { decodeValues: true, map: true });
-            if (cookies.user.value.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
-              throw new Error('invalid encrypted cookie format')
+            var cookies = cookie.parse(res.headers['set-cookie'][0]);
+            if (cookies.user.match(/^e:[A-Za-z0-9+/=]{24}:[A-Za-z0-9+/=]+\.(.*)$/) === null) {
+              throw new Error('invalid encrypted cookie format');
             }
-            if (decrypt(unsign(cookies.user.value.slice(2), secret), secret) !== 'j:{"name":"tobi"}') {
-              throw new Error('encrypted JSON cookie does not decrypt back to original JSON string')
+            if (decrypt(unsign(cookies.user.slice(2), secret), secret) !== 'j:{"name":"tobi"}') {
+              throw new Error('encrypted JSON cookie does not decrypt back to original JSON string');
             }
           })
           .expect(200, done)


### PR DESCRIPTION
I'm proposing support for encrypted cookies in express. I followed an approach similar to the cookie signing code. I created the package [symmetric-cipher.js](https://www.npmjs.com/package/symmetric-cipher.js) which has the encrypt and decrypt functionality. It uses symmetric encryption ('AES-256-CBC') and creates a sha256 hash of the key if the key length is not 32 bytes (256 bits). Encrypted cookies are also signed, to prevent wasting computing resources on a decryption attempt if the cookie has been tampered with. Encryption happens on top of JSON serialisation for JSON cookies so they should decrypt back to `j:`. I have opened a [PR](https://github.com/expressjs/cookie-parser/pull/93) to add the decryption of encrypted cookies to the cookie-parser library.

I have added 1 dependency: symmetric-cipher.js, to abstract away the cryptography. I wrote it myself and made it lightweight.

I have written some security tips in [symmetric-cipher.js README] (https://github.com/FadhiliNjagi/symmetric-cipher.js#security), which could be useful for documentation. For documentation updates, kindly point me in the right direction. I'll be happy to document this.

*PS:* This is my first PR, so go easy :)