### PR TITLE
build: add Node v20 and v21 into ci with minor version removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         - Node.js 18.x
         - Node.js 19.x
         - Node.js 20.x
+        - Node.js 21.x
 
         include:
         - name: Node.js 0.10
@@ -96,25 +97,28 @@ jobs:
           npm-i: mocha@9.2.2
 
         - name: Node.js 14.x
-          node-version: "14.20"
+          node-version: "14"
 
         - name: Node.js 15.x
-          node-version: "15.14"
+          node-version: "15"
 
         - name: Node.js 16.x
-          node-version: "16.20"
+          node-version: "16"
 
         - name: Node.js 17.x
-          node-version: "17.9"
+          node-version: "17"
 
         - name: Node.js 18.x
-          node-version: "18.15"
+          node-version: "18"
 
         - name: Node.js 19.x
-          node-version: "19.7"
+          node-version: "19"
 
         - name: Node.js 20.x
-          node-version: "20.9"
+          node-version: "20"
+
+        - name: Node.js 21.x
+          node-version: "21"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 20.x
 
         include:
         - name: Node.js 0.10
@@ -111,6 +112,9 @@ jobs:
 
         - name: Node.js 19.x
           node-version: "19.7"
+
+        - name: Node.js 20.x
+          node-version: "20.9"
 
     steps:
     - uses: actions/checkout@v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ environment:
     - nodejs_version: "11.15"
     - nodejs_version: "12.22"
     - nodejs_version: "13.14"
-    - nodejs_version: "14.20"
-    - nodejs_version: "15.14"
-    - nodejs_version: "16.20"
-    - nodejs_version: "17.9"
-    - nodejs_version: "18.15"
-    - nodejs_version: "19.7"
-    - nodejs_version: "20.9"
+    - nodejs_version: "14"
+    - nodejs_version: "15"
+    - nodejs_version: "16"
+    - nodejs_version: "17"
+    - nodejs_version: "18"
+    - nodejs_version: "19"
+    - nodejs_version: "20"
 cache:
   - node_modules
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
     - nodejs_version: "17.9"
     - nodejs_version: "18.15"
     - nodejs_version: "19.7"
+    - nodejs_version: "20.9"
 cache:
   - node_modules
 install:


### PR DESCRIPTION
Add Node.js v20 and v21 into the CI pipeline.
Remove hardcoded minor version (eg. `19.7`) from the node-version for those versions without specified dev dependencies. 
The nvm will automatically install the latest published minor version of Node.js, without the need of update every time.