### PR TITLE
Do Not Log Errors to Console If Env is Production

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -644,7 +644,8 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test' && this.get('env') !== 'production') 
+    console.error(err.stack || err.toString());
 }
 
 /**


### PR DESCRIPTION
### Change
Changed the logic that prints the stack trace to the console on errors to not trigger when env is `production` or `test`. 

### Reason
According to the [Express documentation](https://expressjs.com/en/guide/error-handling.html#writing-error-handlers) on error handling, if you run an application with `NODE_ENV: production`, it is not supposed to log stack traces to the console. The only thing preventing the logging was `NODE_ENV === 'test`. This updates to include `NODE_ENV === 'production'` as well. 

![CleanShot 2024-03-29 at 13 22 42](https://github.com/expressjs/express/assets/22082031/8c590341-7ea5-4a7e-913a-1f56c1d58652)

### Context

Have been working through an issue with a project using Express and Datadog, and having issues where Datadog was pulling logs in for errors seperated line by line. This adds to our logging costs and was unknown why this was happening until I realized Express in `production` still logs the stack traces to `console.error` for every error, which Datadog was picking up off our container. 

This change should prevent that from happening in the future versions of Express.