### PR TITLE
add Github Access Structure Overview section

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -91,7 +91,7 @@ Happy triaging!
 
 We're implementing a structured approach to GitHub permissions across our projects, ensuring clarity, security, and efficient collaboration. Each level of access is a superset of the permissions available to the level(s) below it in the hierarchy. Here’s an overview of the structure, permissions, and associated teams:
 
-* Technical Committee – admin permissions across all Express orgs ([expressjs](https://github.com/expressjs), [jshttp](https://github.com/jshttp), [pillarjs](https://github.com/pillarjs)). Highest level of access, owner permissions on repos and orgs. TC members will be added to a github team in each org, and permissions will be granted to the team.
+* Technical Committee – admin permissions across all Express orgs ([expressjs](https://github.com/expressjs), [jshttp](https://github.com/jshttp), [pillarjs](https://github.com/pillarjs)). Highest level of access, owner permissions on repos and orgs. 
 
 * Project Captain – admin permissions on a specific repo. Permissions similar to TC, but scoped to a specific repo not an entire org. Permissions must be applied manually to a Project Captain user as a result. Creating a github team for this is optional, as the permissions are not applied at the team level.
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -91,13 +91,13 @@ Happy triaging!
 
 We're implementing a structured approach to GitHub permissions across our projects, ensuring clarity, security, and efficient collaboration. Each level of access is a superset of the permissions available to the level(s) below it in the hierarchy. Here’s an overview of the structure, permissions, and associated teams:
 
-* Technical Committee – admin permissions across all Express orgs (Expressjs, jshttp, pillarjs). Highest level of access, owner permissions on repos and orgs. TC members will be added to a github team in each org, and permissions will be granted to the team.
+* Technical Committee – admin permissions across all Express orgs ([expressjs](https://github.com/expressjs), [jshttp](https://github.com/jshttp), [pillarjs](https://github.com/pillarjs)). Highest level of access, owner permissions on repos and orgs. TC members will be added to a github team in each org, and permissions will be granted to the team.
 
 * Project Captain – admin permissions on a specific repo. Permissions similar to TC, but scoped to a specific repo not an entire org. Permissions must be applied manually to a Project Captain user as a result. Creating a github team for this is optional, as the permissions are not applied at the team level.
 
 * Committer – commit bit on a given repo or repos. Permissions must be applied manually. Github team here is optional, but recommended. All members of the org who have a commit bit for one or more repos can be members.
 
-* Triager – can close/tag/manage issues/discussions across all orgs. See the Triager Guide for more information. Triagers will be added to a github team in each org, and permissions will be granted to the team.
+* Triager – can close/tag/manage issues/discussions across all orgs. See the [Triager Guide](Triager-Guide.md) for more information. Triagers will be added to a github team in each org, and permissions will be granted to the team.
 
 ## Becoming a Committer
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -87,6 +87,18 @@ the organizations requested. They will then close the issue.
 
 Happy triaging!
 
+## GitHub Access Structure Overview
+
+We're implementing a structured approach to GitHub permissions across our projects, ensuring clarity, security, and efficient collaboration. Each level of access is a superset of the permissions available to the level(s) below it in the hierarchy. Here’s an overview of the structure, permissions, and associated teams:
+
+* Technical Committee – admin permissions across all Express orgs (Expressjs, jshttp, pillarjs). Highest level of access, owner permissions on repos and orgs. TC members will be added to a github team in each org, and permissions will be granted to the team.
+
+* Project Captain – admin permissions on a specific repo. Permissions similar to TC, but scoped to a specific repo not an entire org. Permissions must be applied manually to a Project Captain user as a result. Creating a github team for this is optional, as the permissions are not applied at the team level.
+
+* Committer – commit bit on a given repo or repos. Permissions must be applied manually. Github team here is optional, but recommended. All members of the org who have a commit bit for one or more repos can be members.
+
+* Triager – can close/tag/manage issues/discussions across all orgs. See the Triager Guide for more information. Triagers will be added to a github team in each org, and permissions will be granted to the team.
+
 ## Becoming a Committer
 
 All contributors who land a non-trivial contribution should be on-boarded in a timely manner,

--- a/Contributing.md
+++ b/Contributing.md
@@ -93,9 +93,9 @@ We're implementing a structured approach to GitHub permissions across our projec
 
 * Technical Committee – admin permissions across all Express orgs ([expressjs](https://github.com/expressjs), [jshttp](https://github.com/jshttp), [pillarjs](https://github.com/pillarjs)). Highest level of access, owner permissions on repos and orgs. 
 
-* Project Captain – admin permissions on a specific repo. Permissions similar to TC, but scoped to a specific repo not an entire org. Permissions must be applied manually to a Project Captain user as a result. Creating a github team for this is optional, as the permissions are not applied at the team level.
+* Project Captain – admin permissions on a specific repo. Permissions similar to TC, but scoped to a specific repo not an entire org. Permissions must be applied individually to a Project Captain user as a result. Creating a github team for this is optional, as the permissions are not applied at the team level.
 
-* Committer – commit bit on a given repo or repos. Permissions must be applied manually. Github team here is optional, but recommended. All members of the org who have a commit bit for one or more repos can be members.
+* Committer – commit bit on a given repo or repos. Permissions must be applied individually to the user. Github team here is optional, but recommended. All members of the org who have a commit bit for one or more repos can be members.
 
 * Triager – can close/tag/manage issues/discussions across all orgs. See the [Triager Guide](Triager-Guide.md) for more information. Triagers will be added to a github team in each org, and permissions will be granted to the team.
 


### PR DESCRIPTION
Here's a first pass at adding a section about planned Org/Repo access levels. 

This doesn't spell out what _has changed_ or _will change_ about who has access. You can see some of the shaking out of dust in this issue https://github.com/expressjs/discussions/issues/132

We should document that somewhere, but I wanted to open a PR to land what I've seen proposed. 

I went with my own definitions and opinions here, and specifically am curious if I got the role for Committer correct re: access to a single repo vs all repos in an org. 