### PR TITLE
deps: path-to-regexp@0.1.11

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+  * deps: path-to-regexp@0.1.11
+    - Throws an error on invalid path values
+
 4.21.0 / 2024-09-11
 ==========
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "methods": "~1.1.2",
     "on-finished": "2.4.1",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.10",
+    "path-to-regexp": "0.1.11",
     "proxy-addr": "~2.0.7",
     "qs": "6.13.0",
     "range-parser": "~1.2.1",


### PR DESCRIPTION
New explicit error from `path-to-regexp` to close https://github.com/expressjs/express/issues/5955.