### PR TITLE
Adopt Node@18 as the minimum supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,83 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         name:
-        - Node.js 4.0
-        - Node.js 4.x
-        - Node.js 5.x
-        - Node.js 6.x
-        - Node.js 7.x
-        - Node.js 8.x
-        - Node.js 9.x
-        - Node.js 10.x
-        - Node.js 11.x
-        - Node.js 12.x
-        - Node.js 13.x
-        - Node.js 14.x
-        - Node.js 15.x
-        - Node.js 16.x
-        - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
         - Node.js 20.x
         - Node.js 21.x
 
         include:
-        - name: Node.js 4.0
-          node-version: "4.0"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 4.x
-          node-version: "4.9"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 5.x
-          node-version: "5.12"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 6.x
-          node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
-
-        - name: Node.js 7.x
-          node-version: "7.10"
-          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
-
-        - name: Node.js 8.x
-          node-version: "8.17"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 9.x
-          node-version: "9.11"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 10.x
-          node-version: "10.24"
-          npm-i: mocha@8.4.0
-
-        - name: Node.js 11.x
-          node-version: "11.15"
-          npm-i: mocha@8.4.0
-
-        - name: Node.js 12.x
-          node-version: "12.22"
-          npm-i: mocha@9.2.2
-
-        - name: Node.js 13.x
-          node-version: "13.14"
-          npm-i: mocha@9.2.2
-
-        - name: Node.js 14.x
-          node-version: "14.20"
-
-        - name: Node.js 15.x
-          node-version: "15.14"
-
-        - name: Node.js 16.x
-          node-version: "16.20"
-
-        - name: Node.js 17.x
-          node-version: "17.9"
-
         - name: Node.js 18.x
           node-version: "18.19"
 
@@ -124,18 +53,6 @@ jobs:
 
     - name: Remove non-test dependencies
       run: npm rm --silent --save-dev connect-redis
-
-    - name: Setup Node.js version-specific dependencies
-      shell: bash
-      run: |
-        # eslint for linting
-        # - remove on Node.js < 12
-        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 12 ]]; then
-          node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
-            grep -E '^eslint(-|$)' | \
-            sort -r | \
-            xargs -n1 npm rm --silent --save-dev
-        fi
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name:
-        - Node.js 18.x
-        - Node.js 19.x
-        - Node.js 20.x
-        - Node.js 21.x
+        node-version: [18, 19, 20, 21, 22]
+        # Node.js release schedule: https://nodejs.org/en/about/releases/
 
