### PR TITLE
response: add support for ETag option in res.sendFile

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@ unreleased
 * refactor: prefix built-in node module imports
 * Remove unused `depd` dependency
 * Add support for `Uint8Array` in `res.send`
+* Add support for ETag option in res.sendFile
 * deps: debug@^4.4.0
 * deps: body-parser@^2.1.0
 * deps: router@^2.1.0

--- a/lib/response.js
+++ b/lib/response.js
@@ -389,6 +389,9 @@ res.sendFile = function sendFile(path, options, callback) {
 
   // create file stream
   var pathname = encodeURI(path);
+
+  // wire application etag option to send
+  opts.etag = this.app.enabled('etag');
   var file = send(req, pathname, opts);
 
   // transfer

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -78,6 +78,19 @@ describe('res', function(){
       });
     });
 
+    it('should disable the ETag function if requested', function (done) {
+      var app = createApp(path.resolve(fixtures, 'name.txt')).disable('etag');
+
+      request(app)
+      .get('/')
+      .expect(handleHeaders)
+      .expect(200, done);
+
+      function handleHeaders (res) {
+        assert(res.headers.etag === undefined);
+      }
+    });
+
     it('should 404 for directory', function (done) {
       var app = createApp(path.resolve(fixtures, 'blog'));
 


### PR DESCRIPTION
This patch introduces the ability to control the ETag generation through the `res.sendFile` function. Specifically, the ETag option is wired to the application's configuration, allowing it to be enabled or disabled based on the app's settings.

Fixes: https://github.com/expressjs/express/issues/2294