### PR TITLE
ci: add loadtest workflow & script

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,102 @@
+name: "Express Load Test"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+  workflow_dispatch:
+    inputs:
+      prev_branch:
+        description: 'Base branch (branch-branch)'
+        required: false
+        default: ''
+      curr_branch:
+        description: 'Head branch (branch-branch)'
+        required: false
+        default: ''
+      prev_version:
+        description: 'Base Version (version-version)'
+        required: false
+        default: ''
+      curr_version:
+        description: 'Head Version (version-version)'
+        required: false
+        default: ''
+      version:
+        description: 'Version (version-branch)'
+        required: false
+        default: ''
+      branch:
+        description: 'Branch (version-branch)'
+        required: false
+        default: ''
+
+jobs:
+  load_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch All Branches
+        run: git fetch --all
+
+      - name: Set Up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
+        with:
+          node-version: '20'
+
+      - name: Determine Comparison Type
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" ]]; then
+            # Branch comparison: Default to master for previous branch and use PR branch for current branch
+            echo "PREV_BRANCH=master" >> $GITHUB_ENV
+            echo "CURR_BRANCH=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.inputs.prev_branch }}" && "${{ github.event.inputs.curr_branch }}" ]]; then
+            # Version comparison
+            echo "PREV_BRANCH=${{ github.event.inputs.prev_branch }}" >> $GITHUB_ENV
+            echo "CURR_BRANCH=${{ github.event.inputs.curr_branch }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.inputs.prev_version }}" && "${{ github.event.inputs.curr_version }}" ]]; then
+            # Version comparison
+            echo "PREV_VERSION=${{ github.event.inputs.prev_version }}" >> $GITHUB_ENV
+            echo "CURR_VERSION=${{ github.event.inputs.curr_version }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.inputs.branch }}" && "${{ github.event.inputs.version }}" ]]; then
+            # Branch-Version comparison
+            echo "BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          else
+            echo "Invalid input combination. Provide either two branches, two versions, or one branch and one version."
+            exit 1
+          fi
+
+      - name: Install wrk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wrk
+
+      - name: Start Load Test Server
+        run: node benchmarks/load-test-workflow.js
+        env:
+          PREV_BRANCH: ${{ env.PREV_BRANCH }}
+          CURR_BRANCH: ${{ env.CURR_BRANCH }}
+          PREV_VERSION: ${{ env.PREV_VERSION }}
+          CURR_VERSION: ${{ env.CURR_VERSION }}
+          BRANCH: ${{ env.BRANCH }}
+          VERSION: ${{ env.VERSION }}
+
+      - name: Output Summary
+        run: |
+          cat benchmarks/results*.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Post Summary to PR
+        if: github.event_name == 'pull_request'
+        run: |
+          cat $GITHUB_STEP_SUMMARY
+          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat benchmarks/results*.md)"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ coverage
 # Benchmarking
 benchmarks/graphs
 
+# Webstorm
+.idea
+
 # ignore additional files using core.excludesFile
 # https://git-scm.com/docs/gitignore

