### PR TITLE
Refactor: optimize `hostname` getter function

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -429,20 +429,15 @@ defineGetter(req, 'host', function host(){
  * @api public
  */
 
-defineGetter(req, 'hostname', function hostname(){
-  var host = this.host;
-
+defineGetter(req, 'hostname', function hostname() {
+  const host = this.host;
   if (!host) return;
 
   // IPv6 literal support
-  var offset = host[0] === '['
-    ? host.indexOf(']') + 1
-    : 0;
-  var index = host.indexOf(':', offset);
+  const offset = host.startsWith('[') ? host.indexOf(']') + 1 : 0;
+  const index = host.indexOf(':', offset);
 
-  return index !== -1
-    ? host.substring(0, index)
-    : host;
+  return index !== -1 ? host.slice(0, index) : host;
 });
 
 /**


### PR DESCRIPTION
Replaced `var` with `const` for improved readability and immutability.
Switched to `startsWith` for clearer IPv6 check, and used `slice` instead of `substring` for consistency.
These changes enhance code readability without altering functionality.