### PR TITLE
TC Charter

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -99,35 +99,12 @@ proper review, and have other committers merge their pull requests.
 
 The TC uses a "consensus seeking" process for issues that are escalated to the TC.
 The group tries to find a resolution that has no open objections among TC members.
+
 If a consensus cannot be reached that has no objections then a majority wins vote
 is called. It is also expected that the majority of decisions made by the TC are via
 a consensus seeking process and that voting is only used as a last-resort.
 
-Resolution may involve returning the issue to project captains with suggestions on
-how to move forward towards a consensus. It is not expected that a meeting of the TC
-will resolve all issues on its agenda during that meeting and may prefer to continue
-the discussion happening among the project captains.
-
-Members can be added to the TC at any time. Any TC member can nominate another committer
-to the TC and the TC uses its standard consensus seeking process to evaluate whether or
-not to add this new member. The TC will consist of a minimum of 3 active members and a
-maximum of 10. If the TC should drop below 5 members the active TC members should nominate
-someone new. If a TC member is stepping down, they are encouraged (but not required) to
-nominate someone to take their place.
-
-TC members will be added as admin's on the Github orgs, npm orgs, and other resources as
-necessary to be effective in the role.
-
-To remain "active" a TC member should have participation within the last 6 months and miss
-no more than three consecutive TC meetings. Members who do not meet this are expected to step down.
-If A TC member does not step down, an issue can be opened in the discussions repo to move them
-to inactive status. TC members who step down or are removed due to inactivity will be moved
-into inactive status.
-
-Inactive status members can become active members by self nomination if the TC is not already
-larger than the maximum of 10. They will also be given preference if, while at max size, an
-active member steps down.
-
+For more info about the TC such as eligibility, role, and governance see the [TC Charter](TC-Charter.md).
 ## Project Captains
 
 The Express TC can designate captains for individual projects/repos in the

--- a/TC-Charter.md
+++ b/TC-Charter.md
@@ -37,7 +37,17 @@ Intentionally left blank
 
 ## Decision-Making Process
 
-Intentionally left blank
+The TC uses a "consensus seeking" process for issues that are escalated to the TC.
+The group tries to find a resolution that has no open objections among TC members.
+
+If a consensus cannot be reached that has no objections then a majority wins vote
+is called. It is also expected that the majority of decisions made by the TC are via
+a consensus seeking process and that voting is only used as a last-resort.
+
+Resolution may involve returning the issue to project captains with suggestions on
+how to move forward towards a consensus. It is not expected that a meeting of the TC
+will resolve all issues on its agenda during that meeting and may prefer to continue
+the discussion happening among the project captains.
 
 ## Responsibilities
 

--- a/TC-Charter.md
+++ b/TC-Charter.md
@@ -47,14 +47,9 @@ Intentionally left blank
 - **Security**: Ensuring the project adheres to best practices for security, including regular audits, addressing vulnerabilities, and maintaining a security policy.
 - **Communications**: Representing the project in public forums, conferences, and within the wider Node.js and JavaScript communities.
 
-## Change Management
-
-Intentionally left blank
-
 ## Representation in Cross Project Council (CPC)
 
-- **Duties**: The responsibilities of TC members representing the project in the CPC, including voting on cross-project initiatives and advocacy for the Express project.
-- **Selection**: The process for choosing TC representatives for the CPC, term lengths, and expectations for representation.
+Intentionally left blank
 
 ## Amendments to the Charter
 

