### PR TITLE
Use Array.flat instead of array-flatten

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -21,7 +21,6 @@ var http = require('http');
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
-var flatten = require('array-flatten').flatten
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var once = require('once')
@@ -34,6 +33,7 @@ var setPrototypeOf = require('setprototypeof')
  */
 
 var slice = Array.prototype.slice;
+var flatten = Array.prototype.flat;
 
 /**
  * Application prototype.
@@ -209,7 +209,7 @@ app.use = function use(fn) {
     }
   }
 
-  var fns = flatten(slice.call(arguments, offset));
+  var fns = flatten.call(slice.call(arguments, offset), Infinity);
 
   if (fns.length === 0) {
     throw new TypeError('app.use() requires a middleware function')

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "accepts": "~1.3.8",
-    "array-flatten": "3.0.0",
     "body-parser": "2.0.0-beta.2",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",


### PR DESCRIPTION
Depends upon #5595, Adopt Node@18 as minimum supported version.

With this new version, we get Array.flat(depth), which can be used instead of a package. `Infinity` would have the same behavior as the package, recursively unwrapping nested arrays indefinitely. But, perhaps it might be worth selecting a more reasonable value, to avoid a RangeError, such as when an array contains a reference to itself.

### Note

Mimimum Node.js version supported is 11 
