### PR TITLE
remove --bail from test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+    "test": "mocha --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
     "test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=html --reporter=text npm test",
     "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"


### PR DESCRIPTION
Original intent of bail was that the test script was used only for local dev, and there was a CI script w/o bail ab8d116f4 

Eventually CI script reused local script, so bail got into CI. 12310c529 

bail will stop test execution after the first failure

### aside

can run `npm test -- --bail=false` to override it locally or just run your own watch script

I prefer removing bail instead of changing the ci script to something like passing `-- --bail=false`
```json
"test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test -- --bail=false"
```