### PR TITLE
Refactor: remove redundant function name from app.disable

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -461,7 +461,7 @@ app.enable = function enable(setting) {
  * @public
  */
 
-app.disable = function disable(setting) {
+app.disable = function (setting) {
   return this.set(setting, false);
 };
 


### PR DESCRIPTION
The function name disable was unnecessary since it's already clear from the app.disable property assignment.
Removing it simplifies the code, improves readability, and follows best practices for concise function expressions.