### PR TITLE
perf: removed useless define Getter in favor of direct assignment

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -311,9 +311,7 @@ defineGetter(req, 'protocol', function protocol(){
  * @public
  */
 
-defineGetter(req, 'secure', function secure(){
-  return this.protocol === 'https';
-});
+req.secure = req.protocol === 'https';
 
 /**
  * Return the remote address from the trusted proxy.


### PR DESCRIPTION
Removed useless define getter in favor of direct assignment. Protocol value won't change during a request's lifecycle.

See https://github.com/expressjs/perf-wg/issues/15