### PR TITLE
Refactor variable name from lazyrouter to lazyRouter for camel case consistency

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -141,7 +141,7 @@ app.defaultConfiguration = function defaultConfiguration() {
  *
  * @private
  */
-app.lazyrouter = function lazyrouter() {
+app.lazyRouter = function lazyRouter() {
   if (!this._router) {
     this._router = new Router({
       caseSensitive: this.enabled('case sensitive routing'),
@@ -218,7 +218,7 @@ app.use = function use(fn) {
   }
 
   // setup router
-  this.lazyrouter();
+  this.lazyRouter();
   var router = this._router;
 
   fns.forEach(function (fn) {
@@ -259,7 +259,7 @@ app.use = function use(fn) {
  */
 
 app.route = function route(path) {
-  this.lazyrouter();
+  this.lazyRouter();
   return this._router.route(path);
 };
 
@@ -326,7 +326,7 @@ app.engine = function engine(ext, fn) {
  */
 
 app.param = function param(name, fn) {
-  this.lazyrouter();
+  this.lazyRouter();
 
   if (Array.isArray(name)) {
     for (var i = 0; i < name.length; i++) {
@@ -493,7 +493,7 @@ methods.forEach(function(method){
       return this.set(path);
     }
 
-    this.lazyrouter();
+    this.lazyRouter();
 
     var route = this._router.route(path);
     route[method].apply(route, slice.call(arguments, 1));
@@ -512,7 +512,7 @@ methods.forEach(function(method){
  */
 
 app.all = function all(path) {
-  this.lazyrouter();
+  this.lazyRouter();
 
   var route = this._router.route(path);
   var args = slice.call(arguments, 1);


### PR DESCRIPTION
The camel case convention seems to be the standard naming convention used in this project, and "lazyrouter" does not conform to this standard. I believe it would be better to change it to "lazyRouter". What do you think? Additionally, are there any other areas that might need revision?