### PR TITLE
Refactor: streamline app.enable function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -449,7 +449,7 @@ app.disabled = function disabled(setting) {
  * @public
  */
 
-app.enable = function enable(setting) {
+app.enable = function(setting) {
   return this.set(setting, true);
 };
 


### PR DESCRIPTION
Removed the redundant function name from app.enable. This simplification enhances readability and aligns with best practices for concise function expressions.