### PR TITLE
5.x: Upgrading `merge-descriptors` with allowing minors

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,7 +9,8 @@ unreleased
   * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
-* deps: debug@4.3.6, merge-descriptors@^2.0.0
+* deps: debug@4.3.6
+* deps: merge-descriptors@^2.0.0
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/History.md
+++ b/History.md
@@ -9,7 +9,7 @@ unreleased
   * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
-* deps: debug@4.3.6
+* deps: debug@4.3.6, merge-descriptors@^2.0.0
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "finalhandler": "1.2.0",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
-    "merge-descriptors": "1.0.1",
+    "merge-descriptors": "^1.0.3",
     "methods": "~1.1.2",
     "mime-types": "~2.1.34",
     "on-finished": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "finalhandler": "1.2.0",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
-    "merge-descriptors": "^1.0.3",
+    "merge-descriptors": "^2.0.0",
     "methods": "~1.1.2",
     "mime-types": "~2.1.34",
     "on-finished": "2.4.1",


### PR DESCRIPTION
Similar to #5781 but for v5, with allowing minors according to the following request:
https://github.com/expressjs/express/pull/5781#issuecomment-2243867589