### PR TITLE
Replace array-flatten package with JavaScript flat() function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -25,7 +25,6 @@ var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
 var deprecate = require('depd')('express');
-var flatten = require('array-flatten');
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var setPrototypeOf = require('setprototypeof')
@@ -211,7 +210,7 @@ app.use = function use(fn) {
     }
   }
 
-  var fns = flatten(slice.call(arguments, offset));
+  var fns = slice.call(arguments, offset).flat(Infinity);
 
   if (fns.length === 0) {
     throw new TypeError('app.use() requires a middleware function')

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -19,7 +19,6 @@ var methods = require('methods');
 var mixin = require('utils-merge');
 var debug = require('debug')('express:router');
 var deprecate = require('depd')('express');
-var flatten = require('array-flatten');
 var parseUrl = require('parseurl');
 var setPrototypeOf = require('setprototypeof')
 
@@ -456,7 +455,7 @@ proto.use = function use(fn) {
     }
   }
 
-  var callbacks = flatten(slice.call(arguments, offset));
+  var callbacks = slice.call(arguments, offset).flat(Infinity);
 
   if (callbacks.length === 0) {
     throw new TypeError('Router.use() requires a middleware function')

--- a/lib/router/route.js
+++ b/lib/router/route.js
@@ -14,7 +14,6 @@
  */
 
 var debug = require('debug')('express:router:route');
-var flatten = require('array-flatten');
 var Layer = require('./layer');
 var methods = require('methods');
 
@@ -182,7 +181,7 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
  */
 
 Route.prototype.all = function all() {
-  var handles = flatten(slice.call(arguments));
+  var handles = slice.call(arguments).flat(Infinity);
 
   for (var i = 0; i < handles.length; i++) {
     var handle = handles[i];
@@ -205,7 +204,7 @@ Route.prototype.all = function all() {
 
 methods.forEach(function(method){
   Route.prototype[method] = function(){
-    var handles = flatten(slice.call(arguments));
+    var handles = slice.call(arguments).flat(Infinity);
 
     for (var i = 0; i < handles.length; i++) {
       var handle = handles[i];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,6 @@ var Buffer = require('safe-buffer').Buffer
 var contentDisposition = require('content-disposition');
 var contentType = require('content-type');
 var deprecate = require('depd')('express');
-var flatten = require('array-flatten');
 var mime = require('send').mime;
 var etag = require('etag');
 var proxyaddr = require('proxy-addr');
@@ -66,9 +65,6 @@ exports.isAbsolute = function(path){
  * @return {Array}
  * @api private
  */
-
-exports.flatten = deprecate.function(flatten,
-  'utils.flatten: use array-flatten npm module instead');
 
 /**
  * Normalize the given `type`, for example "html" becomes "text/html".

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "accepts": "~1.3.8",
-    "array-flatten": "1.1.1",
     "body-parser": "1.20.2",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",

--- a/test/utils.js
+++ b/test/utils.js
@@ -87,10 +87,10 @@ describe('utils.isAbsolute()', function(){
   })
 })
 
-describe('utils.flatten(arr)', function(){
+describe('check array.flat()', function(){
   it('should flatten an array', function(){
     var arr = ['one', ['two', ['three', 'four'], 'five']];
-    var flat = utils.flatten(arr)
+    var flat = arr.flat(Infinity);
 
     assert.strictEqual(flat.length, 5)
     assert.strictEqual(flat[0], 'one')


### PR DESCRIPTION
This pull request replaces the array flatten function from the __array-flatten__ package with the built-in JavaScript __flat()__ function.