### PR TITLE
Benchmark Testing

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -32,3 +32,27 @@ You can use `make && node -v` to include the node.js version in the output.
 ### Tip: Save the results to a file
 
 You can use `make > results.log` to save the results to a file `results.log`.
+
+# Result full test
+
+```bash
+$ node ./tools/check-benchmarks.js
+```
+
+| (index) |     Framework      | Requests/sec | Transfer/sec |  Latency   | Total Requests | Transfer Total | Latency Stdev | Latency Max |
+|---------|--------------------|--------------|--------------|------------|----------------|----------------|---------------|-------------|
+|    0    | cluster_fastify     |  138457.36   |   23.24MB    |  15.58ms   |    1388733     |    233.09MB    |   58.10ms     |  842.11ms   |
+|    1    | cluster_http        |  137054.68   |   23.27MB    |  14.56ms   |    1376920     |    233.74MB    |   52.84ms     |  802.10ms   |
+|    2    | cluster_koa         |  122922.41   |   20.51MB    |  14.97ms   |    1234474     |    206.03MB    |   52.39ms     |  823.15ms   |
+|    3    | cluster_hapi        |   94445.64   |   19.91MB    |  23.66ms   |     949082     |    200.03MB    |   83.97ms     |    1.10s    |
+|    4    | cluster_restify     |   93398.96   |   16.48MB    |  22.78ms   |     937893     |    165.47MB    |   79.86ms     |    1.09s    |
+|    5    | cluster_express     |   43577.99   |    9.89MB    |  60.64ms   |     437738     |     99.36MB    |  190.66ms     |    2.00s    |
+|    6    | single_uws          |   37081.93   |    3.71MB    |  27.45ms   |     372355     |     37.29MB    |    3.06ms     |  76.40ms    |
+|    7    | cluster_uws         |   35629.39   |    3.57MB    |  28.57ms   |     357699     |     35.82MB    |    1.82ms     |  95.33ms    |
+|    8    | single_http         |   24159.04   |    4.10MB    |  42.09ms   |     242998     |     41.25MB    |    7.12ms     |  235.08ms   |
+|    9    | single_fastify      |   23794.91   |    3.99MB    |  43.18ms   |     239197     |     40.15MB    |   11.90ms     |  343.66ms   |
+|   10    | single_koa          |   20263.96   |    3.38MB    |  50.25ms   |     204371     |     34.11MB    |   17.65ms     |  294.61ms   |
+|   11    | single_hapi         |   14163.93   |    2.99MB    |  71.82ms   |     142853     |     30.11MB    |   16.06ms     |  410.62ms   |
+|   12    | single_restify      |   14036.58   |    2.48MB    |  72.46ms   |     141118     |     24.90MB    |   13.49ms     |  527.51ms   |
+|   13    | single_express      |   6830.47    |    1.55MB    | 147.89ms   |      68993     |     15.66MB    |   29.75ms     |  626.75ms   |
+

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "express-benchmarks",
+	"version": "0.0.1",
+	"author": "Andre Ferreira <andrehrf@gmail.com>",
+	"description": "Performance test",
+	"main": "index.js",
+	"devDependencies": {
+		"@hapi/hapi": "^21.3.10",
+		"express": "^4.19.2",
+		"fastify": "^4.28.1",
+		"koa": "^2.15.3",
+		"restify": "^11.1.0",
+		"uWebSockets.js": "uNetworking/uWebSockets.js#v20.47.0"
+	},
+	"engines": {
+		"node": ">=12.0.0"
+	},
+	"dependencies": {
+		"bytes": "^3.1.2",
+		"wrk": "^1.2.1"
+	}
+}

--- a/benchmarks/servers/cluster_express.js
+++ b/benchmarks/servers/cluster_express.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const cluster = require('cluster');
+const express = require('express');
+const numCPUs = 6; 
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) 
+        cluster.fork();
+    
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork(); 
+    });
+} else {
+    const app = express();
+
+    app.get('/', (req, res) => {
+        res.send('Hello world');
+    });
+
+    app.listen(3000, () => {});
+}

