### PR TITLE
skip QUERY method test

### DIFF
--- a/test/app.router.js
+++ b/test/app.router.js
@@ -37,6 +37,10 @@ describe('app.router', function(){
   describe('methods', function(){
     methods.concat('del').forEach(function(method){
       if (method === 'connect') return;
+      // Temporarily excluding this test, can gate behind supported Node version when one exists
+      // upstream tracking https://github.com/nodejs/node/pull/51719
+      // express tracking issue: https://github.com/expressjs/express/issues/5615
+      if (method === 'query') return;
 
       it('should include ' + method.toUpperCase(), function(done){
         var app = express();

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -35,12 +35,25 @@ describe('app.router', function(){
   })
 
   describe('methods', function(){
-    methods.concat('del').forEach(function(method){
-      if (method === 'connect') return;
-      // Temporarily excluding this test, can gate behind supported Node version when one exists
+    function getMajorVersion(versionString) {
+      return versionString.split('.')[0];
+    }
+
+    function shouldSkipQuery(versionString) {
+      // Temporarily skipping this test on 21 and 22
+      // update this implementation to run on those release lines on supported versions once they exist
       // upstream tracking https://github.com/nodejs/node/pull/51719
       // express tracking issue: https://github.com/expressjs/express/issues/5615
-      if (method === 'query') return;
+      var majorsToSkip = {
+        "21": true,
+        "22": true
+      }
+      return majorsToSkip[getMajorVersion(versionString)]
+    }
+
+    methods.concat('del').forEach(function(method){
+      if (method === 'connect') return;
+      if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
       it('should include ' + method.toUpperCase(), function(done){
         var app = express();


### PR DESCRIPTION
related: #5615

First step is to stop running this test until there is a node version which supports QUERY properly.

resolves the failure we see in node 21 latest and node 22 latest