### PR TITLE
chore: remove path-is-absolute dependency

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -21,7 +21,6 @@ var http = require('http');
 var onFinished = require('on-finished');
 var mime = require('mime-types')
 var path = require('path');
-var pathIsAbsolute = require('path-is-absolute');
 var statuses = require('statuses')
 var merge = require('utils-merge');
 var sign = require('cookie-signature').sign;
@@ -31,6 +30,7 @@ var setCharset = require('./utils').setCharset;
 var cookie = require('cookie');
 var send = require('send');
 var extname = path.extname;
+var isAbsolute = path.isAbsolute;
 var resolve = path.resolve;
 var vary = require('vary');
 
@@ -392,7 +392,7 @@ res.sendFile = function sendFile(path, options, callback) {
     opts = {};
   }
 
-  if (!opts.root && !pathIsAbsolute(path)) {
+  if (!opts.root && !isAbsolute(path)) {
     throw new TypeError('path must be absolute or specify root to res.sendFile');
   }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "on-finished": "2.4.1",
     "once": "1.4.0",
     "parseurl": "~1.3.3",
-    "path-is-absolute": "1.0.1",
     "proxy-addr": "~2.0.7",
     "qs": "6.11.0",
     "range-parser": "~1.2.1",


### PR DESCRIPTION
https://www.npmjs.com/package/path-is-absolute says:

> This package has been deprecated
Author message:
This package is no longer relevant as Node.js 0.12 is unmaintained.