### PR TITLE
WIP: serve-static@2

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,7 @@ unreleased
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
 * deps: debug@4.3.6
 * deps: merge-descriptors@^2.0.0
+* deps: serve-static@^2.0.0
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "router": "2.0.0-beta.2",
     "safe-buffer": "5.2.1",
     "send": "^1.0.0",
-    "serve-static": "2.0.0-beta.2",
+    "serve-static": "^2.0.0",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
     "type-is": "~1.6.18",


### PR DESCRIPTION
Before I release `serve-static@2` I wanted to run express CI. This is stacked on `send-1` because `serve-static` also depends on `send` so I want to test them together. It is expected this will break in node<6 just as `send` does. That will be fixed once #5595 is landed.

https://github.com/expressjs/serve-static/pull/165