--- a/benchmarks/load-test-workflow.js
+++ b/benchmarks/load-test-workflow.js
@@ -1,0 +1,222 @@
+const {execSync, spawn} = require('child_process')
+const fs = require('fs')
+
+const runCommand = command => execSync(command, {encoding: 'utf8'}).trim()
+
+const startServer = (middleware, isVersionTest) => {
+  console.log(`Starting server with ${middleware} middleware layers...`)
+  const server = spawn('node', ['benchmarks/middleware.js'], {
+    env: {
+      ...process.env,
+      MW: middleware,
+      NO_LOCAL_EXPRESS: isVersionTest
+    },
+    stdio: 'inherit'
+  })
+
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        execSync('curl -s http://127.0.0.1:3333')
+        resolve(server)
+      } catch (error) {
+        server.kill()
+        reject(new Error('Server failed to start.'))
+      }
+    }, 3000)
+  })
+}
+
+const runLoadTest = (url, connectionsList) => {
+  return connectionsList.map(connections => {
+    try {
+      const output = runCommand(`wrk ${url} -d 3 -c ${connections} -t 8`)
+      const reqSec = output.match(/Requests\/sec:\s+(\d+.\d+)/)?.[1]
+      const latency = output.match(/Latency\s+(\d+.\d+)/)?.[1]
+      return {connections, reqSec, latency}
+    } catch (error) {
+      console.error(
+        `Error running load test for ${connections} connections:`,
+        error.message
+      )
+      return {connections, reqSec: 'N/A', latency: 'N/A'}
+    }
+  })
+}
+
+const generateMarkdownTable = results => {
+  const headers = `| Connections | Requests/sec | Latency |\n|-------------|--------------|---------|`
+  const rows = results
+    .map(
+      r => `| ${r.connections} | ${r.reqSec || 'N/A'} | ${r.latency || 'N/A'} |`
+    )
+    .join('\n')
+  return `${headers}\n${rows}`
+}
+
+const cleanUp = () => {
+  console.log('Cleaning up...')
+  runCommand('npm uninstall express')
+  runCommand('rm -rf package-lock.json node_modules')
+}
+
+const runTests = async ({
+  identifier,
+  connectionsList,
+  middlewareCounts,
+  outputFile,
+  isVersionTest = false
+}) => {
+  if (isVersionTest) {
+    console.log(`Installing Express v${identifier}...`)
+    runCommand(`npm install express@${identifier}`)
+  } else {
+    console.log(`Checking out branch ${identifier}...`)
+    runCommand(`git fetch origin ${identifier}`)
+    runCommand(`git checkout ${identifier}`)
+    runCommand('npm install')
+    console.log('Installing deps...')
+  }
+
+  const resultsMarkdown = [
+    `\n\n# Load Test Results for ${isVersionTest ? `Express v${identifier}` : `Branch ${identifier}`}`
+  ]
+
+  for (const middlewareCount of middlewareCounts) {
+    try {
+      const server = await startServer(middlewareCount, isVersionTest)
+      const results = runLoadTest(
+        'http://127.0.0.1:3333/?foo[bar]=baz',
+        connectionsList
+      )
+      server.kill()
+      resultsMarkdown.push(
+        `### Load test for ${middlewareCount} middleware layers\n\n${generateMarkdownTable(results)}`
+      )
+    } catch (error) {
+      console.error('Error in load test process:', error)
+    }
+  }
+
+  fs.writeFileSync(outputFile, resultsMarkdown.join('\n\n'))
+  cleanUp()
+}
+
+const compareBranches = async ({
+  prevBranch,
+  currBranch,
+  connectionsList,
+  middlewareCounts,
+}) => {
+  console.log(`Comparing branches: ${prevBranch} vs ${currBranch}`)
+  await runTests({
+    identifier: prevBranch,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${prevBranch}.md`,
+    isVersionTest: false
+  })
+  await runTests({
+    identifier: currBranch,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${currBranch}.md`,
+    isVersionTest: false
+  })
+}
+
+const compareVersions = async ({
+  prevVersion,
+  currVersion,
+  connectionsList,
+  middlewareCounts,
+}) => {
+  console.log(
+    `Comparing versions: Express v${prevVersion} vs Express v${currVersion}`
+  )
+  await runTests({
+    identifier: prevVersion,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${prevVersion}.md`,
+    isVersionTest: true
+  })
+  await runTests({
+    identifier: currVersion,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${currVersion}.md`,
+    isVersionTest: true
+  })
+}
+
+const compareBranchAndVersion = async ({
+  branch,
+  version,
+  connectionsList,
+  middlewareCounts,
+}) => {
+  console.log(`Comparing branch ${branch} with Express version ${version}`)
+  await runTests({
+    identifier: branch,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${branch}.md`,
+    isVersionTest: false
+  })
+  await runTests({
+    identifier: version,
+    connectionsList,
+    middlewareCounts,
+    outputFile: `benchmarks/results_${version}.md`,
+    isVersionTest: true
+  })
+}
+
+const main = async () => {
+  const connectionsList = [50, 100, 250]
+  const middlewareCounts = [1, 10, 25, 50]
+  const prevBranch = process.env.PREV_BRANCH
+  const currBranch = process.env.CURR_BRANCH
+  const prevVersion = process.env.PREV_VERSION
+  const currVersion = process.env.CURR_VERSION
+  const version = process.env.VERSION
+  const branch = process.env.BRANCH
+
+  if (prevBranch && currBranch) {
+    await compareBranches({
+      prevBranch,
+      currBranch,
+      connectionsList,
+      middlewareCounts,
+    })
+    return
+  }
+
+  if (prevVersion && currVersion) {
+    await compareVersions({
+      prevVersion,
+      currVersion,
+      connectionsList,
+      middlewareCounts,
+    })
+    return
+  }
+
+  if (branch && version) {
+    await compareBranchAndVersion({
+      branch,
+      version,
+      connectionsList,
+      middlewareCounts,
+    })
+    return
+  }
+
+  console.error(
+    'Invalid input combination. Provide either two branches, two versions, or one branch and one version.'
+  )
+  process.exit(1)
+}
+
+main()

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -1,10 +1,10 @@
 
-var express = require('..');
-var app = express();
+const express = process.env.NO_LOCAL_EXPRESS === "true" ? require('express') : require('..');
+const app = express();
 
 // number of middleware
 
-var n = parseInt(process.env.MW || '1', 10);
+let n = parseInt(process.env.MW || '1', 10);
 console.log('  %s middleware', n);
 
 while (n--) {


### PR DESCRIPTION
Purpose of this PR is to add a new github workflow and script which will run the benchmarks for express.

- Automatically at each PR opened & synced 
    - Will compare master branch and the branch from the PR
    > The result will be added as comment in the PR.
- Manually, you can dispatch the workflow
    - You can compare 2 versions of express being published
    - You can compare 2 branches of the express repo
    - You can compare one branch of the express repo and one version of express being published
    > The result will be added as summary of the workflow run

The new script is based from your initial work here https://github.com/UlisesGascon/express-performance-comparator

I reused the `benchmarks/middleware.js` with minimal changes to not alter the original work.

I have created a test repo if you would like to test the workflow here => https://github.com/tchapacan/express-test-wf/

This PR seems a little big to review at once and lack of tests and docs (if necessary), I can split it in smaller PRs if you prefer, ex:

- One PR to add the `load-test-workflow.js` script
- One PR for tests if relevant? (don't really know where to land them smoothly in the repo)
- One PR to modify the `benchmarks/middleware.js` script
- One PR to add the `load-test.yml` workflow
- One PR to document the workflow usage somewhere relevant (don't really know where to land it smoothly in the repo)
- One PR to modify the number of middleware/connection to fine tune benchmark scenario afterward?

LMK if this proposition suits you. I understand that CI might need further discussion between you, specifically if you have already planned/discussed something. Maybe this deserve it's own repo (if more feature, docs, tests are needed then) ?
Furthermore we have to keep in mind that benchmark will run on the runner and the result will strictly depend on it.

Anyway, I'm 100% open to discussion/changes about that, hope it's helping you a little, cheers!