--- a/benchmarks/servers/cluster_fastify.js
+++ b/benchmarks/servers/cluster_fastify.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const cluster = require('cluster');
+const numCPUs = 6; 
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) {
+        cluster.fork();
+    }
+
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork(); 
+    });
+} else {
+    const fastify = require('fastify')();
+
+    fastify.get('/', async (req, reply) => {
+        reply.send('Hello world');
+    });
+
+    fastify.listen({ port: 3000 }, (err, address) => {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+    });
+}

--- a/benchmarks/servers/cluster_hapi.js
+++ b/benchmarks/servers/cluster_hapi.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const cluster = require('cluster');
+const numCPUs = 6;
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) 
+        cluster.fork();
+    
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork();
+    });
+} else {
+    const Hapi = require('@hapi/hapi');
+
+    const init = async () => {
+        const server = Hapi.server({
+            port: 3000,
+            host: 'localhost'
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: (request, h) => {
+                return 'Hello world';
+            }
+        });
+
+        await server.start();
+    };
+
+    process.on('unhandledRejection', (err) => {
+        console.log(err);
+        process.exit(1);
+    });
+
+    init();
+}

--- a/benchmarks/servers/cluster_http.js
+++ b/benchmarks/servers/cluster_http.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const cluster = require('cluster');
+const http = require('http');
+const numCPUs = 6; 
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) 
+        cluster.fork();
+    
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork(); 
+    });
+} else {
+    const requestListener = (req, res) => {
+        if (req.method === 'GET' && req.url === '/') {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('Hello world');
+        }
+    };
+
+    const server = http.createServer(requestListener);
+    server.listen(3000);
+}

--- a/benchmarks/servers/cluster_koa.js
+++ b/benchmarks/servers/cluster_koa.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const cluster = require('cluster');
+const numCPUs = 6;
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) 
+        cluster.fork();
+    
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork();
+    });
+} else {
+    const Koa = require('koa');
+    const app = new Koa();
+
+    app.use(async ctx => {
+        ctx.body = 'Hello world';
+    });
+
+    app.listen(3000);
+}

--- a/benchmarks/servers/cluster_restify.js
+++ b/benchmarks/servers/cluster_restify.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const cluster = require('cluster');
+const numCPUs = 6; 
+
+if (cluster.isMaster) {
+    for (let i = 0; i < numCPUs; i++) 
+        cluster.fork();
+    
+    cluster.on('exit', (worker, code, signal) => {
+        cluster.fork(); 
+    });
+} else {
+    const restify = require('restify');
+
+    const server = restify.createServer();
+
+    server.get('/', (req, res, next) => {
+        res.send('Hello world');
+        next();
+    });
+
+    server.listen(3000);
+}

--- a/benchmarks/servers/cluster_uws.js
+++ b/benchmarks/servers/cluster_uws.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { Worker, isMainThread } = require('worker_threads');
+const uWS = require('uWebSockets.js');
+const numCPUs = 6;
+const port = 3000;
+
+if (isMainThread) {
+	for (let i = 0; i < numCPUs; i++) 
+    	new Worker(__filename);
+} else {
+	const app = uWS.App().get('/*', (res, req) => {
+		res.end('Hello World!');
+	}).listen(port, (token) => {});
+}

--- a/benchmarks/servers/single_cmmv.js
+++ b/benchmarks/servers/single_cmmv.js
@@ -1,0 +1,17 @@
+const { startServer, getMessageFromCpp, processResponse } = require('../build/Release/cmmv_binding');
+
+async function consumerLoop(id) {
+    setInterval(async () => {
+        const message = getMessageFromCpp();
+
+        if (message && message.reqId) 
+            processResponse(message.reqId, `Hello from Consumer ${id}`);        
+    }, 1)
+}
+
+startServer('127.0.0.1', 3000);
+
+const numConsumers = 24;
+for (let i = 1; i <= numConsumers; i++) {
+    consumerLoop(i).catch((error) => console.error(`Erro no Consumer ${i}:`, error));
+}

