### PR TITLE
deps: path-to-regexp@0.1.8

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+  * deps: path-to-regexp@0.1.8
+    - Adds support for named matching groups in the routes using a regex
+
 4.19.2 / 2024-03-25
 ==========
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "methods": "~1.1.2",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "0.1.8",
     "proxy-addr": "~2.0.7",
     "qs": "6.11.0",
     "range-parser": "~1.2.1",

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -188,6 +188,23 @@ describe('app.router', function(){
       .expect('editing user 10', done);
     })
 
+    if (supportsRegexp('(?<foo>.*)')) {
+      it('should populate req.params with named captures', function(done){
+        var app = express();
+        var re = new RegExp('^/user/(?<userId>[0-9]+)/(view|edit)?$');
+
+        app.get(re, function(req, res){
+          var id = req.params.userId
+            , op = req.params[0];
+          res.end(op + 'ing user ' + id);
+        });
+
+        request(app)
+        .get('/user/10/edit')
+        .expect('editing user 10', done);
+      })
+    }
+
     it('should ensure regexp matches path prefix', function (done) {
       var app = express()
       var p = []
@@ -1109,3 +1126,12 @@ describe('app.router', function(){
     assert.strictEqual(app.get('/', function () {}), app)
   })
 })
+
+function supportsRegexp(source) {
+  try {
+    new RegExp(source)
+    return true
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
Adds support for named capturing groups (https://github.com/pillarjs/path-to-regexp/pull/301). Closes https://github.com/expressjs/express/issues/4277.