### PR TITLE
chore: add license readme badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,7 @@
   [![NPM Version][npm-version-image]][npm-url]
   [![NPM Install Size][npm-install-size-image]][npm-install-size-url]
   [![NPM Downloads][npm-downloads-image]][npm-downloads-url]
+  [![Licenses][licenses-image]][licenses-url]
 
 ```js
 const express = require('express')
@@ -158,6 +159,8 @@ The current lead maintainer is [Douglas Christopher Wilson](https://github.com/d
 [coveralls-url]: https://coveralls.io/r/expressjs/express?branch=master
 [github-actions-ci-image]: https://badgen.net/github/checks/expressjs/express/master?label=linux
 [github-actions-ci-url]: https://github.com/expressjs/express/actions/workflows/ci.yml
+[licenses-image]: https://licenses.dev/b/npm/express
+[licenses-url]: https://licenses.dev/npm/express
 [npm-downloads-image]: https://badgen.net/npm/dm/express
 [npm-downloads-url]: https://npmcharts.com/compare/express?minimal=true
 [npm-install-size-image]: https://badgen.net/packagephobia/install/express


### PR DESCRIPTION
This service recursively checks/lists all licenses within a package's dependency graph. 

In this case, express has 61 total licenses within its graph. Because there are 3 different license types (MIT, ISC, BSD3) – and they're all "green" licenses — the total number of licenses is shown.