### PR TITLE
send@1.0.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ unreleased
   * `res.status()` accepts only integers, and input must be greater than 99 and less than 1000
     * will throw a `RangeError: Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.` for inputs outside this range
     * will throw a `TypeError: Invalid status code: ${code}. Status code must be an integer.` for non integer inputs
+  * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "range-parser": "~1.2.1",
     "router": "2.0.0-beta.2",
     "safe-buffer": "5.2.1",
-    "send": "1.0.0-beta.2",
+    "send": "^1.0.0",
     "serve-static": "2.0.0-beta.2",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",


### PR DESCRIPTION
This updates `send@^1.0.0`.

The failure in CI is expected until we land #5595 because send dropped node versions. It looks like we explicitly break <6 with this.