### PR TITLE
Update support Node.js@18 in the CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           node-version: "17.9"
 
         - name: Node.js 18.x
-          node-version: "18.17"
+          node-version: "18.19"
 
         - name: Node.js 19.x
           node-version: "19.9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
     - nodejs_version: "15.14"
     - nodejs_version: "16.20"
     - nodejs_version: "17.9"
-    - nodejs_version: "18.17"
+    - nodejs_version: "18.19"
     - nodejs_version: "19.9"
 cache:
   - node_modules


### PR DESCRIPTION
### Main Changes

Add support for Node 18.19.1 in the CI and appveyor (c7e075814e1cd973e8c43aa959d192a8eb3c68c4)

Note: Node 18.19.1 is last version available

### Changelog
- c7e075814e1cd973e8c43aa959d192a8eb3c68c4 build: support Node.js 18.19.1 by @UlisesGascon



