### PR TITLE
Nominate jonchurch as repo captain for `http-errors`, `expressjs.com`, `morgan`, `cors`, `body-parser`

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -158,17 +158,19 @@ dissent.  When the PR is merged, a TC member will add them to the proper GitHub/
 
 - `expressjs/express`: @wesleytodd
 - `expressjs/discussions`: @wesleytodd
-- `expressjs/expressjs.com`: @crandmck
-- `expressjs/body-parser`: @wesleytodd
+- `expressjs/expressjs.com`: @crandmck, @jonchurch
+- `expressjs/body-parser`: @wesleytodd, @jonchurch
 - `expressjs/multer`: @LinusU
+- `expressjs/morgan`: @jonchurch
 - `expressjs/cookie-parser`: @wesleytodd
+- `expressjs/cors`: @jonchurch
 - `expressjs/generator`: @wesleytodd
 - `expressjs/statusboard`: @wesleytodd
 - `pillarjs/path-to-regexp`: @blakeembrey
 - `pillarjs/router`: @dougwilson, @wesleytodd
 - `pillarjs/finalhandler`: @wesleytodd
 - `pillarjs/request`: @wesleytodd
-- `jshttp/http-errors`: @wesleytodd
+- `jshttp/http-errors`: @wesleytodd, @jonchurch
 - `jshttp/cookie`: @wesleytodd
 - `jshttp/on-finished`: @wesleytodd
 - `jshttp/forwarded`: @wesleytodd


### PR DESCRIPTION
Hey @expressjs/express-tc 

I want to help captain `expressjs.com` with @crandmck, as well as co-captain `http-errors` with @wesleytodd.

I have gone on a deep dive on http-errors recently in https://github.com/jshttp/http-errors/issues/104 and https://github.com/jshttp/http-errors/issues/98

No this-next-week-plans for releasing anything, my goal of captaining is to help focus my scope of involvement in express so I can get more done.

> I'm also interested in captaining `cors`, but want to deep dive on it first before I PR that in.

EDIT: After talking offline, Im putting my name out there for `morgan, cors, body-parser` (body-parser co-captain with Wes). These can always change, but having someone at the helm helps a lot as these are high impact packages.