### PR TITLE
ignore ETAG query test on 21 and 22, reuse skip util

### DIFF
--- a/test/app.router.js
+++ b/test/app.router.js
@@ -6,6 +6,8 @@ var express = require('../')
   , assert = require('assert')
   , methods = require('methods');
 
+var shouldSkipQuery = require('./support/utils').shouldSkipQuery
+
 describe('app.router', function(){
   it('should restore req.params after leaving router', function(done){
     var app = express();
@@ -35,22 +37,6 @@ describe('app.router', function(){
   })
 
   describe('methods', function(){
-    function getMajorVersion(versionString) {
-      return versionString.split('.')[0];
-    }
-
-    function shouldSkipQuery(versionString) {
-      // Temporarily skipping this test on 21 and 22
-      // update this implementation to run on those release lines on supported versions once they exist
-      // upstream tracking https://github.com/nodejs/node/pull/51719
-      // express tracking issue: https://github.com/expressjs/express/issues/5615
-      var majorsToSkip = {
-        "21": true,
-        "22": true
-      }
-      return majorsToSkip[getMajorVersion(versionString)]
-    }
-
     methods.concat('del').forEach(function(method){
       if (method === 'connect') return;
       if (method === 'query' && shouldSkipQuery(process.versions.node)) return

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -7,6 +7,8 @@ var methods = require('methods');
 var request = require('supertest');
 var utils = require('./support/utils');
 
+var shouldSkipQuery = require('./support/utils').shouldSkipQuery
+
 describe('res', function(){
   describe('.send()', function(){
     it('should set body to ""', function(done){
@@ -407,6 +409,7 @@ describe('res', function(){
 
       methods.forEach(function (method) {
         if (method === 'connect') return;
+        if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
         it('should send ETag in response to ' + method.toUpperCase() + ' request', function (done) {
           var app = express();

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -16,6 +16,7 @@ exports.shouldHaveBody = shouldHaveBody
 exports.shouldHaveHeader = shouldHaveHeader
 exports.shouldNotHaveBody = shouldNotHaveBody
 exports.shouldNotHaveHeader = shouldNotHaveHeader;
+exports.shouldSkipQuery = shouldSkipQuery
 
 /**
  * Assert that a supertest response has a specific body.
@@ -70,3 +71,20 @@ function shouldNotHaveHeader(header) {
     assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header);
   };
 }
+
+function getMajorVersion(versionString) {
+  return versionString.split('.')[0];
+}
+
+function shouldSkipQuery(versionString) {
+  // Temporarily skipping this test on 21 and 22
+  // update this implementation to run on those release lines on supported versions once they exist
+  // upstream tracking https://github.com/nodejs/node/pull/51719
+  // express tracking issue: https://github.com/expressjs/express/issues/5615
+  var majorsToSkip = {
+    "21": true,
+    "22": true
+  }
+  return majorsToSkip[getMajorVersion(versionString)]
+}
+


### PR DESCRIPTION
Forgot this test in #5628, because we aren't running any affected versions in CI yet

repro'd the fail after rebasing #5627 and locally. this fixes the failures on 21 and 22