### PR TITLE
Refactor: simplify req.acceptsCharsets with spread syntax

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -155,9 +155,8 @@ req.acceptsEncodings = function(){
  * @public
  */
 
-req.acceptsCharsets = function(){
-  var accept = accepts(this);
-  return accept.charsets.apply(accept, arguments);
+req.acceptsCharsets = function(...charsets) {
+  return accepts(this).charsets(...charsets);
 };
 
 /**


### PR DESCRIPTION
Replaces `arguments` with spread syntax (`...charsets`) in `req.acceptsCharsets`, making the function more concise and improving readability. The new implementation passes arguments directly to `accepts(this).charsets`, achieving the same functionality with cleaner code.