### PR TITLE
feat: add cache to defineGetter

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -226,7 +226,7 @@ defineGetter(req, 'query', function query(){
   var querystring = parse(this).query;
 
   return queryparse(querystring);
-});
+}, true);
 
 /**
  * Check if the incoming request contains the "Content-Type"
@@ -504,12 +504,19 @@ defineGetter(req, 'xhr', function xhr(){
  * @param {Object} obj
  * @param {String} name
  * @param {Function} getter
+ * @param {boolean} enableCache
  * @private
  */
-function defineGetter(obj, name, getter) {
+function defineGetter(obj, name, getter, enableCache) {
+  let cache;
   Object.defineProperty(obj, name, {
     configurable: true,
     enumerable: true,
-    get: getter
+    get: function() {
+      if (typeof cache === "undefined" || !enableCache) {
+        cache = getter.call(this);
+      }
+      return cache;
+    }
   });
 }


### PR DESCRIPTION
Adding this cache to the defineGetter function has several implications:

- **Performance Improvement**: The getter function will only be called once, and its result will be stored. Subsequent accesses to the property will return the cached value, avoiding the cost of repeatedly executing the getter function.
- **Consistency**: The value returned by the getter will remain consistent for the lifetime of the property on the object. If the getter logic involves any computation that could potentially change, this cache will prevent any changes from being reflected in the property's value after the first access.
- **Side Effects**: If the getter function has side effects (e.g., logging, triggering other operations), these will only occur once when the value is first computed. Subsequent accesses will not trigger these side effects.

Just for POC, I have enabled only on `query`