### PR TITLE
Upgrade cookie signature

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,7 +9,7 @@ unreleased
   * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
-* deps: cookie-signature@1.2.1
+* deps: cookie-signature@^1.2.1
 * deps: debug@4.3.6
 * deps: merge-descriptors@^2.0.0
 * deps: serve-static@^2.0.0

--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@ unreleased
   * deps: send@1.0.0
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
+* deps: cookie-signature@1.2.1
 * deps: debug@4.3.6
 * deps: merge-descriptors@^2.0.0
 * deps: serve-static@^2.0.0

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.6.0",
-    "cookie-signature": "1.2.1",
+    "cookie-signature": "^1.2.1",
     "debug": "4.3.6",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.6.0",
-    "cookie-signature": "1.0.6",
+    "cookie-signature": "1.2.1",
     "debug": "4.3.6",
     "depd": "2.0.0",
     "encodeurl": "~1.0.2",


### PR DESCRIPTION
In accordance with the https://github.com/expressjs/discussions/issues/256, we are upgrading the `cookie-signature` from _1.0.6_ to _1.2.1_.

#### Notes
Since all items listed in [list](https://github.com/expressjs/discussions/issues/256) are already landed, this PR 

- fixes  https://github.com/expressjs/discussions/issues/256
