### PR TITLE
Deprecate `"back"` magic string in redirects

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Deprecate `res.location("back")` and `res.redirect("back")` magic string
+
 4.20.0 / 2024-09-10
 ==========
   * deps: serve-static@0.16.0

--- a/lib/response.js
+++ b/lib/response.js
@@ -916,7 +916,7 @@ res.location = function location(url) {
 
   // "back" is an alias for the referrer
   if (url === 'back') {
-    deprecate('res.location("back"): use res.location(req.get("Referrer") || "/") and refer to https://expressjs.com/en/advanced/best-practice-security.html#prevent-open-redirects for best practices');
+    deprecate('res.location("back"): use res.location(req.get("Referrer") || "/") and refer to https://dub.sh/security-redirect for best practices');
     loc = this.req.get('Referrer') || '/';
   } else {
     loc = String(url);

--- a/lib/response.js
+++ b/lib/response.js
@@ -916,6 +916,7 @@ res.location = function location(url) {
 
   // "back" is an alias for the referrer
   if (url === 'back') {
+    deprecate('res.location("back"): use res.location(req.get("Referrer") || "/") and refer to https://expressjs.com/en/advanced/best-practice-security.html#prevent-open-redirects for best practices');
     loc = this.req.get('Referrer') || '/';
   } else {
     loc = String(url);


### PR DESCRIPTION
Related to https://github.com/expressjs/express/pull/5933, deprecates this and directs users to read security best practices for open redirects.