### PR TITLE
chore: upgrade `debug` dep from 3.10 to 4.3.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@ unreleased
   * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
+* deps: debug@4.3.6
 
 5.0.0-beta.3 / 2024-03-25
 =========================

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.6.0",
     "cookie-signature": "1.0.6",
-    "debug": "3.1.0",
+    "debug": "4.3.6",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
Related discussion: https://github.com/expressjs/discussions/issues/256
