### PR TITLE
Fix link variable use in attribution section of CODE OF CONDUCT

### DIFF
--- a/Code-Of-Conduct.md
+++ b/Code-Of-Conduct.md
@@ -127,7 +127,7 @@ project community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant, version 2.0](cc-20-doc).
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.0][cc-20-doc].
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).


### PR DESCRIPTION
A definition for `cc-20-doc` was indeed present however, at the first paragraph of *Attribution* it was not referenced properly to use the defined variable.