### PR TITLE
Refactor: simplify req.acceptsEncodings with spread syntax

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -141,9 +141,8 @@ req.accepts = function(){
  * @public
  */
 
-req.acceptsEncodings = function(){
-  var accept = accepts(this);
-  return accept.encodings.apply(accept, arguments);
+req.acceptsEncodings = function(...encodings) {
+  return accepts(this).encodings(...encodings);
 };
 
 /**


### PR DESCRIPTION
Replaced use of `arguments` in `req.acceptsEncodings` with the spread syntax (`...encodings`) to improve readability and reduce code complexity, while maintaining the same functionality.