### PR TITLE
patch(bigint): handle bigint in responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,9 @@ res.send = function send(body) {
     case 'boolean':
     case 'number':
     case 'object':
+    case 'bigint':
+      if (typeof chunk === 'bigint')
+        chunk = Number(chunk);
       if (chunk === null) {
         chunk = '';
       } else if (Buffer.isBuffer(chunk)) {
@@ -1130,6 +1133,43 @@ function sendfile(res, file, options, callback) {
   file.pipe(res);
 }
 
+
+function convertBigIntsToNumbers(obj) {
+  // If the type is a BigInt, convert them to number
+  if (typeof obj === 'bigint') {
+    return Number(obj);
+  }
+
+  // If the input is not an object or array, return it as is
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  // If it's an array, loop over its elements and convert them recursively
+  if (Array.isArray(obj)) {
+    for (var index = 0; index < obj.length; index += 1) {
+      obj[index] = convertBigIntsToNumbers(obj[index]);
+    }
+    return obj;
+  }
+
+  // Otherwise, it's an object, so iterate over its keys
+  for (var key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      var value = obj[key];
+      // If the value is a BigInt, convert it to a number
+      if (typeof value === 'bigint') {
+        obj[key] = Number(value);
+      } else if (typeof value === 'object') {
+        // If the value is an object, recursively convert it
+        obj[key] = convertBigIntsToNumbers(value);
+      }
+    }
+  }
+
+  return obj;
+}
+
 /**
  * Stringify JSON, like JSON.stringify, but v8 optimized, with the
  * ability to escape characters that can trigger HTML sniffing.
@@ -1145,9 +1185,10 @@ function sendfile(res, file, options, callback) {
 function stringify (value, replacer, spaces, escape) {
   // v8 checks arguments.length for optimizing simple call
   // https://bugs.chromium.org/p/v8/issues/detail?id=4730
+  var valueWithoutBigInt = convertBigIntsToNumbers(value);
   var json = replacer || spaces
-    ? JSON.stringify(value, replacer, spaces)
-    : JSON.stringify(value);
+    ? JSON.stringify(valueWithoutBigInt, replacer, spaces)
+    : JSON.stringify(valueWithoutBigInt);
 
   if (escape && typeof json === 'string') {
     json = json.replace(/[<>&]/g, function (c) {


### PR DESCRIPTION
converts bigints to numbers recursively in case of objects/arrays.

Hi there!
I have came across a situation in which we were not able to send responses directly due to bigints, earlier I used to handle this logic in my application code but I thought how about let express handles it automatically, so that new application user doesn't have to handle this on their own.

I have written logic in ES5 intentionally such that it doesn't break very old Nodejs versions if this PR gets merged.

I could have thought to write unit tests for the same, but can you confirm which is the minumum nodejs version should I set (is this progamatically possible btw ?) so that these tests should work only for those nodejs versions which supports BigInt.

@mikeal @peters @nick @mcolyer 