--- a/benchmarks/servers/single_express.js
+++ b/benchmarks/servers/single_express.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => res.send('Hello world'));
+app.listen(3000);

--- a/benchmarks/servers/single_fastify.js
+++ b/benchmarks/servers/single_fastify.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const fastify = require('fastify')();
+fastify.get('/', async (req, reply) => reply.send('Hello world'));
+fastify.listen({ port: 3000 });

--- a/benchmarks/servers/single_hapi.js
+++ b/benchmarks/servers/single_hapi.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+
+const init = async () => {
+    const server = Hapi.server({
+        port: 3000,
+        host: 'localhost'
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/',
+        handler: (request, h) => {
+            return 'Hello world';
+        }
+    });
+
+    await server.start();
+};
+
+process.on('unhandledRejection', (err) => {
+    console.log(err);
+    process.exit(1);
+});
+
+init();

--- a/benchmarks/servers/single_http.js
+++ b/benchmarks/servers/single_http.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const http = require('http');
+
+const requestListener = (req, res) => {
+    if (req.method === 'GET' && req.url === '/') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('Hello world');
+    }
+};
+
+const server = http.createServer(requestListener);
+server.listen(3000);

--- a/benchmarks/servers/single_koa.js
+++ b/benchmarks/servers/single_koa.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Koa = require('koa');
+const app = new Koa();
+
+app.use(async ctx => {
+  ctx.body = 'Hello world';
+});
+
+app.listen(3000);

--- a/benchmarks/servers/single_restify.js
+++ b/benchmarks/servers/single_restify.js
@@ -1,0 +1,9 @@
+const restify = require('restify');
+
+const server = restify.createServer();
+server.get('/', (req, res, next) => {
+  res.send('Hello world');
+  next();
+});
+
+server.listen(3000, () => {});

--- a/benchmarks/servers/single_uws.js
+++ b/benchmarks/servers/single_uws.js
@@ -1,0 +1,8 @@
+/* Minimal HTTP/3 example */
+
+const uWS = require('uWebSockets.js');
+const port = 3000;
+
+uWS.App().get('/*', (res, req) => {
+  res.end('Hello World!');
+}, 5).listen(port, () =>{});

