### PR TITLE
add pull request template + compliance check action

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+# STOP! Read this before submitting your pull request
+
+## ⚠️ Warning ⚠️
+This repository is not for educational exercises or trivial changes. Pull requests that do not provide substantial value will be closed immediately.
+
+Before submitting your pull request, make sure you answer YES to ALL of the following (replace each "[ ]" with "[x]" - if any do not apply, do not create the pull request):
+-->
+
+## Checklist
+
+- [ ] I have read and understood the contributing guidelines
+- [ ] This pull request addresses an existing issue or adds significant functionality
+- [ ] I have tested my changes thoroughly
+- [ ] My commit messages are clear and descriptive
+- [ ] I am NOT submitting this as part of a coding course or tutorial
+
+## Confirmation
+By submitting this pull request, I confirm that:
+- [ ] This is NOT a trivial change (e.g., simple README updates)
+- [ ] I understand that misuse of this repository may result in being blocked
+
+## Description
+<!-- Please provide a clear and concise description of your changes: -->
+
+## Related Issue
+<!-- If this PR addresses an existing issue, please link to it: -->
+
+<!--
+**Note: Pull requests that do not fill out this template completely and honestly will be closed without review.**
+-->

--- a/.github/workflows/pr-compliance-check.yml
+++ b/.github/workflows/pr-compliance-check.yml
@@ -1,0 +1,43 @@
+name: Pull Request Compliance Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body
+        id: check_pr_body
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const prBody = context.payload.pull_request.body;
+            const requiredChecks = [
+              '- [x] This is NOT a trivial change',
+              '- [x] I understand that misuse of this repository may result in being blocked',
+              '- [x] I am NOT submitting this as part of a coding course or tutorial',
+            ];
+            
+            const missingChecks = requiredChecks.filter(check => !prBody.includes(check));
+            
+            if (missingChecks.length) {
+              console.log(`Pull request is not compliant. Missing checks:`, missingChecks);
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'This pull request does not comply with our submission guidelines. It will be automatically closed. Please read our contributing guidelines carefully before submitting a new pull request.'
+              });
+              
+              github.rest.pulls.update({
+                pull_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed'
+              });
+            } else {
+              console.log(`Pull request is compliant`);
+            }


### PR DESCRIPTION
Based on an X conversation - it seems there's at least one coding course that instructs students to [spam](https://github.com/expressjs/express/pulls?q=is%3Apr+is%3Aclosed+is%3Aunmerged+%22Update%22) express. Hopefully this can help cut it down.

https://x.com/mmkalmmkal/status/1828811200802816185

I'm not 100% sure the compliance check will actually work with the default GitHub token. If not there may be a free GitHub app that can do something similar.