### PR TITLE
tests: use cb() instead of done()

### DIFF
--- a/test/Router.js
+++ b/test/Router.js
@@ -606,8 +606,8 @@ describe('Router', function(){
       var req2 = { url: '/foo/10/bar', method: 'get' };
       var router = new Router();
       var sub = new Router();
+      var cb = after(2, done)
 
-      done = after(2, done);
 
       sub.get('/bar', function(req, res, next) {
         next();
@@ -626,14 +626,14 @@ describe('Router', function(){
         assert.ifError(err);
         assert.equal(req1.ms, 50);
         assert.equal(req1.originalUrl, '/foo/50/bar');
-        done();
+        cb()
       });
 
       router.handle(req2, {}, function(err) {
         assert.ifError(err);
         assert.equal(req2.ms, 10);
         assert.equal(req2.originalUrl, '/foo/10/bar');
-        done();
+        cb()
       });
     });
   });

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -896,7 +896,7 @@ describe('app.router', function(){
 
       request(app)
         .get('/foo.json')
-        .expect(200, 'foo as json', done)
+        .expect(200, 'foo as json', cb)
     })
   })
 

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -57,7 +57,7 @@ describe('app', function(){
 
       request(app)
         .get('/forum')
-        .expect(200, 'forum', done)
+        .expect(200, 'forum', cb)
     })
 
     it('should set the child\'s .parent', function(){


### PR DESCRIPTION
I changed two uses of the `done()` callback to `cb()` since, as far as I can tell, this is what was intended.

Also, I changed the reassignment of the `done()` callback to creating a new `cb()` callback, since this is less confusing and more consistent with the rest of the tests.

If these changes are mistaken, please let me know.