### PR TITLE
cleanup: remove unnecessary require for global Buffer

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ unreleased
 ========================
 
 * Remove `Object.setPrototypeOf` polyfill
+* cleanup: remove unnecessary require for global Buffer
 
 5.0.1 / 2024-10-08
 ==========

--- a/lib/response.js
+++ b/lib/response.js
@@ -12,7 +12,6 @@
  * @private
  */
 
-var Buffer = require('node:buffer').Buffer
 var contentDisposition = require('content-disposition');
 var createError = require('http-errors')
 var encodeUrl = require('encodeurl');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,6 @@
  * @api private
  */
 
-var Buffer = require('node:buffer').Buffer
 var contentType = require('content-type');
 var etag = require('etag');
 var mime = require('mime-types')

--- a/test/express.json.js
+++ b/test/express.json.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
 

--- a/test/express.raw.js
+++ b/test/express.raw.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
 

--- a/test/express.static.js
+++ b/test/express.static.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var assert = require('assert')
-var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var path = require('path')
 var request = require('supertest')

--- a/test/express.text.js
+++ b/test/express.text.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
 

--- a/test/express.urlencoded.js
+++ b/test/express.urlencoded.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
 

--- a/test/res.attachment.js
+++ b/test/res.attachment.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var Buffer = require('node:buffer').Buffer
 var express = require('../')
   , request = require('supertest');
 

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -3,7 +3,6 @@
 var after = require('after');
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('..');
 var path = require('path')
 var request = require('supertest');

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var assert = require('assert')
-var Buffer = require('node:buffer').Buffer
 var express = require('..');
 var methods = require('methods');
 var request = require('supertest');

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -3,7 +3,6 @@
 var after = require('after');
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('node:buffer').Buffer
 var express = require('../')
   , request = require('supertest')
 var onFinished = require('on-finished');

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -5,7 +5,6 @@
  */
 
 var assert = require('assert');
-var Buffer = require('node:buffer').Buffer
 
 /**
  * Module exports.

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var assert = require('assert');
-var Buffer = require('node:buffer').Buffer
 var utils = require('../lib/utils');
 
 describe('utils.etag(body, encoding)', function(){


### PR DESCRIPTION
The Buffer object is globally available in Node.js, so there is no need to explicitly require it.