### PR TITLE
Fix favicon-related bug in cookie-sessions example

### DIFF
--- a/examples/cookie-sessions/index.js
+++ b/examples/cookie-sessions/index.js
@@ -13,13 +13,10 @@ var app = module.exports = express();
 app.use(cookieSession({ secret: 'manny is cool' }));
 
 // do something with the session
-app.use(count);
-
-// custom middleware
-function count(req, res) {
+app.get('/', function (req, res) {
   req.session.count = (req.session.count || 0) + 1
   res.send('viewed ' + req.session.count + ' times\n')
-}
+})
 
 /* istanbul ignore next */
 if (!module.parent) {


### PR DESCRIPTION
Added the check for /favicon request in " count" middleware.  Without this check, a request to /favicon that is made by most browsers will also increment the counter. This will lead to unwanted behaviour when a reload of a page will increment the counter for 2 instead of 1.
<img width="378" alt="image" src="https://github.com/expressjs/express/assets/61388150/6a8cbcc4-2da1-4b0c-adfd-095e186fd4b1">
