### PR TITLE
Remove Object.setPrototypeOf polyfill

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased
+========================
+
+* Remove `Object.setPrototypeOf` polyfill
+
 5.0.1 / 2024-10-08
 ==========
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -25,7 +25,6 @@ var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var once = require('once')
 var Router = require('router');
-var setPrototypeOf = require('setprototypeof')
 
 /**
  * Module variables.
@@ -117,10 +116,10 @@ app.defaultConfiguration = function defaultConfiguration() {
     }
 
     // inherit protos
-    setPrototypeOf(this.request, parent.request)
-    setPrototypeOf(this.response, parent.response)
-    setPrototypeOf(this.engines, parent.engines)
-    setPrototypeOf(this.settings, parent.settings)
+    Object.setPrototypeOf(this.request, parent.request)
+    Object.setPrototypeOf(this.response, parent.response)
+    Object.setPrototypeOf(this.engines, parent.engines)
+    Object.setPrototypeOf(this.settings, parent.settings)
   });
 
   // setup locals
@@ -168,8 +167,8 @@ app.handle = function handle(req, res, callback) {
   res.req = req;
 
   // alter the prototypes
-  setPrototypeOf(req, this.request)
-  setPrototypeOf(res, this.response)
+  Object.setPrototypeOf(req, this.request)
+  Object.setPrototypeOf(res, this.response)
 
   // setup locals
   if (!res.locals) {
@@ -232,8 +231,8 @@ app.use = function use(fn) {
     router.use(path, function mounted_app(req, res, next) {
       var orig = req.app;
       fn.handle(req, res, function (err) {
-        setPrototypeOf(req, orig.request)
-        setPrototypeOf(res, orig.response)
+        Object.setPrototypeOf(req, orig.request)
+        Object.setPrototypeOf(res, orig.response)
         next(err);
       });
     });

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "safe-buffer": "5.2.1",
     "send": "^1.1.0",
     "serve-static": "^2.1.0",
-    "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
     "type-is": "^2.0.0",
     "utils-merge": "1.0.1",


### PR DESCRIPTION
This PR removes the `Object.setPrototypeOf` polyfill, which is no longer needed since Express now requires Node.js v18 as the minimum supported version. All existing tests should pass, as this change only impacts older Node versions no longer supported.