### PR TITLE
CVE-2022-21681. updated marked, disable unsupported opts

### DIFF
--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -17,7 +17,7 @@ var app = module.exports = express();
 app.engine('md', function(path, options, fn){
   fs.readFile(path, 'utf8', function(err, str){
     if (err) return fn(err);
-    var html = marked.parse(str).replace(/\{([^}]+)\}/g, function(_, name){
+    var html = marked.parse(str, {mangle: false, headerIds: false}).replace(/\{([^}]+)\}/g, function(_, name){
       return escapeHtml(options[name] || '');
     });
     fn(null, html);

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint": "8.36.0",
     "express-session": "1.17.2",
     "hbs": "4.2.0",
-    "marked": "0.7.0",
+    "marked": "6.0.0",
     "method-override": "3.0.0",
     "mocha": "10.2.0",
     "morgan": "1.10.0",


### PR DESCRIPTION
### CVE Link 🔗

[CVE-2022-21680](https://github.com/advisories/GHSA-rrrm-qjm4-v8hf)
[CVE-2022-21681](https://github.com/advisories/GHSA-5v2h-r2cx-5xgj)

### Notes ✍️

- `marked` was updated - [link](https://www.npmjs.com/package/marked);
- Unsupported options were disabled;