### PR TITLE
chore: upgrade `send` to `1.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "range-parser": "~1.2.1",
     "router": "2.0.0-beta.2",
     "safe-buffer": "5.2.1",
-    "send": "1.0.0-beta.2",
+    "send": "~1.0.0",
     "serve-static": "2.0.0-beta.2",
     "setprototypeof": "1.2.0",
     "statuses": "2.0.1",


### PR DESCRIPTION
Why don't you use `^` anywhere and why do only some have `~`? By pinning all these versions you prevent dependency deduping. There are two versions of `send` in the dependency tree, which makes the dependency tree much larger: https://npmgraph.js.org/?q=express@5.0.0-beta.3