### PR TITLE
Bump qs to 6.9.7 (CVE-2022-24999)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "parseurl": "~1.3.3",
     "path-is-absolute": "1.0.1",
     "proxy-addr": "~2.0.7",
-    "qs": "6.9.6",
+    "qs": "6.9.7",
     "range-parser": "~1.2.1",
     "router": "2.0.0-beta.1",
     "safe-buffer": "5.2.1",


### PR DESCRIPTION
I'm using 5.x, and it still has a dependency on qs 6.9.6, which is [vulnerable to prototype pollution](https://github.com/advisories/GHSA-hrpp-h998-j3pp). I see you fixed it on master branch with version 6.11.0, but I wasn't sure if it was compatible with this 5.x branch. In doubt, I only bumped the patch version up to the first patched version.

Here's a [diff between qs 6.9.6 and 6.9.7](https://github.com/ljharb/qs/compare/v6.9.6...v6.9.7).