### PR TITLE
changed "req.name" to "req.pathname"

### DIFF
--- a/History.md
+++ b/History.md
@@ -2771,7 +2771,7 @@ unreleased
   * Added `req.subdomains`
   * Added `req.protocol`
   * Added `req.secure`
-  * Added `req.path`
+  * Added `req.pathname`
   * Added `req.ips`
   * Added `req.fresh`
   * Added `req.stale`
@@ -2872,7 +2872,7 @@ unreleased
 
   * Added mkdirp to express(1). Closes #795
   * Added simple _json-config_ example
-  * Added  shorthand for the parsed request's pathname via `req.path`
+  * Added  shorthand for the parsed request's pathname via `req.pathname`
   * Changed connect dep to 1.7.x to fix npm issue...
   * Fixed `res.redirect()` __HEAD__ support. [reported by xerox]
   * Fixed `req.flash()`, only escape args

--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -15,7 +15,7 @@ app.use(logger('dev'));
 // express on its own has no notion
 // of a "file". The express.static()
 // middleware checks for a file matching
-// the `req.path` within the directory
+// the `req.pathname` within the directory
 // that you pass it. In this case "GET /js/app.js"
 // will look for "./public/js/app.js".
 

--- a/test/req.path.js
+++ b/test/req.path.js
@@ -4,12 +4,12 @@ var express = require('../')
   , request = require('supertest');
 
 describe('req', function(){
-  describe('.path', function(){
+  describe('.pathname', function(){
     it('should return the parsed pathname', function(done){
       var app = express();
 
       app.use(function(req, res){
-        res.end(req.path);
+        res.end(req.pathname);
       });
 
       request(app)

--- a/test/req.signedCookies.js
+++ b/test/req.signedCookies.js
@@ -12,7 +12,7 @@ describe('req', function(){
       app.use(cookieParser('secret'));
 
       app.use(function(req, res){
-        if (req.path === '/set') {
+        if (req.pathname === '/set') {
           res.cookie('obj', { foo: 'bar' }, { signed: true });
           res.end();
         } else {


### PR DESCRIPTION
this PR changes the deprecated "req.path" to "req.pathname"

fixes #3407