--- a/TC-Charter.md
+++ b/TC-Charter.md
@@ -1,0 +1,62 @@
+# Express Technical Committee (TC) Roles and Responsibilities
+
+## Introduction
+
+This document provides a comprehensive overview of the roles and responsibilities of the Express Technical Committee (TC). The TC plays a pivotal role in guiding the Express project's direction, ensuring its growth, stability, and alignment with the community's needs.
+
+## Purpose of the TC
+
+The TC is responsible for strategic planning, project oversight, and decision-making concerning the technical and operational aspects of the Express project. Its primary goal is to foster the development of Express as a robust, scalable, and secure framework for building web applications.
+
+## TC Membership
+
+### Eligibility
+
+- **Criteria**: Potential TC members should demonstrate significant contributions to the project, possess deep expertise in the Express framework and related technologies, and actively engage in the community. Eligibility is determined by contributions to code, documentation, community support, and involvement in project discussions.
+
+### Selection Process
+
+- **Nomination**: Any current TC member can nominate a committer to the TC. The nominee's contributions and engagement with the project are then evaluated through the TC's consensus-seeking process.
+- **Consensus Seeking**: As outlined in the Contributing.md, the TC strives for a resolution without open objections among members. If consensus cannot be reached, a majority vote is called. This process underscores that voting is a method of last resort.
+- **Membership Limits**: The TC will consist of a minimum of 3 active members and a maximum of 10, ensuring effective governance while maintaining a manageable group size for decision-making.
+
+### Responsibilities
+
+- **Active Participation**: TC members are expected to actively participate in discussions, contribute to decision-making processes, and engage in project governance. Participation in TC meetings is crucial, with the expectation to not miss more than three consecutive meetings.
+- **Maintaining Active Status**: Active participation within the last 6 months is required to maintain active TC status. Members not meeting this criterion are expected to step down or may be moved to inactive status, as detailed in the Contributing.md.
+- **Role of Project Captains**: Collaborate with project captains, providing guidance and suggestions to help move discussions forward towards consensus, especially on issues escalated to the TC.
+
+## Managing Inactivity and Transitions
+
+- **Inactivity and Transition**: The process for addressing inactivity and transitions within the TC, including stepping down and nominating replacements, aligns with the practices described in the Contributing.md. TC members stepping down are encouraged to nominate their replacements, ensuring continuity and knowledge transfer.
+- **Inactive Status**: Members who become inactive or do not meet the active participation requirements will be moved to inactive status but can nominate themselves back to active status if the TC has not reached its maximum size. Preference is given to returning inactive members in the event of a vacancy, provided the maximum size limit is respected.
+
+## Governance Structure
+
+Intentionally left blank
+
+## Decision-Making Process
+
+Intentionally left blank
+
+## Responsibilities
+
+- **Technical Oversight**: Overseeing the technical direction of the project, including the review and approval of project enhancements, architecture decisions, and major releases.
+- **Community Engagement**: Fostering a healthy community by engaging with contributors, addressing conflicts, and ensuring a welcoming environment for new contributors.
+- **Financial and Legal Oversight**: If applicable, managing the project's finances, fundraising efforts, and adherence to legal and licensing obligations.
+- **Security**: Ensuring the project adheres to best practices for security, including regular audits, addressing vulnerabilities, and maintaining a security policy.
+- **Communications**: Representing the project in public forums, conferences, and within the wider Node.js and JavaScript communities.
+
+## Change Management
+
+Intentionally left blank
+
+## Representation in Cross Project Council (CPC)
+
+- **Duties**: The responsibilities of TC members representing the project in the CPC, including voting on cross-project initiatives and advocacy for the Express project.
+- **Selection**: The process for choosing TC representatives for the CPC, term lengths, and expectations for representation.
+
+## Amendments to the Charter
+
+Intentionally left blank
+

--- a/TC-Charter.md
+++ b/TC-Charter.md
@@ -53,5 +53,5 @@ Intentionally left blank
 
 ## Amendments to the Charter
 
-Intentionally left blank
-
+This charter can be amended by the TC requiring at least two approvals and a minimum two
+week comment period for other TC members or CPC members to object.


### PR DESCRIPTION
An expectation of https://github.com/expressjs/discussions/issues/169 (Define Technical Committee role) is

> Charter for the TC and specific part for processes that could involve the TC, for example nominating new TC members, appointing a Captain or creating a Working Group.
This would also include role of the TC at a more global scope, for example CPC representation

I don't think we've addressed this directly yet, so here is a draft to do so. 

With this, I am requesting input or direct pushes to this branch (I am turning on Allow Edits from Maintainers to allow pushing to my fork). The sections in this doc are my opinion of what are required to document the TC process to the satisfaction of the EFI section Define Technical Committee Role. Missing from that EFI doc is language around Working Groups and Project Captains.

Specifically I've left blank:

* Governance Structure
* ~Decision making process~ (lifted langauge from Contributing.md, still open for improvement)
* ~Change Management~ (removed this as it's vague and covered by Amendments)
* ~Amendments to the charter~ (lifted some language from Charter.md, still open for improvement)
* CPC Representation