### PR TITLE
build: support Node.js 21.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 21.x
 
         include:
         - name: Node.js 0.10
@@ -111,6 +112,9 @@ jobs:
 
         - name: Node.js 19.x
           node-version: "19.7"
+
+        - name: Node.js 21.x
+          node-version: "21.1"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR add supports for Node.js 21.1 in the CI