### PR TITLE
Remove `utils-merge` dependency - use spread syntax instead

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ========================
 
+* Remove `utils-merge` dependency - use spread syntax instead
 * Remove `Object.setPrototypeOf` polyfill
 * cleanup: remove AsyncLocalStorage check from tests
 * cleanup: remove unnecessary require for global Buffer

--- a/lib/application.js
+++ b/lib/application.js
@@ -21,7 +21,6 @@ var http = require('http');
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
-var merge = require('utils-merge');
 var resolve = require('path').resolve;
 var once = require('once')
 var Router = require('router');
@@ -525,7 +524,6 @@ app.render = function render(name, options, callback) {
   var done = callback;
   var engines = this.engines;
   var opts = options;
-  var renderOptions = {};
   var view;
 
   // support callback function as second arg
@@ -534,16 +532,8 @@ app.render = function render(name, options, callback) {
     opts = {};
   }
 
-  // merge app.locals
-  merge(renderOptions, this.locals);
-
-  // merge options._locals
-  if (opts._locals) {
-    merge(renderOptions, opts._locals);
-  }
-
   // merge options
-  merge(renderOptions, opts);
+  var renderOptions = { ...this.locals, ...opts._locals, ...opts };
 
   // set .cache unless explicitly provided
   if (renderOptions.cache == null) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -22,7 +22,6 @@ var mime = require('mime-types')
 var path = require('path');
 var pathIsAbsolute = require('path').isAbsolute;
 var statuses = require('statuses')
-var merge = require('utils-merge');
 var sign = require('cookie-signature').sign;
 var normalizeType = require('./utils').normalizeType;
 var normalizeTypes = require('./utils').normalizeTypes;
@@ -732,7 +731,7 @@ res.clearCookie = function clearCookie(name, options) {
  */
 
 res.cookie = function (name, value, options) {
-  var opts = merge({}, options);
+  var opts = { ...options };
   var secret = this.req.secret;
   var signed = opts.signed;
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "serve-static": "^2.1.0",
     "statuses": "2.0.1",
     "type-is": "^2.0.0",
-    "utils-merge": "1.0.1",
     "vary": "~1.1.2"
   },
   "devDependencies": {

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -3,7 +3,6 @@
 var express = require('../')
   , request = require('supertest')
   , cookieParser = require('cookie-parser')
-var merge = require('utils-merge');
 
 describe('res', function(){
   describe('.cookie(name, object)', function(){
@@ -130,7 +129,7 @@ describe('res', function(){
         var app = express();
 
         var options = { maxAge: 1000 };
-        var optionsCopy = merge({}, options);
+        var optionsCopy = { ...options };
 
         app.use(function(req, res){
           res.cookie('name', 'tobi', options)


### PR DESCRIPTION
Removes the `utils-merge` dependency and uses ~~[`Object.assign()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)~~ spread syntax