--- a/benchmarks/tools/check-benchmarks.js
+++ b/benchmarks/tools/check-benchmarks.js
@@ -1,0 +1,120 @@
+//@see https://github.com/nestjs/nest/blob/master/tools/benchmarks/check-benchmarks.ts
+
+const bytes = require('bytes');
+const { getBenchmarks, LIBS } = require('./get-benchmarks');
+
+module.default = async function checkBenchmarks() {
+  const currentBenchmarks = await getBenchmarks();
+  
+  const baselineBenchmarks = await loadBaselineBenchmarks();
+  
+  const report = getBenchmarksReport(currentBenchmarks, baselineBenchmarks);
+  
+  console.log(report.longDescription);
+
+  await saveBaselineBenchmarks(currentBenchmarks);
+}
+
+async function loadBaselineBenchmarks() {
+  return undefined;
+}
+
+async function saveBaselineBenchmarks(benchmarks) {}
+
+function getBenchmarksReport(current, baseline) {
+  const diff = getDiff(current, baseline);
+
+  const shortDescription = getShortDescription(baseline, diff);
+  const longDescription = getLongDescription(current, baseline, diff);
+
+  return {
+    name: 'Benchmarks',
+    status: 'success',
+    shortDescription,
+    longDescription,
+  };
+}
+
+function getShortDescription(baseline, diff) {
+  if (!baseline) {
+    return 'New benchmarks generated';
+  }
+
+  const avgDiff = getAverageDiff(diff);
+  if (avgDiff > 0) {
+    return `Performance improved by ${avgDiff.toFixed(2)}% on average, good job!`;
+  }
+  if (avgDiff === 0) {
+    return `No changes in performance detected`;
+  }
+  if (avgDiff < 0) {
+    return `Performance decreased by ${avgDiff.toFixed(2)}% on average, be careful!`;
+  }
+}
+
+function getLongDescription(current, baseline, diff) {
+  function printTableRow(id, label) {
+    return `${label} | ${current[id].requestsPerSec.toFixed(0)} | ${current[id].transferPerSec} | ${baseline ? formatPerc(diff[id].requestsPerSecDiff) : '-'} | ${baseline ? formatPerc(diff[id].transferPerSecDiff) : '-'}`;
+  }
+
+  let table = `
+| Framework | Req/sec | Trans/sec | Req/sec DIFF | Trans/sec DIFF |
+|-----------|---------|-----------|--------------|----------------|
+${printTableRow('express', 'Express')}
+${printTableRow('fastify', 'Fastify')}
+`;
+
+  return table.trim();
+}
+
+function getDiff(current, baseline) {
+  const diff = {};
+  for (const l of LIBS) {
+    if (!baseline) {
+      diff[l] = {
+        requestsPerSecDiff: undefined,
+        transferPerSecDiff: undefined
+      };
+      continue;
+    }
+
+    const currentValue = current[l];
+    const baselineValue = baseline[l];
+
+    diff[l] = {
+      requestsPerSecDiff: getRequestDiff(
+        currentValue.requestsPerSec,
+        baselineValue.requestsPerSec,
+      ),
+      transferPerSecDiff: getTransferDiff(
+        currentValue.transferPerSec,
+        baselineValue.transferPerSec,
+      ),
+    };
+  }
+  return diff;
+}
+
+function getTransferDiff(currentTransfer, baselineTransfer) {
+  return 1 - bytes.parse(currentTransfer) / bytes.parse(baselineTransfer);
+}
+
+function getAverageDiff(diff) {
+  const validDiffs = Object.values(diff).filter(
+    (d) => d && d.requestsPerSecDiff !== undefined && d.transferPerSecDiff !== undefined
+  );
+  
+  const totalDiff = validDiffs.reduce((acc, d) => {
+    return acc + (d.requestsPerSecDiff ?? 0) + (d.transferPerSecDiff ?? 0);
+  }, 0);
+  
+  return totalDiff / (validDiffs.length * 2);
+}
+
+function getRequestDiff(currentRequest, baselineRequest) {
+  return 1 - currentRequest / baselineRequest;
+}
+
+function formatPerc(n) {
+  return (n > 0 ? '+' : '') + (n * 100).toFixed(2) + '%';
+}

--- a/benchmarks/tools/get-benchmarks.js
+++ b/benchmarks/tools/get-benchmarks.js
@@ -1,0 +1,89 @@
+//@see https://github.com/nestjs/nest/blob/master/tools/benchmarks/get-benchmarks.ts
+
+const wrkPkg = require('wrk');
+const { spawn } = require('child_process');
+const { join } = require('path');
+const { table } = require('console');
+
+const wrk = (options) =>
+  new Promise((resolve, reject) =>
+    wrkPkg(options, (err, result) =>
+      err ? reject(err) : resolve(result),
+    ),
+  );
+
+const sleep = (time) =>
+  new Promise(resolve => setTimeout(resolve, time));
+
+const BENCHMARK_PATH = join(process.cwd(), 'servers');
+const LIBS = [
+  'single_uws', 'single_express', 'single_fastify', 
+  'single_koa', 'single_hapi', 'single_http', 
+  'single_restify', 'cluster_http', 'cluster_express',
+  'cluster_uws', 'cluster_fastify', 'cluster_koa',
+  'cluster_hapi', 'cluster_restify'
+];//cmmv, 
+
+async function runBenchmarkOfLib(lib) {
+  const libPath = join(BENCHMARK_PATH, `${lib}.js`);
+  const process = spawn('node', [libPath], {
+    //detached: true,
+  });
+
+  process.stdout.on('data', data => {
+    console.log(`stdout: ${data}`);
+  });
+
+  process.stderr.on('data', data => {
+    console.log(`stderr: ${data}`);
+  });
+
+  process.unref();
+
+  await sleep(5000); 
+
+  const result = await wrk({
+    threads: 8,
+    duration: '10s',
+    connections: 1024,
+    url: 'http://localhost:3000',
+  });
+
+  process.kill();
+  return result;
+}
+
+async function getBenchmarks() {
+  const results = {};
+  for (const lib of LIBS) {
+    console.log(`Running benchmark for ${lib}`);
+    try {
+      const result = await runBenchmarkOfLib(lib);
+      results[lib] = result;
+    } catch (error) {
+      console.error(`Error during benchmark for ${lib}:`, error);
+    }
+  }
+  return results;
+}
+
+async function run() {
+  const results = await getBenchmarks();
+
+  const tableData = Object.entries(results).map(([lib, result]) => ({
+    Framework: lib,
+    'Requests/sec': result.requestsPerSec,
+    'Transfer/sec': result.transferPerSec,
+    Latency: result.latencyAvg,
+    'Total Requests': result.requestsTotal,
+    'Transfer Total': result.transferTotal,
+    'Latency Stdev': result.latencyStdev,
+    'Latency Max': result.latencyMax,
+  }));
+
+  tableData.sort((a, b) => b['Requests/sec'] - a['Requests/sec']);
+
+  console.table(tableData);
+}
+
+run();

