### PR TITLE
Don't store request specific data into the Layer object

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -218,20 +218,19 @@ proto.handle = function handle(req, res, out) {
 
     // find next matching layer
     var layer;
-    var match;
+    var match = false;
     var route;
 
-    while (match !== true && idx < stack.length) {
+    while (match === false && idx < stack.length) {
       layer = stack[idx++];
-      match = matchLayer(layer, path);
+      try {
+        match = layer.match(path);
+      } catch (err) {
+        layerError = layerError || err;
+      }
       route = layer.route;
 
-      if (typeof match !== 'boolean') {
-        // hold on to layerError
-        layerError = layerError || match;
-      }
-
-      if (match !== true) {
+      if (match === false) {
         continue;
       }
 
@@ -261,7 +260,7 @@ proto.handle = function handle(req, res, out) {
     }
 
     // no match
-    if (match !== true) {
+    if (match === false) {
       return done(layerError);
     }
 
@@ -272,9 +271,9 @@ proto.handle = function handle(req, res, out) {
 
     // Capture one-time layer values
     req.params = self.mergeParams
-      ? mergeParams(layer.params, parentParams)
-      : layer.params;
-    var layerPath = layer.path;
+      ? mergeParams(match.params, parentParams)
+      : match.params;
+    var layerPath = match.path;
 
     // this should be done for the layer
     self.process_params(layer, paramcalled, req, res, function (err) {
@@ -570,22 +569,6 @@ function gettype(obj) {
   // inspect [[Class]] for objects
   return toString.call(obj)
     .replace(objectRegExp, '$1');
-}
-
-/**
- * Match path to a layer.
- *
- * @param {Layer} layer
- * @param {string} path
- * @private
- */
-
-function matchLayer(layer, path) {
-  try {
-    return layer.match(path);
-  } catch (err) {
-    return err;
-  }
 }
 
 // merge params with parent params

--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -40,8 +40,6 @@ function Layer(path, options, fn) {
 
   this.handle = fn;
   this.name = fn.name || '<anonymous>';
-  this.params = undefined;
-  this.path = undefined;
   this.regexp = pathRegexp(path, this.keys = [], opts);
 
   // set fast path flags
@@ -113,16 +111,18 @@ Layer.prototype.match = function match(path) {
   if (path != null) {
     // fast path non-ending match for / (any path matches)
     if (this.regexp.fast_slash) {
-      this.params = {}
-      this.path = ''
-      return true
+      return {
+        path: '',
+        params: {}
+      }
     }
 
     // fast path for * (everything matched in a param)
     if (this.regexp.fast_star) {
-      this.params = {'0': decode_param(path)}
-      this.path = path
-      return true
+      return {
+        path: path,
+        params: {'0': decode_param(path)}
+      }
     }
 
     // match the path
@@ -130,17 +130,12 @@ Layer.prototype.match = function match(path) {
   }
 
   if (!match) {
-    this.params = undefined;
-    this.path = undefined;
     return false;
   }
 
   // store values
-  this.params = {};
-  this.path = match[0]
-
   var keys = this.keys;
-  var params = this.params;
+  var params = {};
 
   for (var i = 1; i < match.length; i++) {
     var key = keys[i - 1];
@@ -152,7 +147,10 @@ Layer.prototype.match = function match(path) {
     }
   }
 
-  return true;
+  return {
+    path: match[0],
+    params: params
+  };
 };
 
 /**


### PR DESCRIPTION
Currently, the path & params of the latest request is stored into the last matched layer.
The "Layer" object should be immutable: a request should not modify its attributes.

This means that parameters are kept into memory after the end a request.

For example, this code will show the latest value of the parameter, as the value is stored until a new request is made:
```javascript
const express = require('./index.js');
const app = express();
const port = 3000;

app.get('/secret/:token', (req, res) => {
	res.send('Hello World!');
});

app.listen(port, () => {
	console.log(`Example app listening on port ${port}`);
});

setInterval(() => {
	console.log(app._router.stack.at(2).params);
}, 1000);
```

```bash
curl localhost:3000/secret/super_secret
```

Result:
```
Example app listening on port 3000
undefined
undefined
undefined
{ token: 'super_secret' }
{ token: 'super_secret' }

```