### PR TITLE
add encoding to UTF-8 for res.json and res.jsonp

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -273,7 +273,7 @@ res.json = function json(obj) {
 
   // content-type
   if (!this.get('Content-Type')) {
-    this.set('Content-Type', 'application/json');
+    this.set('Content-Type', 'application/json; charset=utf-8');
   }
 
   return this.send(body);
@@ -318,7 +318,7 @@ res.jsonp = function jsonp(obj) {
   // content-type
   if (!this.get('Content-Type')) {
     this.set('X-Content-Type-Options', 'nosniff');
-    this.set('Content-Type', 'application/json');
+    this.set('Content-Type', 'application/json; charset=utf-8');
   }
 
   // fixup callback


### PR DESCRIPTION
Based on the [IETF RFC4627](http://www.ietf.org/rfc/rfc4627.txt):

> JSON text SHALL be encoded in Unicode.  The default encoding is UTF-8

I updated some references for the `res.json` and `res.jsonp`. The thing is that the tests are passing w/o additional changes so I am wondering if I am missing something here.