### PR TITLE
refactor: simplify `normalizeTypes` function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,15 +64,10 @@ exports.normalizeType = function(type){
  * @api private
  */
 
-exports.normalizeTypes = function(types){
-  var ret = [];
-
-  for (var i = 0; i < types.length; ++i) {
-    ret.push(exports.normalizeType(types[i]));
-  }
-
-  return ret;
+exports.normalizeTypes = function(types) {
+  return types.map(exports.normalizeType);
 };
+
 
 /**
  * Parse accept params `str` returning an


### PR DESCRIPTION
- Replaced the manual for loop with Array.map for better readability and conciseness.
- The new implementation directly maps each element in the input array to the normalized output, improving code clarity.
- This change maintains the same functionality while leveraging built-in array methods for cleaner code.

Related: https://github.com/expressjs/express/pull/6093