### PR TITLE
Refactor: simplify `acceptsLanguages` implementation using spread operator

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -169,9 +169,8 @@ req.acceptsCharsets = function(){
  * @public
  */
 
-req.acceptsLanguages = function(){
-  var accept = accepts(this);
-  return accept.languages.apply(accept, arguments);
+req.acceptsLanguages = function(...languages) {
+  return accepts(this).languages(...languages);
 };
 
 /**


### PR DESCRIPTION
Refactored `req.acceptsLanguages` to use the spread operator for passing arguments directly to `accept.languages`, eliminating the need for `.apply`. This approach improves readability and streamlines the function call.