### PR TITLE
Refactor req.is for cleaner argument handling

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -249,22 +249,13 @@ defineGetter(req, 'query', function query(){
  *      req.is('html');
  *      // => false
  *
- * @param {String|Array} types...
- * @return {String|false|null}
+ * @param {(String|Array)} types...
+ * @return {(String|false|null)}
  * @public
  */
 
 req.is = function is(types) {
-  var arr = types;
-
-  // support flattened arguments
-  if (!Array.isArray(types)) {
-    arr = new Array(arguments.length);
-    for (var i = 0; i < arr.length; i++) {
-      arr[i] = arguments[i];
-    }
-  }
-
+  const arr = Array.isArray(types) ? types : Array.from(arguments);
   return typeis(this, arr);
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -255,16 +255,7 @@ defineGetter(req, 'query', function query(){
  */
 
 req.is = function is(types) {
-  var arr = types;
-
-  // support flattened arguments
-  if (!Array.isArray(types)) {
-    arr = new Array(arguments.length);
-    for (var i = 0; i < arr.length; i++) {
-      arr[i] = arguments[i];
-    }
-  }
-
+  const arr = Array.isArray(types) ? types : Array.from(arguments);
   return typeis(this, arr);
 };
 


### PR DESCRIPTION
- Simplified the logic for accepting both array and flattened arguments.
- Used Array.from for improved readability and conciseness.

Related: https://github.com/expressjs/express/pull/6093