### PR TITLE
deps: encodeurl@~2.0.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+  * deps: encodeurl@~2.0.0
+    - Removes encoding of `\`, `|`, and `^` to align better with URL spec
+
 4.19.2 / 2024-03-25
 ==========
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -55,7 +55,6 @@ module.exports = res
  */
 
 var charsetRegExp = /;\s*charset\s*=/;
-var schemaAndHostRegExp = /^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?\/\/[^\\\/\?]+/;
 
 /**
  * Set status `code`.
@@ -914,14 +913,7 @@ res.location = function location(url) {
     loc = String(url);
   }
 
-  var m = schemaAndHostRegExp.exec(loc);
-  var pos = m ? m[0].length + 1 : 0;
-
-  // Only encode after host to avoid invalid encoding which can introduce
-  // vulnerabilities (e.g. `\\` to `%5C`).
-  loc = loc.slice(0, pos) + encodeUrl(loc.slice(pos));
-
-  return this.set('Location', loc);
+  return this.set('Location', encodeUrl(loc));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cookie-signature": "1.0.6",
     "debug": "2.6.9",
     "depd": "2.0.0",
-    "encodeurl": "~1.0.2",
+    "encodeurl": "~2.0.0",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",
     "finalhandler": "1.2.0",

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -293,23 +293,12 @@ describe('res', function(){
       );
     });
 
-    it('should percent encode backslashes in the path', function (done) {
+    it('should keep backslashes in the path', function (done) {
       var app = createRedirectServerForDomain('google.com');
       testRequestedRedirect(
         app,
         'https://google.com/foo\\bar\\baz',
-        'https://google.com/foo%5Cbar%5Cbaz',
-        'google.com',
-        done
-      );
-    });
-
-    it('should encode backslashes in the path after the first backslash that triggered path parsing', function (done) {
-      var app = createRedirectServerForDomain('google.com');
-      testRequestedRedirect(
-        app,
-        'https://google.com\\@app\\l\\e.com',
-        'https://google.com\\@app%5Cl%5Ce.com',
+        'https://google.com/foo\\bar\\baz',
         'google.com',
         done
       );
@@ -364,7 +353,7 @@ describe('res', function(){
       testRequestedRedirect(
         app,
         'file:///etc\\passwd',
-        'file:///etc%5Cpasswd',
+        'file:///etc\\passwd',
         '',
         done
       );


### PR DESCRIPTION
This should be an improved and more flexible fix over https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94. No more parsing required, but it does change the encoding behavior of 3 characters (`\`, `|`, `^`). They will no longer be encoded. I'm considering this a continuation of the bug fix, although it introduces a potential breaking change for any one that might have been relying on `\` to be encoded in the location header without having encoding it themselves. I believe the impact should be negligible to non-existent, but it's not possible to confirm before landing this fix.

This fix is preferred over the existing patch in master because it'll better handle all alternative formats of URLs and encode them consistently.