### PR TITLE
Refactor: Simplify `req.xhr` getter by removing redundant function name

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -493,8 +493,8 @@ defineGetter(req, 'stale', function stale(){
  * @public
  */
 
-defineGetter(req, 'xhr', function xhr(){
-  var val = this.get('X-Requested-With') || '';
+defineGetter(req, 'xhr', function() {
+  const val = this.get('X-Requested-With') || '';
   return val.toLowerCase() === 'xmlhttprequest';
 });
 


### PR DESCRIPTION
The function name `xhr` was removed as it is clear from the property definition. This change improves readability and follows best practices for concise function expressions.