--- a/benchmarks/tools/report-contents.md
+++ b/benchmarks/tools/report-contents.md
@@ -1,0 +1,18 @@
+## Benchmark Results
+
+| (index) |     Framework      | Requests/sec | Transfer/sec |  Latency   | Total Requests | Transfer Total | Latency Stdev | Latency Max |
+|---------|--------------------|--------------|--------------|------------|----------------|----------------|---------------|-------------|
+|    0    | cluster_fastify     |  138457.36   |   23.24MB    |  15.58ms   |    1388733     |    233.09MB    |   58.10ms     |  842.11ms   |
+|    1    | cluster_http        |  137054.68   |   23.27MB    |  14.56ms   |    1376920     |    233.74MB    |   52.84ms     |  802.10ms   |
+|    2    | cluster_koa         |  122922.41   |   20.51MB    |  14.97ms   |    1234474     |    206.03MB    |   52.39ms     |  823.15ms   |
+|    3    | cluster_hapi        |   94445.64   |   19.91MB    |  23.66ms   |     949082     |    200.03MB    |   83.97ms     |    1.10s    |
+|    4    | cluster_restify     |   93398.96   |   16.48MB    |  22.78ms   |     937893     |    165.47MB    |   79.86ms     |    1.09s    |
+|    5    | cluster_express     |   43577.99   |    9.89MB    |  60.64ms   |     437738     |     99.36MB    |  190.66ms     |    2.00s    |
+|    6    | single_uws          |   37081.93   |    3.71MB    |  27.45ms   |     372355     |     37.29MB    |    3.06ms     |  76.40ms    |
+|    7    | cluster_uws         |   35629.39   |    3.57MB    |  28.57ms   |     357699     |     35.82MB    |    1.82ms     |  95.33ms    |
+|    8    | single_http         |   24159.04   |    4.10MB    |  42.09ms   |     242998     |     41.25MB    |    7.12ms     |  235.08ms   |
+|    9    | single_fastify      |   23794.91   |    3.99MB    |  43.18ms   |     239197     |     40.15MB    |   11.90ms     |  343.66ms   |
+|   10    | single_koa          |   20263.96   |    3.38MB    |  50.25ms   |     204371     |     34.11MB    |   17.65ms     |  294.61ms   |
+|   11    | single_hapi         |   14163.93   |    2.99MB    |  71.82ms   |     142853     |     30.11MB    |   16.06ms     |  410.62ms   |
+|   12    | single_restify      |   14036.58   |    2.48MB    |  72.46ms   |     141118     |     24.90MB    |   13.49ms     |  527.51ms   |
+|   13    | single_express      |   6830.47    |    1.55MB    | 147.89ms   |      68993     |     15.66MB    |   29.75ms     |  626.75ms   |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "Guillermo Rauch <rauchg@gmail.com>",
     "Jonathan Ong <me@jongleberry.com>",
     "Roman Shtylman <shtylman+expressjs@gmail.com>",
