### PR TITLE
use random port in test so it won't fail on already listening

### DIFF
--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -6,7 +6,7 @@ describe('app.listen()', function(){
   it('should wrap with an HTTP server', function(done){
     var app = express();
 
-    var server = app.listen(9999, function(){
+    var server = app.listen(0, function () {
       server.close(done)
     });
   })


### PR DESCRIPTION
In my machine, the docker desktop is using port 9999, so replacing it to 0 so it won't fail...

```console
$ lsof -i:9999
COMMAND    PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
com.docke 1752 myuser  295u  IPv6 0x83cfbdc03dd8f0bf      0t0  TCP *:distinct (LISTEN)

$ ps aux | grep 1752
myuser          1752   0.8  0.1 409650768  83072   ??  S    12:26AM   0:53.99 /Applications/Docker.app/Contents/MacOS/com.docker.backend -watchdog -native-api
```


