### PR TITLE
[v4] Deprecate `res.clearCookie` accepting `options.maxAge` and `options.expires`

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@ unreleased
 
   * deps: encodeurl@~2.0.0
     - Removes encoding of `\`, `|`, and `^` to align better with URL spec
+  * Deprecate passing `options.maxAge` and `options.expires` to `res.clearCookie`
+    - Will be ignored in v5, clearCookie will set a cookie with an expires in the past to instruct clients to delete the cookie
 
 4.19.2 / 2024-03-25
 ==========

--- a/lib/response.js
+++ b/lib/response.js
@@ -34,7 +34,6 @@ var extname = path.extname;
 var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
-var deprecate = require('depd')('express');
 
 /**
  * Response prototype.

--- a/lib/response.js
+++ b/lib/response.js
@@ -824,10 +824,10 @@ res.get = function(field){
 res.clearCookie = function clearCookie(name, options) {
   if (options) {
     if (options.maxAge) {
-      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
+      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
     if (options.expires) {
-      deprecate('res.clearCookie: Passing "options.expires" is deprecated and should be removed. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
+      deprecate('res.clearCookie: Passing "options.expires" is deprecated. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
   }
   var opts = merge({ expires: new Date(1), path: '/' }, options);

--- a/lib/response.js
+++ b/lib/response.js
@@ -825,10 +825,10 @@ res.get = function(field){
 res.clearCookie = function clearCookie(name, options) {
   if (options && (options.maxAge || options.expires)) {
     if (options.maxAge) {
-      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated. In the next major release of Express, this option will be ignored, and the method will solely delete cookies.');
+      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
     if (options.expires) {
-      deprecate('res.clearCookie: Passing "options.expires" is deprecated. In the next major release of Express, this option will be ignored, and the method will solely delete cookies.');
+      deprecate('res.clearCookie: Passing "options.expires" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
   }
   var opts = merge({ expires: new Date(1), path: '/' }, options);

--- a/lib/response.js
+++ b/lib/response.js
@@ -822,7 +822,7 @@ res.get = function(field){
  */
 
 res.clearCookie = function clearCookie(name, options) {
-  if (options && (options.maxAge || options.expires)) {
+  if (options) {
     if (options.maxAge) {
       deprecate('res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }

--- a/lib/response.js
+++ b/lib/response.js
@@ -824,10 +824,10 @@ res.get = function(field){
 res.clearCookie = function clearCookie(name, options) {
   if (options) {
     if (options.maxAge) {
-      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
+      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
     if (options.expires) {
-      deprecate('res.clearCookie: Passing "options.expires" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
+      deprecate('res.clearCookie: Passing "options.expires" is deprecated and should be removed. In v5.0.0 of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.');
     }
   }
   var opts = merge({ expires: new Date(1), path: '/' }, options);

--- a/lib/response.js
+++ b/lib/response.js
@@ -34,6 +34,7 @@ var extname = path.extname;
 var mime = send.mime;
 var resolve = path.resolve;
 var vary = require('vary');
+var deprecate = require('depd')('express');
 
 /**
  * Response prototype.
@@ -822,6 +823,14 @@ res.get = function(field){
  */
 
 res.clearCookie = function clearCookie(name, options) {
+  if (options && (options.maxAge || options.expires)) {
+    if (options.maxAge) {
+      deprecate('res.clearCookie: Passing "options.maxAge" is deprecated. In the next major release of Express, this option will be ignored, and the method will solely delete cookies.');
+    }
+    if (options.expires) {
+      deprecate('res.clearCookie: Passing "options.expires" is deprecated. In the next major release of Express, this option will be ignored, and the method will solely delete cookies.');
+    }
+  }
   var opts = merge({ expires: new Date(1), path: '/' }, options);
 
   return this.cookie(name, '', opts);

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -47,7 +47,7 @@ describe('res', function(){
       .expect(200, done)
     })
 
-    it('should set maxAge when passed', function(done) {
+    it('should set both maxAge and expires when passed', function(done) {
       var maxAgeInMs = 10000
       var expiresAt = new Date()
       var expectedExpires = new Date(expiresAt.getTime() + maxAgeInMs)
@@ -59,6 +59,8 @@ describe('res', function(){
 
       request(app)
       .get('/')
+      // yes, this is the behavior. When we set a max-age, we also set expires to a date 10 sec ahead of expires
+      // even if we set max-age only, we will also set an expires 10 sec in the future
       .expect('Set-Cookie', 'sid=; Max-Age=10; Path=/; Expires=' + expectedExpires.toUTCString())
       .expect(200, done)
     })

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -32,5 +32,35 @@ describe('res', function(){
       .expect('Set-Cookie', 'sid=; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
       .expect(200, done)
     })
+
+    it('should set expires when passed', function(done) {
+      var expiresAt = new Date()
+      var app = express();
+
+      app.use(function(req, res){
+        res.clearCookie('sid', { expires: expiresAt }).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Set-Cookie', 'sid=; Path=/; Expires=' + expiresAt.toUTCString() )
+      .expect(200, done)
+    })
+
+    it('should set maxAge when passed', function(done) {
+      var maxAgeInMs = 10000
+      var expiresAt = new Date()
+      var expectedExpires = new Date(expiresAt.getTime() + maxAgeInMs)
+      var app = express();
+
+      app.use(function(req, res){
+        res.clearCookie('sid', { expires: expiresAt, maxAge: maxAgeInMs }).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Set-Cookie', 'sid=; Max-Age=10; Path=/; Expires=' + expectedExpires.toUTCString())
+      .expect(200, done)
+    })
   })
 })


### PR DESCRIPTION
closes https://github.com/expressjs/express/issues/5640

Adds a deprecation notice when users pass a truthy value in `options` for `maxAge` or `expires` when calling `res.clearCookie(name, options)`.

example:
> res.clearCookie: Passing "options.maxAge" is deprecated and should be removed. Starting with the next major release of Express, this option will be ignored, as res.clearCookie will automatically set cookies to expire immediately. Please update your code to omit this option.

Related #4852 