### PR TITLE
skip QUERY tests for Node 21 only, still not supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,10 @@ jobs:
           node-version: "20.11"
 
         - name: Node.js 21.x
-          node-version: "21.6"
+          node-version: "21.7"
 
         - name: Node.js 22.x
-          node-version: "22.0"
+          node-version: "22.2"
 
     steps:
     - uses: actions/checkout@v4

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -42,7 +42,7 @@ describe('app.router', function(){
 
       it('should include ' + method.toUpperCase(), function(done){
         if (method === 'query' && shouldSkipQuery(process.versions.node)) {
-          this.skip("QUERY is not fully supported in this version of Node")
+          this.skip()
         }
         var app = express();
 

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -39,9 +39,11 @@ describe('app.router', function(){
   describe('methods', function(){
     methods.concat('del').forEach(function(method){
       if (method === 'connect') return;
-      if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
       it('should include ' + method.toUpperCase(), function(done){
+        if (method === 'query' && shouldSkipQuery(process.versions.node)) {
+          this.skip("QUERY is not fully supported in this version of Node")
+        }
         var app = express();
 
         app[method]('/foo', function(req, res){

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -412,7 +412,7 @@ describe('res', function(){
 
         it('should send ETag in response to ' + method.toUpperCase() + ' request', function (done) {
           if (method === 'query' && shouldSkipQuery(process.versions.node)) {
-            this.skip("QUERY is not fully supported in this version of Node")
+            this.skip()
           }
           var app = express();
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -409,9 +409,11 @@ describe('res', function(){
 
       methods.forEach(function (method) {
         if (method === 'connect') return;
-        if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
         it('should send ETag in response to ' + method.toUpperCase() + ' request', function (done) {
+          if (method === 'query' && shouldSkipQuery(process.versions.node)) {
+            this.skip("QUERY is not fully supported in this version of Node")
+          }
           var app = express();
 
           app[method]('/', function (req, res) {

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -77,12 +77,12 @@ function getMajorVersion(versionString) {
 }
 
 function shouldSkipQuery(versionString) {
-  // Temporarily skipping this test on 22
-  // update this implementation to run on those release lines on supported versions once they exist
-  // upstream tracking https://github.com/nodejs/node/pull/51719
+  // Skipping HTTP QUERY tests on 21, it is reported in http.METHODS on 21.7.2 but not supported
+  // update this implementation to run on supported versions of 21 once they exist
+  // upstream tracking https://github.com/nodejs/node/issues/51562
   // express tracking issue: https://github.com/expressjs/express/issues/5615
   var majorsToSkip = {
-    "22": true
+    "21": true
   }
   return majorsToSkip[getMajorVersion(versionString)]
 }

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -77,13 +77,10 @@ function getMajorVersion(versionString) {
 }
 
 function shouldSkipQuery(versionString) {
-  // Skipping HTTP QUERY tests on 21, it is reported in http.METHODS on 21.7.2 but not supported
+  // Skipping HTTP QUERY tests on Node 21, it is reported in http.METHODS on 21.7.2 but not supported
   // update this implementation to run on supported versions of 21 once they exist
   // upstream tracking https://github.com/nodejs/node/issues/51562
   // express tracking issue: https://github.com/expressjs/express/issues/5615
-  var majorsToSkip = {
-    "21": true
-  }
-  return majorsToSkip[getMajorVersion(versionString)]
+  return Number(getMajorVersion(versionString)) === 21
 }
 


### PR DESCRIPTION
We just landed #5690, but the reason it passes is a quirk of our CI setup rn where we are pinning Node versions that we test on. So current CI does not run w/ a version of Node 21 that knows about QUERY. 

QUERY support has now landed in Node 22.2.0. Updating our skip so that we test it on 22, but skip it on 21 where it is not supported by Node.

## This PR
* Skips QUERY tests on Node 21
* Updates CI to use Node 21.7
* Updates CI to use Node 22.2

related: #5615 