### PR TITLE
Ignore `expires` and `maxAge` in `res.clearCookie()`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,6 @@
 root: true
 env:
-  es6: true
+  es2022: true
   node: true
 rules:
   eol-last: error

--- a/History.md
+++ b/History.md
@@ -5,7 +5,7 @@ unreleased
     * will throw a `RangeError: Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.` for inputs outside this range
     * will throw a `TypeError: Invalid status code: ${code}. Status code must be an integer.` for non integer inputs
 * change:
-  - `res.clearCookie` ignore user provided `maxAge` and `expires` options
+  - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@ unreleased
   * `res.status()` accepts only integers, and input must be greater than 99 and less than 1000
     * will throw a `RangeError: Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.` for inputs outside this range
     * will throw a `TypeError: Invalid status code: ${code}. Status code must be an integer.` for non integer inputs
+* change:
+  - `res.clearCookie` ignore user provided `maxAge` and `expires` options
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/lib/response.js
+++ b/lib/response.js
@@ -708,8 +708,9 @@ res.get = function(field){
 
 res.clearCookie = function clearCookie(name, options) {
   // Force cookie expiration by setting expires to the past
-  // ensure maxAge is undefined
-  const opts = {path: '/', ...options, expires: new Date(1), maxAge: undefined}
+  const opts = { path: '/', ...options, expires: new Date(1) }
+  // ensure maxAge is not passed
+  delete opts.maxAge
 
   return this.cookie(name, '', opts);
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -707,7 +707,9 @@ res.get = function(field){
  */
 
 res.clearCookie = function clearCookie(name, options) {
-  var opts = merge({ expires: new Date(1), path: '/' }, options);
+  // Force cookie expiration by setting expires to the past
+  // ensure maxAge is undefined
+  const opts = {path: '/', ...options, expires: new Date(1), maxAge: undefined}
 
   return this.cookie(name, '', opts);
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -708,7 +708,7 @@ res.get = function(field){
 
 res.clearCookie = function clearCookie(name, options) {
   // Force cookie expiration by setting expires to the past
-  const opts = { path: '/', ...options, expires: new Date(1) }
+  const opts = Object.assign({ path: '/' } , options, { expires: new Date(1) })
   // ensure maxAge is not passed
   delete opts.maxAge
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -708,7 +708,7 @@ res.get = function(field){
 
 res.clearCookie = function clearCookie(name, options) {
   // Force cookie expiration by setting expires to the past
-  const opts = Object.assign({ path: '/' } , options, { expires: new Date(1) })
+  const opts = { path: '/', ...options, expires: new Date(1)};
   // ensure maxAge is not passed
   delete opts.maxAge
 

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -37,7 +37,7 @@ describe('res', function(){
       var app = express();
 
       app.use(function(req, res){
-        res.clearCookie('sid', { path: '/admin', maxAge: 900 }).end();
+        res.clearCookie('sid', { path: '/admin', maxAge: 1000 }).end();
       });
 
       request(app)

--- a/test/res.clearCookie.js
+++ b/test/res.clearCookie.js
@@ -32,5 +32,31 @@ describe('res', function(){
       .expect('Set-Cookie', 'sid=; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
       .expect(200, done)
     })
+
+    it('should ignore maxAge', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.clearCookie('sid', { path: '/admin', maxAge: 900 }).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Set-Cookie', 'sid=; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+      .expect(200, done)
+    })
+
+    it('should ignore user supplied expires param', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.clearCookie('sid', { path: '/admin', expires: new Date() }).end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Set-Cookie', 'sid=; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+      .expect(200, done)
+    })
   })
 })


### PR DESCRIPTION
Opened a new PR for this, supersedes https://github.com/expressjs/express/pull/4852

closes https://github.com/expressjs/express/issues/4851

The PR overrides any expires value set, and explicitly deletes maxAge from the options object.

The reason this is needed is that `res.cookie()` will set a relative `expires` value if it sees a `maxAge` value in the options.

clearCookie is meant to delete a cookie, but that deletion can be thwarted if you pass a `maxAge` value, by setting an `expires` into the future relative to the `maxAge`