### PR TITLE
docs: nominating @wesleytodd to be project captian

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -154,7 +154,21 @@ dissent.  When the PR is merged, a TC member will add them to the proper GitHub/
 
 ### Current Project Captains
 
-- `expressjs.com`: @crandmck
-- `multer`: @LinusU
-- `path-to-regexp`: @blakeembrey
-- `router`: @dougwilson
+- `expressjs/express`: @wesleytodd
+- `expressjs/discussions`: @wesleytodd
+- `expressjs/expressjs.com`: @crandmck
+- `expressjs/body-parser`: @wesleytodd
+- `expressjs/multer`: @LinusU
+- `expressjs/cookie-parser`: @wesleytodd
+- `expressjs/generator`: @wesleytodd
+- `expressjs/statusboard`: @wesleytodd
+- `pillarjs/path-to-regexp`: @blakeembrey
+- `pillarjs/router`: @dougwilson, @wesleytodd
+- `pillarjs/finalhandler`: @wesleytodd
+- `pillarjs/request`: @wesleytodd
+- `jshttp/http-errors`: @wesleytodd
+- `jshttp/cookie`: @wesleytodd
+- `jshttp/on-finished`: @wesleytodd
+- `jshttp/forwarded`: @wesleytodd
+- `jshttp/proxy-addr`: @wesleytodd
+


### PR DESCRIPTION
I wanted to get the ball rolling on having folks self nominate for repos they particularly would like to help with in the captain role. We can (and should) have multiple for each.

The main issue right now is that most of us are *not* committers for 6 months (even those of on the TC) but I think that we should make an exception to ensure that we have coverage for now. My thinking was that if we can get active folks on each we can start getting the repos organized and ensure nothing is falling through the cracks. Is anyone opposed to this exception to get us started?