### PR TITLE
missing middleware for parsing json

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -1,81 +1,137 @@
-/*!
- * express
- * Copyright(c) 2009-2013 TJ Holowaychuk
- * Copyright(c) 2013 Roman Shtylman
- * Copyright(c) 2014-2015 Douglas Christopher Wilson
- * MIT Licensed
- */
-
 'use strict';
 
-/**
- * Module dependencies.
- */
+var assert = require('assert');
+var express = require('..');
+var request = require('supertest');
 
-var bodyParser = require('body-parser')
-var EventEmitter = require('events').EventEmitter;
-var mixin = require('merge-descriptors');
-var proto = require('./application');
-var Router = require('router');
-var req = require('./request');
-var res = require('./response');
+describe('app', function() {
+  it('should inherit from event emitter', function(done) {
+    var app = express();
+    app.on('foo', done);
+    app.emit('foo');
+  });
 
-/**
- * Expose `createApplication()`.
- */
+  it('should be callable', function() {
+    var app = express();
+    assert.equal(typeof app, 'function');
+  });
 
-exports = module.exports = createApplication;
+  it('should 404 without routes', function(done) {
+    request(express())
+      .get('/')
+      .expect(404, done);
+  });
+});
 
-/**
- * Create an express application.
- *
- * @return {Function}
- * @api public
- */
+// New section: Ensure JSON parsing is enabled
+describe('app with JSON middleware', function() {
+  it('should respond with JSON for POST requests', function(done) {
+    var app = express();
+    app.use(express.json()); // Ensure JSON parsing middleware is added
 
-function createApplication() {
-  var app = function(req, res, next) {
-    app.handle(req, res, next);
-  };
+    app.post('/data', function(req, res) {
+      res.json(req.body);
+    });
 
-  mixin(app, EventEmitter.prototype, false);
-  mixin(app, proto, false);
+    request(app)
+      .post('/data')
+      .send({ key: 'value' })
+      .expect(200, { key: 'value' }, done);
+  });
+});
 
-  // expose the prototype that will get set on requests
-  app.request = Object.create(req, {
-    app: { configurable: true, enumerable: true, writable: true, value: app }
-  })
+describe('app.parent', function() {
+  it('should return the parent when mounted', function() {
+    var app = express(),
+      blog = express(),
+      blogAdmin = express();
 
-  // expose the prototype that will get set on responses
-  app.response = Object.create(res, {
-    app: { configurable: true, enumerable: true, writable: true, value: app }
-  })
+    app.use('/blog', blog);
+    blog.use('/admin', blogAdmin);
 
-  app.init();
-  return app;
-}
+    assert(!app.parent, 'app.parent');
+    assert.strictEqual(blog.parent, app);
+    assert.strictEqual(blogAdmin.parent, blog);
+  });
+});
 
-/**
- * Expose the prototypes.
- */
+describe('app.mountpath', function() {
+  it('should return the mounted path', function() {
+    var admin = express();
+    var app = express();
+    var blog = express();
+    var fallback = express();
 
-exports.application = proto;
-exports.request = req;
-exports.response = res;
+    app.use('/blog', blog);
+    app.use(fallback);
+    blog.use('/admin', admin);
 
-/**
- * Expose constructors.
- */
+    assert.strictEqual(admin.mountpath, '/admin');
+    assert.strictEqual(app.mountpath, '/');
+    assert.strictEqual(blog.mountpath, '/blog');
+    assert.strictEqual(fallback.mountpath, '/');
+  });
+});
 
-exports.Route = Router.Route;
-exports.Router = Router;
+describe('app.path()', function() {
+  it('should return the canonical', function() {
+    var app = express(),
+      blog = express(),
+      blogAdmin = express();
 
-/**
- * Expose middleware
- */
+    app.use('/blog', blog);
+    blog.use('/admin', blogAdmin);
 
-exports.json = bodyParser.json
-exports.raw = bodyParser.raw
-exports.static = require('serve-static');
-exports.text = bodyParser.text
-exports.urlencoded = bodyParser.urlencoded
+    assert.strictEqual(app.path(), '');
+    assert.strictEqual(blog.path(), '/blog');
+    assert.strictEqual(blogAdmin.path(), '/blog/admin');
+  });
+});
+
+describe('in development', function() {
+  before(function() {
+    this.env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+  });
+
+  after(function() {
+    process.env.NODE_ENV = this.env;
+  });
+
+  it('should disable "view cache"', function() {
+    var app = express();
+    assert.ok(!app.enabled('view cache'));
+  });
+});
+
+describe('in production', function() {
+  before(function() {
+    this.env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+  });
+
+  after(function() {
+    process.env.NODE_ENV = this.env;
+  });
+
+  it('should enable "view cache"', function() {
+    var app = express();
+    assert.ok(app.enabled('view cache'));
+  });
+});
+
+describe('without NODE_ENV', function() {
+  before(function() {
+    this.env = process.env.NODE_ENV;
+    process.env.NODE_ENV = '';
+  });
+
+  after(function() {
+    process.env.NODE_ENV = this.env;
+  });
+
+  it('should default to development', function() {
+    var app = express();
+    assert.strictEqual(app.get('env'), 'development');
+  });
+});


### PR DESCRIPTION
Update to Use express.json(): If you're planning to handle JSON requests in your Express application, ensure that your main application file includes express.json() as middleware.

Ensure Proper Initialization: If there's a specific test failing, make sure the app is correctly initialized before running requests against it.

Improve Error Handling: Make sure to handle errors gracefully, especially for any routes that might throw errors.