### PR TITLE
fix #5554 passing URL instances with new location encoding

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased changes
+==========
+
+  * Allow passing non-strings to res.location with new encoding handling checks
+
 4.19.0 / 2024-03-20
 ==========
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -905,7 +905,7 @@ res.cookie = function (name, value, options) {
  */
 
 res.location = function location(url) {
-  var loc = url;
+  var loc = String(url);
 
   // "back" is an alias for the referrer
   if (url === 'back') {

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -145,5 +145,20 @@ describe('res', function(){
         .expect(200, done)
       })
     })
+
+    if (typeof URL !== 'undefined') {
+      it('should accept an instance of URL', function (done) {
+        var app = express();
+
+        app.use(function(req, res){
+          res.location(new URL('http://google.com/')).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect('Location', 'http://google.com/')
+          .expect(200, done);
+      });
+    }
   })
 })


### PR DESCRIPTION
The new check did not account for operating on the input to `.location` previously being wrapped with `String()` inside `encodeurl`. Adds explicit fix for that.