### PR TITLE
Use loop for acceptParams

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,16 +84,33 @@ exports.normalizeTypes = function(types){
  */
 
 function acceptParams (str) {
-  var parts = str.split(/ *; */);
-  var ret = { value: parts[0], quality: 1, params: {} }
+  var length = str.length;
+  var colonIndex = str.indexOf(';');
+  var index = colonIndex === -1 ? length : colonIndex;
+  var ret = { value: str.slice(0, index).trim(), quality: 1, params: {} };
 
-  for (var i = 1; i < parts.length; ++i) {
-    var pms = parts[i].split(/ *= */);
-    if ('q' === pms[0]) {
-      ret.quality = parseFloat(pms[1]);
-    } else {
-      ret.params[pms[0]] = pms[1];
+  while (index < length) {
+    var splitIndex = str.indexOf('=', index);
+    if (splitIndex === -1) break;
+
+    var colonIndex = str.indexOf(';', index);
+    var endIndex = colonIndex === -1 ? length : colonIndex;
+
+    if (splitIndex > endIndex) {
+      index = str.lastIndexOf(';', splitIndex - 1) + 1;
+      continue;
     }
+
+    var key = str.slice(index, splitIndex).trim();
+    var value = str.slice(splitIndex + 1, endIndex).trim();
+
+    if (key === 'q') {
+      ret.quality = parseFloat(value);
+    } else {
+      ret.params[key] = value;
+    }
+
+    index = endIndex + 1;
   }
 
   return ret;


### PR DESCRIPTION
Using a loop here would improve performance for parsing over splitting into an array and iterating over it, then splitting some more. If we prefer the overall split on `;` for readability though, we can still avoid the second split by using `indexOf` instead. There's also some slices and `trim` that could be avoided for extra performance but it seemed a little overkill for this function.

Finally, given the code is only used here: https://github.com/expressjs/express/blob/a46cfdc37f5e422db7ce6f12d321eb79694c1e9b/lib/response.js#L575-L584. If we avoid exporting these utils to users we can just return `value` only and avoid the rest of the processing entirely.

_closes https://github.com/expressjs/security-triage/issues/24_