### PR TITLE
Refactor req.accepts to utilize rest parameters for better argument handling

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -128,9 +128,8 @@ req.header = function header(name) {
  * @public
  */
 
-req.accepts = function(){
-  var accept = accepts(this);
-  return accept.types.apply(accept, arguments);
+req.accepts = function(...types) {
+  return accepts(this).types(...types);
 };
 
 /**


### PR DESCRIPTION
- The function signature has been updated to accept a variable number of type arguments using the spread operator (`...types`).
- The internal logic now directly invokes `accepts(this).types(...types)`, simplifying the code and improving readability.