-        include:
-        - name: Node.js 18.x
-          node-version: "18.19"
-
-        - name: Node.js 19.x
-          node-version: "19.9"
-
-        - name: Node.js 20.x
-          node-version: "20.11"
-
-        - name: Node.js 21.x
-          node-version: "21.6"
+    name: Node.js ${{ matrix.node-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -70,7 +56,7 @@ jobs:
       shell: bash
       run: |
         npm run test-ci
-        cp coverage/lcov.info "coverage/${{ matrix.name }}.lcov"
+        cp coverage/lcov.info "coverage/${{ matrix.node-version }}.lcov"
 
     - name: Lint code
       if: steps.list_env.outputs.eslint != ''
@@ -78,9 +64,9 @@ jobs:
 
     - name: Collect code coverage
       run: |
-        mv ./coverage "./${{ matrix.name }}"
+        mv ./coverage "./${{ matrix.node-version }}"
         mkdir ./coverage
-        mv "./${{ matrix.name }}" "./coverage/${{ matrix.name }}"
+        mv "./${{ matrix.node-version }}" "./coverage/${{ matrix.node-version }}"
 
     - name: Upload code coverage
       uses: actions/upload-artifact@v3

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -11,14 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         name:
-        - Node.js 4.0
-        - Node.js 4.x
-        - Node.js 5.x
-        - Node.js 6.x
-        - Node.js 7.x
-        - Node.js 8.x
-        - Node.js 9.x
-        - Node.js 10.x
         - Node.js 11.x
         - Node.js 12.x
         - Node.js 13.x
@@ -28,38 +20,6 @@ jobs:
         - Node.js 17.x
 
         include:
-        - name: Node.js 4.0
-          node-version: "4.0"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 4.x
-          node-version: "4.9"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 5.x
-          node-version: "5.12"
-          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
-
-        - name: Node.js 6.x
-          node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
-
-        - name: Node.js 7.x
-          node-version: "7.10"
-          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
-
-        - name: Node.js 8.x
-          node-version: "8.17"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 9.x
-          node-version: "9.11"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 10.x
-          node-version: "10.24"
-          npm-i: mocha@8.4.0
-
         - name: Node.js 11.x
           node-version: "11.15"
           npm-i: mocha@8.4.0

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,0 +1,182 @@
+name: legacy
+
+on:
+- pull_request
+- push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+        - Node.js 4.0
+        - Node.js 4.x
+        - Node.js 5.x
+        - Node.js 6.x
+        - Node.js 7.x
+        - Node.js 8.x
+        - Node.js 9.x
+        - Node.js 10.x
+        - Node.js 11.x
+        - Node.js 12.x
+        - Node.js 13.x
+        - Node.js 14.x
+        - Node.js 15.x
+        - Node.js 16.x
+        - Node.js 17.x
+
+        include:
+        - name: Node.js 4.0
+          node-version: "4.0"
+          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
+
+        - name: Node.js 4.x
+          node-version: "4.9"
+          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
+
+        - name: Node.js 5.x
+          node-version: "5.12"
+          npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
+
+        - name: Node.js 6.x
+          node-version: "6.17"
+          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
+
+        - name: Node.js 7.x
+          node-version: "7.10"
+          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
+
+        - name: Node.js 8.x
+          node-version: "8.17"
+          npm-i: mocha@7.2.0 nyc@14.1.1
+
+        - name: Node.js 9.x
+          node-version: "9.11"
+          npm-i: mocha@7.2.0 nyc@14.1.1
+
+        - name: Node.js 10.x
+          node-version: "10.24"
+          npm-i: mocha@8.4.0
+
+        - name: Node.js 11.x
+          node-version: "11.15"
+          npm-i: mocha@8.4.0
+
+        - name: Node.js 12.x
+          node-version: "12.22"
+          npm-i: mocha@9.2.2
+
+        - name: Node.js 13.x
+          node-version: "13.14"
+          npm-i: mocha@9.2.2
+
+        - name: Node.js 14.x
+          node-version: "14.20"
+
+        - name: Node.js 15.x
+          node-version: "15.14"
+
+        - name: Node.js 16.x
+          node-version: "16.20"
+
+        - name: Node.js 17.x
+          node-version: "17.9"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Node.js ${{ matrix.node-version }}
+      shell: bash -eo pipefail -l {0}
+      run: |
+        nvm install --default ${{ matrix.node-version }}
+        dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
+
+    - name: Configure npm
+      run: |
+        npm config set loglevel error
+        if [[ "$(npm config get package-lock)" == "true" ]]; then
+          npm config set package-lock false
+        else
+          npm config set shrinkwrap false
+        fi
+
+    - name: Install npm module(s) ${{ matrix.npm-i }}
+      run: npm install --save-dev ${{ matrix.npm-i }}
+      if: matrix.npm-i != ''
+
+    - name: Remove non-test dependencies
+      run: npm rm --silent --save-dev connect-redis
+
+    - name: Setup Node.js version-specific dependencies
+      shell: bash
+      run: |
+        # eslint for linting
+        # - remove on Node.js < 12
+        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 12 ]]; then
+          node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
+            grep -E '^eslint(-|$)' | \
+            sort -r | \
+            xargs -n1 npm rm --silent --save-dev
+        fi
+
+    - name: Install Node.js dependencies
+      run: npm install
+
+    - name: List environment
+      id: list_env
+      shell: bash
+      run: |
+        echo "node@$(node -v)"
+        echo "npm@$(npm -v)"
+        npm -s ls ||:
+        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print $2 "=" $3 }' >> "$GITHUB_OUTPUT"
+
+    - name: Run tests
+      shell: bash
+      run: |
+        npm run test-ci
+        cp coverage/lcov.info "coverage/${{ matrix.name }}.lcov"
+
+    - name: Lint code
+      if: steps.list_env.outputs.eslint != ''
+      run: npm run lint
+
+    - name: Collect code coverage
+      run: |
+        mv ./coverage "./${{ matrix.name }}"
+        mkdir ./coverage
+        mv "./${{ matrix.name }}" "./coverage/${{ matrix.name }}"
+
+    - name: Upload code coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: ./coverage
+        retention-days: 1
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install lcov
+      shell: bash
+      run: sudo apt-get -y install lcov
+
+    - name: Collect coverage reports
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage
+        path: ./coverage
+
+    - name: Merge coverage reports
+      shell: bash
+      run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./coverage/lcov.info
+
+    - name: Upload coverage report
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "4.9"
-    - nodejs_version: "5.12"
-    - nodejs_version: "6.17"
-    - nodejs_version: "7.10"
-    - nodejs_version: "8.17"
-    - nodejs_version: "9.11"
-    - nodejs_version: "10.24"
-    - nodejs_version: "11.15"
-    - nodejs_version: "12.22"
-    - nodejs_version: "13.14"
-    - nodejs_version: "14.20"
-    - nodejs_version: "15.14"
-    - nodejs_version: "16.20"
-    - nodejs_version: "17.9"
     - nodejs_version: "18.19"
     - nodejs_version: "19.9"
     - nodejs_version: "20.11"
