### PR TITLE
chore: update cookie-signature dep from 1.0.6 to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.6.0",
-    "cookie-signature": "1.0.6",
+    "cookie-signature": "1.2.1",
     "debug": "3.1.0",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",


### PR DESCRIPTION
Related discussion https://github.com/expressjs/discussions/issues/256