### PR TITLE
Delete `back` as a magic string

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@ unreleased
     * will throw a `RangeError: Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.` for inputs outside this range
     * will throw a `TypeError: Invalid status code: ${code}. Status code must be an integer.` for non integer inputs
   * deps: send@1.0.0
+  * `res.redirect('back')` and `res.location('back')` is no longer a supported magic string, explicitly use `req.get('Referrer') || '/'`.
 * change:
   - `res.clearCookie` will ignore user provided `maxAge` and `expires` options
 * deps: cookie-signature@^1.2.1

--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -116,7 +116,7 @@ app.post('/login', function (req, res, next) {
         req.session.success = 'Authenticated as ' + user.name
           + ' click to <a href="/logout">logout</a>. '
           + ' You may now access <a href="/restricted">/restricted</a>.';
-        res.redirect('back');
+        res.redirect(req.get('Referrer') || '/');
       });
     } else {
       req.session.error = 'Authentication failed, please check your '

--- a/examples/cookies/index.js
+++ b/examples/cookies/index.js
@@ -33,7 +33,7 @@ app.get('/', function(req, res){
 
 app.get('/forget', function(req, res){
   res.clearCookie('remember');
-  res.redirect('back');
+  res.redirect(req.get('Referrer') || '/');
 });
 
 app.post('/', function(req, res){
@@ -43,7 +43,7 @@ app.post('/', function(req, res){
     res.cookie('remember', 1, { maxAge: minute })
   }
 
-  res.redirect('back');
+  res.redirect(req.get('Referrer') || '/');
 });
 
 /* istanbul ignore next */

--- a/examples/route-separation/user.js
+++ b/examples/route-separation/user.js
@@ -43,5 +43,5 @@ exports.update = function(req, res){
   var user = req.body.user;
   req.user.name = user.name;
   req.user.email = user.email;
-  res.redirect('back');
+  res.redirect(req.get('Referrer') || '/');
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -785,25 +785,12 @@ res.cookie = function (name, value, options) {
  */
 
 res.location = function location(url) {
-  var loc;
-
-  // "back" is an alias for the referrer
-  if (url === 'back') {
-    loc = this.req.get('Referrer') || '/';
-  } else {
-    loc = String(url);
-  }
-
-  return this.set('Location', encodeUrl(loc));
+  return this.set('Location', encodeUrl(url));
 };
 
 /**
  * Redirect to the given `url` with optional response `status`
  * defaulting to 302.
- *
- * The resulting `url` is determined by `res.location()`, so
- * it will play nicely with mounted apps, relative paths,
- * `"back"` etc.
  *
  * Examples:
  *

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -46,64 +46,6 @@ describe('res', function(){
       .expect(200, done)
     })
 
-    describe('when url is "back"', function () {
-      it('should set location from "Referer" header', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.location('back').end()
-        })
-
-        request(app)
-        .get('/')
-        .set('Referer', '/some/page.html')
-        .expect('Location', '/some/page.html')
-        .expect(200, done)
-      })
-
-      it('should set location from "Referrer" header', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.location('back').end()
-        })
-
-        request(app)
-        .get('/')
-        .set('Referrer', '/some/page.html')
-        .expect('Location', '/some/page.html')
-        .expect(200, done)
-      })
-
-      it('should prefer "Referrer" header', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.location('back').end()
-        })
-
-        request(app)
-        .get('/')
-        .set('Referer', '/some/page1.html')
-        .set('Referrer', '/some/page2.html')
-        .expect('Location', '/some/page2.html')
-        .expect(200, done)
-      })
-
-      it('should set the header to "/" without referrer', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.location('back').end()
-        })
-
-        request(app)
-        .get('/')
-        .expect('Location', '/')
-        .expect(200, done)
-      })
-    })
-
     it('should encode data uri1', function (done) {
       var app = express()
       app.use(function (req, res) {


### PR DESCRIPTION
From https://github.com/expressjs/express/pull/2692#issuecomment-2297916766, removing `"back"` as a magic string to have people do this explicitly to ensure redirections are going where they expect.