@@ -41,51 +27,6 @@ install:
       cmd.exe /c "node -pe `"Object.keys(require('./package').devDependencies).join('\n')`"" | `
         sls "^eslint(-|$)" | `
         %{ npm rm --silent --save-dev $_ }
-  # Setup Node.js version-specific dependencies
-  - ps: |
-      # mocha for testing
-      # - use 5.x for Node.js < 6
-      # - use 6.x for Node.js < 8
-      # - use 7.x for Node.js < 10
-      # - use 8.x for Node.js < 12
-      # - use 9.x for Node.js < 14
-      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
-        npm install --silent --save-dev mocha@3.5.3
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 6) {
-        npm install --silent --save-dev mocha@5.2.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 8) {
-        npm install --silent --save-dev mocha@6.2.2
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 10) {
-        npm install --silent --save-dev mocha@7.2.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 12) {
-        npm install --silent --save-dev mocha@8.4.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 14) {
-        npm install --silent --save-dev mocha@9.2.2
-      }
-  - ps: |
-      # nyc for test coverage
-      # - use 10.3.2 for Node.js < 4
-      # - use 11.9.0 for Node.js < 6
-      # - use 14.1.1 for Node.js < 10
-      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
-        npm install --silent --save-dev nyc@10.3.2
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 6) {
-        npm install --silent --save-dev nyc@11.9.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 10) {
-        npm install --silent --save-dev nyc@14.1.1
-      }
-  - ps: |
-      # supertest for http calls
-      # - use 2.0.0 for Node.js < 4
-      # - use 3.4.2 for Node.js < 7
-      # - use 6.1.6 for Node.js < 8
-      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
-        npm install --silent --save-dev supertest@2.0.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 7) {
-        npm install --silent --save-dev supertest@3.4.2
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 8) {
-        npm install --silent --save-dev supertest@6.1.6
-      }
   # Update Node.js modules
   - ps: |
       # Prune & rebuild node_modules

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "vhost": "~3.0.2"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">= 18"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION

As discussed in https://github.com/expressjs/discussions/issues/224 and https://github.com/expressjs/discussions/issues/196. 

Here is a proposal to set Node@18 as the minimum version supported by Express v5.x

### Main Changes
- Set Node 18 as the minimum version in the `package.json` (4b3b8cc231381fe9357d7d98f6afd3e8e9f9d63c)
- Remove from the CI any Node.js version prior to 18 (e9bcdd399b244079f4cf77dd5ffa58c5831b8b90)
 
### Changelog
- e9bcdd399b244079f4cf77dd5ffa58c5831b8b90 ci: adopt Node@18 as the minimum supported version by @UlisesGascon 
- 4b3b8cc231381fe9357d7d98f6afd3e8e9f9d63c feat: adopt Node@18 as the minimum supported version  by @UlisesGascon 