### PR TITLE
Refactor compileETag function for clarity

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,33 +102,29 @@ function acceptParams (str) {
 /**
  * Compile "etag" value to function.
  *
- * @param  {Boolean|String|Function} val
- * @return {Function}
+ * @param {boolean|function|string} val
+ * @return {function|undefined}
+ * @throws {TypeError}
  * @api private
  */
-
 exports.compileETag = function(val) {
-  var fn;
-
   if (typeof val === 'function') {
     return val;
+  }
+
+  if (val === false) {
+    return;
   }
 
   switch (val) {
     case true:
     case 'weak':
-      fn = exports.wetag;
-      break;
-    case false:
-      break;
+      return exports.wetag;
     case 'strong':
-      fn = exports.etag;
-      break;
+      return exports.etag;
     default:
-      throw new TypeError('unknown value for etag function: ' + val);
+      throw new TypeError(`unknown value for etag function: ${val}`);
   }
-
-  return fn;
 }
 
 /**


### PR DESCRIPTION
- Simplified logic by removing unnecessary variable assignments.
- Streamlined the switch statement to directly return the appropriate ETag function.
- Updated JSDoc comments for consistency and clarity.
- Removed redundant handling of false, returning undefined directly.

Related: https://github.com/expressjs/express/pull/6093