### PR TITLE
Benchmarking suite documentation and historical benchmark storage

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,17 +1,34 @@
+# Get the current ISO8601 date time format but remove + and :
+$(shell date -I'minutes'| cut -d+ -f1 | sed 's/:/-/'> ./current)
+
+CURRENT_NODE_VERSION := $(shell node -v)
+
+# Create directory for current node version if it doesn't exist
+$(shell mkdir -p ./results/${CURRENT_NODE_VERSION})
+
+OUT_PATH := ./results/${CURRENT_NODE_VERSION}/$(shell cat ./current)
+
+# Write git username to top of output file
+$(shell git config --get-all credential.username > $(OUT_PATH))
+
+# Write CPU model to top of output file
+# Potentially split the results by CPU instead?
+$(shell lscpu | grep 'Model name' | cut -d: -f2 | sed 's/\s*//' | sed 's/\s//g' | sed 's/\([^a-zA-Z0-9]\)/_/g' >> $(OUT_PATH))
 
 all:
-	@./run 1 middleware 50
-	@./run 5 middleware 50
-	@./run 10 middleware 50
-	@./run 15 middleware 50
-	@./run 20 middleware 50
-	@./run 30 middleware 50
-	@./run 50 middleware 50
-	@./run 100 middleware 50
-	@./run 10 middleware 100
-	@./run 10 middleware 250
-	@./run 10 middleware 500
-	@./run 10 middleware 1000
-	@echo
+	@echo | tee -a $(OUT_PATH)
+	@./run 1 middleware 50 "$(OUT_PATH)"
+	@./run 5 middleware 50 "$(OUT_PATH)"
+	@./run 10 middleware 50 "$(OUT_PATH)"
+	@./run 15 middleware 50 "$(OUT_PATH)"
+	@./run 20 middleware 50 "$(OUT_PATH)"
+	@./run 30 middleware 50 "$(OUT_PATH)"
+	@./run 50 middleware 50 "$(OUT_PATH)"
+	@./run 100 middleware 50 "$(OUT_PATH)"
+	@./run 10 middleware 100 "$(OUT_PATH)"
+	@./run 10 middleware 250 "$(OUT_PATH)"
+	@./run 10 middleware 500 "$(OUT_PATH)"
+	@./run 10 middleware 1000 "$(OUT_PATH)"
+	$(shell rm ./current)
 
 .PHONY: all

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,7 +16,32 @@ Add the path to the binary to your path if it isn't already there.
 
 # Instructions
 
-Once all depedencies are met, you can run: `make` in the current directory:
-`benchmarks`.
+The makefile relies on a particular git config variable that isn't always set:
+`credential.username`. Run: `git config --get-all credential.username` to check
+whether it is set. If it is not, run:
+
+`git config credential.username "yourusername"`
+
+To set it accordingly.
+
+
+Once all depedencies are met, you can run: `make` in the `benchmarks` directory
+to run a HTTP server tests as defined in the 'run' script.
+
+Once the benchmarks have finished running, your results will be outputed to the
+terminal and stored in `results/<your-node-version>/<time-date>`
+
+The output format is as follows:
+```
+# Of connections
+Average latency
+Requests / second
+```
+
+For more information on how these are calculated, see: `wrk --help`
+
+
+TODO: Write a script for testing current benchmarks with the last previous
+benchmark for this version of Node and (potentially) for this user.
 
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,22 @@
+# Overview
+
+A shell script which uses [wrk](https://github.com/wg/wrk) to test the
+performance of Express under various different loads.
+
+
+# Depedencies
+
+[wrk](https://github.com/wg/wrk) is the HTTP benchmarking tool used.
+
+Your OS may have a binary for it available but if not, you'll have to compile it
+from source. To do that, clone its repo and run: `make`. This will output a
+binary executable in the directory you ran `make` in.
+
+Add the path to the binary to your path if it isn't already there.
+
+# Instructions
+
+Once all depedencies are met, you can run: `make` in the current directory:
+`benchmarks`.
+
+

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -5,7 +5,7 @@ var app = express();
 // number of middleware
 
 var n = parseInt(process.env.MW || '1', 10);
-console.log('  %s middleware', n);
+console.log('%s middleware', n);
 
 while (n--) {
   app.use(function(req, res, next){

--- a/benchmarks/results/v19.9.0/2023-04-22T23-27
+++ b/benchmarks/results/v19.9.0/2023-04-22T23-27
@@ -1,0 +1,51 @@
+notthelewis
+Intel_R_Core_TM_i7_8565UCPU_1_80GHz
+
+50 connections
+4.94ms
+9597.94
+
+50 connections
+4.91ms
+9860.20
+
+50 connections
+4.67ms
+10212.46
+
+50 connections
+4.91ms
+9615.04
+
+50 connections
+4.59ms
+10400.18
+
+50 connections
+4.87ms
+9822.32
+
+50 connections
+4.81ms
+9933.98
+
+50 connections
+4.86ms
+9864.17
+
+100 connections
+10.24ms
+9409.44
+
+250 connections
+28.58ms
+8728.76
+
+500 connections
+55.60ms
+8861.11
+
+1000 connections
+97.62ms
+9082.83
+

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
 echo
-MW=$1 node $2 &
+
+MIDDLEWARE=$1 node $2 &
 pid=$!
 
-echo "  $3 connections"
+OUT_PATH=$4
+
+echo "$3 connections" | tee -a $OUT_PATH
 
 sleep 2
 
@@ -13,6 +16,9 @@ wrk 'http://localhost:3333/?foo[bar]=baz' \
   -c $3 \
   -t 8 \
   | grep 'Requests/sec\|Latency' \
-  | awk '{ print " " $2 }'
+  | awk '{ print $2 }' \
+  | tee -a $OUT_PATH
+
+echo >> $OUT_PATH
 
 kill $pid


### PR DESCRIPTION
This is the first time I've ever commited to a public repository, so I hope I've ticked all the right boxes! 

I wanted to get stuck in and try to see if I could optimise anything, for curiosity's sake. I was delighted when I found the `benchmarks` folder but slightly disheartened when I couldn't find any documentation. 

This PR attempts to address the documentation issue but also adds new functionality: Historical benchmark storage.

The idea is to store every benchmark output in plain text, sorted by version number and stored alongside the CPU and username of the person who ran the benchmark. The latter two points I'm a little unsure of, as I don't know whether it could be a security issue to store the username and CPU model of everyone that runs the benchmark.

Alongside this, I'm a little unsure of the benefit of storing all benchmarks in the repository itself. Might it be a better idea to add them to a gitignore, and use them only for local reference- especially since results are going to be extremely hardware dependent?

I would like to take this barebones feature and mould it into a more cohesive reporting suite, which allows you to compare the current output with previous outputs- or compare any two outputs by taking in the two files. 

Before venturing too far down that path, I thought it best to try get a P.O.C in first and see whether this actually provides any value. Looking forward to hearing back :) 