### PR TITLE
Refactor: update JSDoc for subdomains getter and simplify implementation

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -364,19 +364,18 @@ defineGetter(req, 'ips', function ips() {
  * If "subdomain offset" is not set, req.subdomains is `["ferrets", "tobi"]`.
  * If "subdomain offset" is 3, req.subdomains is `["tobi"]`.
  *
- * @return {Array}
+ * @return {Array<String>}
  * @public
  */
 
-defineGetter(req, 'subdomains', function subdomains() {
-  var hostname = this.hostname;
-
+defineGetter(req, 'subdomains', function() {
+  const { hostname, app } = this;
   if (!hostname) return [];
 
-  var offset = this.app.get('subdomain offset');
-  var subdomains = !isIP(hostname)
-    ? hostname.split('.').reverse()
-    : [hostname];
+  const offset = app.get('subdomain offset');
+  const subdomains = isIP(hostname)
+    ? [hostname]
+    : hostname.split('.').reverse();
 
   return subdomains.slice(offset);
 });


### PR DESCRIPTION
- Changed JSDoc return type to specify an array of strings.
- Removed the unnecessary function name from the subdomains getter for better readability.
- Used destructuring to simplify property access and enhance clarity in the code.