### PR TITLE
Do not auto-remove content headers for body-less status codes

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -209,23 +209,26 @@ res.send = function send(body) {
   // freshness
   if (req.fresh) this.statusCode = 304;
 
-  // strip irrelevant headers
-  if (204 === this.statusCode || 304 === this.statusCode) {
+  // remove content headers for 204
+  if (this.statusCode === 204) {
     this.removeHeader('Content-Type');
     this.removeHeader('Content-Length');
     this.removeHeader('Transfer-Encoding');
-    chunk = '';
   }
 
   // alter headers for 205
   if (this.statusCode === 205) {
     this.set('Content-Length', '0')
     this.removeHeader('Transfer-Encoding')
-    chunk = ''
   }
 
-  if (req.method === 'HEAD') {
-    // skip body for HEAD
+  if (
+    req.method === 'HEAD' ||
+    this.statusCode === 204 ||
+    this.statusCode === 205 ||
+    this.statusCode === 304
+  ) {
+    // skip body
     this.end();
   } else {
     // respond

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -300,7 +300,7 @@ describe('res', function(){
   })
 
   describe('when .statusCode is 304', function(){
-    it('should strip Content-* fields, Transfer-Encoding field, and body', function(done){
+    it('should ignore the body', function(done){
       var app = express();
 
       app.use(function(req, res){
@@ -309,10 +309,9 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect(utils.shouldNotHaveHeader('Content-Type'))
-      .expect(utils.shouldNotHaveHeader('Content-Length'))
-      .expect(utils.shouldNotHaveHeader('Transfer-Encoding'))
-      .expect(304, '', done);
+      .expect(304)
+      .expect(utils.shouldNotHaveBody())
+      .end(done);
     })
   })
 


### PR DESCRIPTION
According to [RFC 2616 (HTTP/1.1 spec)](https://datatracker.ietf.org/doc/html/rfc2616#page-54) a `HEAD` request is supposed to return *exactly* the same entity-headers as a `GET` request but no body, ~~imho responding to such a request with a 204 status code seems reasonable, thus we should not remove any headers but only ensure that no body is sent.~~