### PR TITLE
Refactor: Simplify `req.stale` getter by removing redundant function name

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -482,7 +482,7 @@ defineGetter(req, 'fresh', function(){
  * @public
  */
 
-defineGetter(req, 'stale', function stale(){
+defineGetter(req, 'stale', function() {
   return !this.fresh;
 });
 


### PR DESCRIPTION
The function name `stale` was removed as it is clear from the property definition. 
This simplification enhances readability and adheres to modern JavaScript practices.