### PR TITLE
Add default value to the isAbsolute function of utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,6 +57,8 @@ exports.isAbsolute = function(path){
   if ('/' === path[0]) return true;
   if (':' === path[1] && ('\\' === path[2] || '/' === path[2])) return true; // Windows device path
   if ('\\\\' === path.substring(0, 2)) return true; // Microsoft Azure absolute path
+
+  return false; // None of the conditions are met
 };
 
 /**


### PR DESCRIPTION
Add default value to the isAbsolute function in utils for providing a default behavior when no path is specified, enhancing usability and maintainability.