-    "Young Jae Sim <hanul@hanul.me>"
+    "Young Jae Sim <hanul@hanul.me>",
+    "Andre Ferreira <andrehrf@gmail.com>"
   ],
   "license": "MIT",
   "repository": "expressjs/express",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "after": "0.8.2",
+    "bytes": "^3.1.2",
     "connect-redis": "3.4.2",
     "cookie-parser": "1.4.6",
     "cookie-session": "2.0.0",
@@ -76,7 +78,8 @@
     "nyc": "15.1.0",
     "pbkdf2-password": "1.2.1",
     "supertest": "6.3.0",
-    "vhost": "~3.0.2"
+    "vhost": "~3.0.2",
+    "wrk": "^1.2.1"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -93,6 +96,7 @@
     "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
     "test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=html --reporter=text npm test",
-    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+    "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+    "benchmarks": "node --trace-deprecation ./benchmarks/tools/check-benchmarks.js"
   }
 }


### PR DESCRIPTION
Benchmark Testing Implementation for Various Node.js Frameworks
This pull request introduces a comprehensive benchmarking test that compares the performance of several popular Node.js frameworks. The benchmarks were designed to measure each framework’s:

Requests per second: The number of requests the framework can handle per second.
Transfer rate: The amount of data transferred per second.
Latency: The average time taken to respond to requests.
Latency Stdev: The standard deviation in the response time across all requests.
Max Latency: The maximum latency observed during the tests.

Frameworks Tested:

uWebSockets.js (uws)
Node.js HTTP (http)
Fastify
Koa
Restify
Hapi
Express

Results Summary:
The table below highlights the key metrics recorded during the benchmarking:

| (index) |     Framework      | Requests/sec | Transfer/sec |  Latency   | Total Requests | Transfer Total | Latency Stdev | Latency Max |
|---------|--------------------|--------------|--------------|------------|----------------|----------------|---------------|-------------|
|    0    | cluster_fastify     |  138457.36   |   23.24MB    |  15.58ms   |    1388733     |    233.09MB    |   58.10ms     |  842.11ms   |
|    1    | cluster_http        |  137054.68   |   23.27MB    |  14.56ms   |    1376920     |    233.74MB    |   52.84ms     |  802.10ms   |
|    2    | cluster_koa         |  122922.41   |   20.51MB    |  14.97ms   |    1234474     |    206.03MB    |   52.39ms     |  823.15ms   |
|    3    | cluster_hapi        |   94445.64   |   19.91MB    |  23.66ms   |     949082     |    200.03MB    |   83.97ms     |    1.10s    |
|    4    | cluster_restify     |   93398.96   |   16.48MB    |  22.78ms   |     937893     |    165.47MB    |   79.86ms     |    1.09s    |
|    5    | cluster_express     |   43577.99   |    9.89MB    |  60.64ms   |     437738     |     99.36MB    |  190.66ms     |    2.00s    |
|    6    | single_uws          |   37081.93   |    3.71MB    |  27.45ms   |     372355     |     37.29MB    |    3.06ms     |  76.40ms    |
|    7    | cluster_uws         |   35629.39   |    3.57MB    |  28.57ms   |     357699     |     35.82MB    |    1.82ms     |  95.33ms    |
|    8    | single_http         |   24159.04   |    4.10MB    |  42.09ms   |     242998     |     41.25MB    |    7.12ms     |  235.08ms   |
|    9    | single_fastify      |   23794.91   |    3.99MB    |  43.18ms   |     239197     |     40.15MB    |   11.90ms     |  343.66ms   |
|   10    | single_koa          |   20263.96   |    3.38MB    |  50.25ms   |     204371     |     34.11MB    |   17.65ms     |  294.61ms   |
|   11    | single_hapi         |   14163.93   |    2.99MB    |  71.82ms   |     142853     |     30.11MB    |   16.06ms     |  410.62ms   |
|   12    | single_restify      |   14036.58   |    2.48MB    |  72.46ms   |     141118     |     24.90MB    |   13.49ms     |  527.51ms   |
|   13    | single_express      |   6830.47    |    1.55MB    | 147.89ms   |      68993     |     15.66MB    |   29.75ms     |  626.75ms   |