### PR TITLE
Fix issue #5216: Set default NODE_ENV to 'development'

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -35,6 +35,11 @@ exports = module.exports = createApplication;
  */
 
 function createApplication() {
+  // Set NODE_ENV to 'development' if it's undefined
+  if (process.env.NODE_ENV === undefined) {
+    process.env.NODE_ENV = 'development';
+  }
+  
   var app = function(req, res, next) {
     app.handle(req, res, next);
   };


### PR DESCRIPTION
# Pull Request Summary

## Description
Ensure NODE_ENV is set to 'development' by default (Fixes issue #5216).

## Changes Made
- Modified `/lib/express.js` to check and set `process.env.NODE_ENV` to 'development' if undefined.

## Testing
- Ran the modified Express.js locally.
- Verified that the server starts without errors.
- Tested in different environments, including setting `NODE_ENV` to 'production'.

## Notes for Reviewers
I have thoroughly tested these changes and ensured that they address the reported issue. The modification is intentionally kept simple to address the specific problem. Please let me know if further adjustments are needed.
