### PR TITLE
Add Dependency Review Action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1


### PR DESCRIPTION
### Main Changes

This GitHub action will add an additional check when a PR is created in the project and will review any change in the dependencies (cda07fd).

> This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
> _[Source repository](https://github.com/actions/dependency-review-action)_

Overall, this will prevent us to introduce vulnerable dependencies versions without the need to manually check that.

### Impact in the OSSF Scorecard

![Screenshot 2024-02-02 at 17 14 02](https://github.com/expressjs/express/assets/5110813/9c594c05-9c7b-4590-9576-d30bf689a127)

Note that our current score is 10/10, so this is a preventive measurement.

### Context

- Ref: https://github.com/expressjs/security-wg/issues/2
- Report: https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/expressjs/express/commit/2a00da2067b7017f769c9100205a2a5f267a884b

### Changelog

- cda07fd chore: add dependency review tool by @UlisesGascon
