### PR TITLE
Bump body-parser to 2.0.0-beta.2 (CVE-2022-24999)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "accepts": "~1.3.7",
     "array-flatten": "3.0.0",
-    "body-parser": "2.0.0-beta.1",
+    "body-parser": "2.0.0-beta.2",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.4.1",


### PR DESCRIPTION
Bumping body-parser to beta.2 to address [a vulnerability in qs](https://github.com/advisories/GHSA-hrpp-h998-j3pp) that [has been fixed in this latest release](https://github.com/christianblais/body-parser/blob/fccaf4879e960d5e8b105759d39d4fc5ecf2f4e4/package.json#L19).