### PR TITLE
build: support Node.js 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 20.x
 
         include:
         - name: Node.js 0.10
@@ -112,6 +113,8 @@ jobs:
         - name: Node.js 19.x
           node-version: "19.7"
 
+        - name: Node.js 20.x
+          node-version: "20.9"
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR add supports for Node.js 20.9 in the CI