### PR TITLE
Cut down on duplicated CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,9 @@ on:
       - '4.x'
       - '5.x'
     paths-ignore:
-      - 'examples/**'
       - '*.md'
   pull_request:
     paths-ignore:
-      - 'examples/**'
       - '*.md'
 
 # Cancel in progress workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ on:
       - 'examples/**'
       - '*.md'
 
+# Cancel in progress workflows
+# in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
+concurrency:
+  group: "${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - develop
       - '4.x'
       - '5.x'
     paths-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,18 @@
 name: ci
 
 on:
-- pull_request
-- push
+  push:
+    branches:
+      - master
+      - '4.x'
+      - '5.x'
+    paths-ignore:
+      - 'examples/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'examples/**'
+      - '*.md'
 
 jobs:
   test:


### PR DESCRIPTION
## The Issue

The combination of running on all PR and all Push rn means that if a maintainer creates a branch just for a PR, but pushes the branch to `origin` instead of their `upstream` fork, we will run CI twice.

An example of the duplicated runs can be seen on this PR:

https://github.com/expressjs/express/pull/5562

It ran 48 status checks, which is all 24 in the CI job x2. One for the push event and one for the PR event:

<img width="599" alt="Screenshot 2024-03-25 at 10 20 23 PM" src="https://github.com/expressjs/express/assets/12915163/3a83aac3-04ae-4868-84d1-b607c2e72326">

This is wasteful of CI time, but also likely not intended behavior.

## The Change
> Note: none of these changes would impact the Windows tests configured through appveyor, the status of which we can tackle elsewhere

### Only run CI for push events on select branches
We'll still run on all PRs, this limits only our runs triggered by pushes to branches on `origin`.

For selected branches I added:

* `master`
* `develop` 
* `4.x`
* `5.x` 

We could try a glob for versions instead, but this should be fine until we need that. 

### Skip CI if the change is only to `.md` files

We don't lint md currently, so if a PR only changes md, no need to run any of our ci jobs

### Manage concurrency

Leverages github actions concurrency group feature to stop any workflows for a given PR or HEAD if a newer trigger is run for that same PR or HEAD. Essentially dedupes, ensuring only the newest changes are fully run.
