### PR TITLE
Update `cookie` semver lock to address CVE-2024-47764

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+* Update `cookie` semver lock to address CVE-2024-47764
+
 5.0.0 / 2024-09-10
 =========================
 * remove:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "body-parser": "^2.0.1",
     "content-disposition": "^1.0.0",
     "content-type": "~1.0.4",
-    "cookie": "0.6.0",
+    "cookie": "^0.7.1",
     "cookie-signature": "^1.2.1",
     "debug": "4.3.6",
     "depd": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "body-parser": "^2.0.1",
     "content-disposition": "^1.0.0",
     "content-type": "~1.0.4",
-    "cookie": "^0.7.1",
+    "cookie": "0.7.1",
     "cookie-signature": "^1.2.1",
     "debug": "4.3.6",
     "depd": "2.0.0",


### PR DESCRIPTION
Per CVE-2024-47764 (https://github.com/advisories/GHSA-pxg6-pf52-xh8x), versions `< 0.7.0` of `cookie` have a low severity vulnerability.

Because express uses a strict semver lock of `0.6.0` this will cause downstream projects to pull a vulnerable version of cookie unless they explicitly overwrite the resolution in their `package.json` with:

```json
"resolutions": {
  "cookie": ">= 0.7.0"
},
```

Updating the semver to `^0.7.1` to both resolve the vulnerability and allow backwards compatible updates in the future.

Fixes #6019 