### PR TITLE
4.x: Upgrade `merge-descriptors` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "finalhandler": "1.2.0",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
-    "merge-descriptors": "~1.0.1",
+    "merge-descriptors": "1.0.3",
     "methods": "~1.1.2",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "finalhandler": "1.2.0",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
-    "merge-descriptors": "1.0.1",
+    "merge-descriptors": "~1.0.1",
     "methods": "~1.1.2",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",


### PR DESCRIPTION
The line in `package.json` on that dependency is 9 years old.
There were two patches to that package since then.
Because the dependency version is fixed, it can not be deduplicated if a newer version is also installed by another dependency.
I'm suggesting to allow patches. There should be no harm in it.