### PR TITLE
Refactor: simplify req.path getter

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -388,7 +388,7 @@ defineGetter(req, 'subdomains', function subdomains() {
  * @public
  */
 
-defineGetter(req, 'path', function path() {
+defineGetter(req, 'path', function() {
   return parse(this).pathname;
 });
 


### PR DESCRIPTION
- Removed redundant function name from the req.path getter for improved readability. The function now directly utilizes the concise function expression.