### PR TITLE
WIP: release process ascii diagram

### DIFF
--- a/Release-Process.md
+++ b/Release-Process.md
@@ -43,6 +43,28 @@ non-patch flow.
 
 ### Branch terminology
 
+Key:
+  - `F`: A feature commit
+  - `S`: A security patch
+  - `V`: A version (includes package.json and changelog)
+  - `*`: The release is run *after* merge (but the merge is a rebase, so the history flattens)
+
+```
+                      4.x is Current Major                |           5.x is Current
+
+feature | -F1       -F2                                   |             -S1
+        |   \        \                                                     \
+master  | ---F1-------F2----------------------------------|--------------*--S1----------*
+        |     \  \     \   \                    /                       /    \         /
+4.x     | ----F1- \ ----F2- \ -----------------*----------|------------/------\--S1(cherry-pick)
+        |          \  \      \   \            /                       /        \     /
+4.18.3  |           \  F1---  \ --F2---V4.18.3            |          /          \   /
+        |            \         \                                    /            \ /
+5.x     | -----------F1--------F2---------------------*---|---V5.0.0--------------*
+        |              \         \                   /
+5.0(.0) |               F1--------F2---V5.0.0-beta.1
+```
+
 "Master branch"
 
 - There is a branch in git used for the current major version of Express, named


### PR DESCRIPTION
I had started drafting this a bit back to try and clear up the `5.0` vs `5.x` branch thing. I just added a little bit, but I don't think it is right to merge yet but also I didn't want it to get lost on my machine.

I think the *main* confusion with the `5.0` branch is that it exists instead of using *individual* release branches for the inital beta releases. I know the goal was to keep the prerelease verison commits out of the history and also not have individual branches littering around for the betas, but actually that might have made it easier now.

Anyway, I am going to see if I can get this PR into a shape where it is both a recommendation for a way (which @UlisesGascon also did in #5513) which is more *simple*. I will keep it in draft for now so it is clear this is not something to merge, but I am going to try and focus on the real work to get this stuff landed first. These branches are a distraction which we need to fix, but I think we can do it *after* we publish (as much as I know it has been a confusion for folks). Happy to help with anything in the mean time, but I just have limited time and don't want to try and make it perfect before we make it good.