### PR TITLE
Replace `node:querystring` with `URLSearchParams`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,6 @@ var etag = require('etag');
 var mime = require('mime-types')
 var proxyaddr = require('proxy-addr');
 var qs = require('qs');
-var querystring = require('querystring');
 
 /**
  * Return strong ETag for `body`.
@@ -132,35 +131,38 @@ exports.compileETag = function(val) {
 }
 
 /**
- * Compile "query parser" value to function.
- *
- * @param  {String|Function} val
- * @return {Function}
- * @api private
+ * @typedef {(raw: string) => Record<string, string>} QueryParser
  */
 
-exports.compileQueryParser = function compileQueryParser(val) {
-  var fn;
-
-  if (typeof val === 'function') {
-    return val;
+/**
+ * Compile "query parser" value to function.
+ *
+ * @param  {boolean | 'simple' | 'extended' | QueryParser} modeOrFactory \
+ * `true` | `simple`: use  {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams|URLSearchParams} \
+ * `extended`: use {@link https://www.npmjs.com/package/qs|qs} \
+ * `false`: disable query parsing \
+ *  a function: provide a custom query parser
+ *
+ * @return {QueryParser | undefined}
+ * @api private
+ */
+exports.compileQueryParser = function compileQueryParser(modeOrFactory) {
+  if (typeof modeOrFactory === 'function') {
+    return modeOrFactory;
   }
 
-  switch (val) {
+  switch (modeOrFactory) {
     case true:
     case 'simple':
-      fn = querystring.parse;
-      break;
-    case false:
-      break;
+      return (raw) => Object.fromEntries(new URLSearchParams(raw).entries());
     case 'extended':
-      fn = parseExtendedQueryString;
-      break;
+      return (raw) => qs.parse(raw, { allowPrototypes: true });
+    case false:
+      // Indicate the query parser is disabled
+      return undefined;
     default:
-      throw new TypeError('unknown value for query parser function: ' + val);
+      throw new TypeError('unknown value for query parser function: ' + modeOrFactory);
   }
-
-  return fn;
 }
 
 /**
@@ -234,18 +236,4 @@ function createETagGenerator (options) {
 
     return etag(buf, options)
   }
-}
-
-/**
- * Parse an extended query string with qs.
- *
- * @param {String} str
- * @return {Object}
- * @private
- */
-
-function parseExtendedQueryString(str) {
-  return qs.parse(str, {
-    allowPrototypes: true
-  });
 }


### PR DESCRIPTION
As discussed in #5723, I've replaced `node:querystring` with `URLSearchParams` for better interoperability and standards compliance.

The "multiple keys" scenario isn't defined by the URL and URLSearchParams spec so the JSONP test for checking that the first `callback` parameter is used, is failing.
You can read more here: https://www.rfc-editor.org/rfc/rfc3986#section-3.4 https://url.spec.whatwg.org/#urlsearchparams

:grey_question: How do we want to proceed with this?