### PR TITLE
feat: upgrade to body-parser@1.20.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,9 @@
 unreleased
 ==========
-
+  * deps: body-parser@0.6.0
+    * add `depth` option to customize the depth level in the parser
+    * IMPORTANT: The default `depth` level for parsing URL-encoded data is now `32` (previously was `Infinity`)
+  * Remove link renderization in html while using `res.redirect`
   * deps: path-to-regexp@0.1.10
     - Adds support for named matching groups in the routes using a regex
     - Adds backtracking protection to parameters without regexes defined

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "accepts": "~1.3.8",
     "array-flatten": "1.1.1",
-    "body-parser": "1.20.2",
+    "body-parser": "1.20.3",
     "content-disposition": "0.5.4",
     "content-type": "~1.0.4",
     "cookie": "0.6.0",

--- a/test/express.urlencoded.js
+++ b/test/express.urlencoded.js
@@ -212,7 +212,7 @@ describe('express.urlencoded()', function () {
       it('should parse deep object', function (done) {
         var str = 'foo'
 
-        for (var i = 0; i < 500; i++) {
+        for (var i = 0; i < 32; i++) {
           str += '[p]'
         }
 
@@ -230,7 +230,7 @@ describe('express.urlencoded()', function () {
             var depth = 0
             var ref = obj.foo
             while ((ref = ref.p)) { depth++ }
-            assert.strictEqual(depth, 500)
+            assert.strictEqual(depth, 32)
           })
           .expect(200, done)
       })


### PR DESCRIPTION
This PR introduces the ability to customize the `depth` level in `body-parser` (default is `32`, previously `Infinity`). Lower values are recommended for security reasons when possible.

You can customize it like this:


```js
app.post('/', bodyParser.urlencoded({
    depth: 5,
    // Other options...
})
```