### PR TITLE
List and sort all projects, add captains

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -180,8 +180,8 @@ dissent.  When the PR is merged, a TC member will add them to the proper GitHub/
 - `jshttp/http-errors`: @wesleytodd, @jonchurch
 - `jshttp/media-typer`: @blakeembrey
 - `jshttp/methods`: @blakeembrey
-- `jshttp/mime-db`: @blakeembrey
-- `jshttp/mime-types`: @blakeembrey
+- `jshttp/mime-db`: @blakeembrey, @UlisesGascon 
+- `jshttp/mime-types`: @blakeembrey, @UlisesGascon 
 - `jshttp/negotiator`: @blakeembrey
 - `jshttp/on-finished`: @wesleytodd
 - `jshttp/on-headers`: @blakeembrey

--- a/Contributing.md
+++ b/Contributing.md
@@ -63,13 +63,13 @@ compromise among committers be the default resolution mechanism.
 Anyone can become a triager! Read more about the process of being a triager in
 [the triage process document](Triager-Guide.md).
 
-Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate 
-a new triager. If you are interested in becoming a triager, our best advice is to actively participate 
+Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
+a new triager. If you are interested in becoming a triager, our best advice is to actively participate
 in the community by helping triaging issues and pull requests. As well we recommend
-to engage in other community activities like attending the TC meetings, and participating in the Slack 
+to engage in other community activities like attending the TC meetings, and participating in the Slack
 discussions.
 
-You can also reach out to any of the [organization members](https://github.com/orgs/expressjs/people) 
+You can also reach out to any of the [organization members](https://github.com/orgs/expressjs/people)
 if you have questions or need guidance.
 
 ## Becoming a Committer
@@ -139,28 +139,70 @@ the project, their GitHub handle and npm username (if different). The PR will re
 at least 2 approvals from TC members and 2 weeks hold time to allow for comment and/or
 dissent.  When the PR is merged, a TC member will add them to the proper GitHub/npm groups.
 
-### Current Project Captains
+### Active Projects and Captains
 
-- `expressjs/express`: @wesleytodd
-- `expressjs/discussions`: @wesleytodd
-- `expressjs/expressjs.com`: @crandmck, @jonchurch
+- `expressjs/badgeboard`: @wesleytodd
+- `expressjs/basic-auth-connect`: N/A
 - `expressjs/body-parser`: @wesleytodd, @jonchurch
-- `expressjs/multer`: @LinusU
-- `expressjs/morgan`: @jonchurch
+- `expressjs/compression`: N/A
+- `expressjs/connect-multiparty`: N/A
 - `expressjs/cookie-parser`: @wesleytodd
+- `expressjs/cookie-session`: N/A
 - `expressjs/cors`: @jonchurch
+- `expressjs/discussions`: @wesleytodd
+- `expressjs/errorhandler`: N/A
+- `expressjs/express-paginate`: N/A
+- `expressjs/express`: @wesleytodd
+- `expressjs/expressjs.com`: @crandmck, @jonchurch
+- `expressjs/flash`: N/A
 - `expressjs/generator`: @wesleytodd
+- `expressjs/method-override`: N/A
+- `expressjs/morgan`: @jonchurch
+- `expressjs/multer`: @LinusU
+- `expressjs/response-time`: @blakeembrey
+- `expressjs/serve-favicon`: N/A
+- `expressjs/serve-index`: N/A
+- `expressjs/serve-static`: N/A
+- `expressjs/session`: N/A
 - `expressjs/statusboard`: @wesleytodd
-- `pillarjs/encodeurl`: @blakeembrey
-- `pillarjs/path-to-regexp`: @blakeembrey
-- `pillarjs/router`: @dougwilson, @wesleytodd
-- `pillarjs/finalhandler`: @wesleytodd
-- `pillarjs/request`: @wesleytodd
-- `jshttp/http-errors`: @wesleytodd, @jonchurch
+- `expressjs/timeout`: N/A
+- `expressjs/vhost`: N/A
+- `jshttp/accepts`: @blakeembrey
+- `jshttp/basic-auth`: @blakeembrey
+- `jshttp/compressible`: @blakeembrey
+- `jshttp/content-disposition`: @blakeembrey
+- `jshttp/content-type`: @blakeembrey
 - `jshttp/cookie`: @wesleytodd
+- `jshttp/etag`: @blakeembrey
+- `jshttp/forwarded`: @blakeembrey
+- `jshttp/fresh`: @blakeembrey
+- `jshttp/http-assert`: @wesleytodd, @jonchurch
+- `jshttp/http-errors`: @wesleytodd, @jonchurch
+- `jshttp/media-typer`: @blakeembrey
+- `jshttp/methods`: @blakeembrey
+- `jshttp/mime-db`: @blakeembrey
+- `jshttp/mime-types`: @blakeembrey
+- `jshttp/negotiator`: @blakeembrey
 - `jshttp/on-finished`: @wesleytodd
-- `jshttp/forwarded`: @wesleytodd
+- `jshttp/on-headers`: @blakeembrey
 - `jshttp/proxy-addr`: @wesleytodd
+- `jshttp/range-parser`: @blakeembrey
+- `jshttp/statuses`: @blakeembrey
+- `jshttp/type-is`: @blakeembrey
+- `jshttp/vary`: @blakeembrey
+- `pillarjs/cookies`: @blakeembrey
+- `pillarjs/csrf`: N/A
+- `pillarjs/encodeurl`: @blakeembrey
+- `pillarjs/finalhandler`: @wesleytodd
+- `pillarjs/hbs`: N/A
+- `pillarjs/multiparty`: @blakeembrey
+- `pillarjs/parseurl`: @blakeembrey
+- `pillarjs/path-to-regexp`: @blakeembrey
+- `pillarjs/request`: @wesleytodd
+- `pillarjs/resolve-path`: @blakeembrey
+- `pillarjs/router`: @blakeembrey
+- `pillarjs/send`: @blakeembrey
+- `pillarjs/understanding-csrf`: N/A
 
 ### Current Initiative Captains
 


### PR DESCRIPTION
A few changes to the project list:

1. Listing all active projects so we can easily see what exists
2. Set myself as defacto on many of the lower level utils
3. Assigned badgeboard to @wesleytodd based on recent commit (happy to undo?)
4. Assigned `jshttp/forwarded` from @wesleytodd to myself since it seems similar to all the other jshttp modules I'm picking up (happy to undo this, wasn't sure if `forwarded` is special in some way)
5. Assigned `jshttp/http-assert` to @wesleytodd and @jonchurch since it's similar to `jshttp/http-errors`
6. Assigned `pillarjs/router` to myself based on recent discussions

None of this needs to be permanent and probably shouldn't be. I have probably too many lower level modules to work on, but I'll try to review one a day or something until v5 releases.