### PR TITLE
cleanup: remove AsyncLocalStorage check

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ unreleased
 ========================
 
 * Remove `Object.setPrototypeOf` polyfill
+* cleanup: remove AsyncLocalStorage check from tests
 
 5.0.1 / 2024-10-08
 ==========

--- a/test/express.json.js
+++ b/test/express.json.js
@@ -1,14 +1,10 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('express.json()', function () {
   it('should parse JSON', function (done) {
@@ -503,13 +499,13 @@ describe('express.json()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var app = express()
       var store = { foo: 'bar' }
 
       app.use(function (req, res, next) {
-        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage = new AsyncLocalStorage()
         req.asyncLocalStorage.run(store, next)
       })
 
@@ -754,13 +750,5 @@ function shouldContainInBody (str) {
   return function (res) {
     assert.ok(res.text.indexOf(str) !== -1,
       'expected \'' + res.text + '\' to contain \'' + str + '\'')
-  }
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
   }
 }

--- a/test/express.raw.js
+++ b/test/express.raw.js
@@ -1,14 +1,10 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('express.raw()', function () {
   before(function () {
@@ -328,13 +324,13 @@ describe('express.raw()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var app = express()
       var store = { foo: 'bar' }
 
       app.use(function (req, res, next) {
-        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage = new AsyncLocalStorage()
         req.asyncLocalStorage.run(store, next)
       })
 
@@ -513,12 +509,4 @@ function createApp (options) {
   })
 
   return app
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
 }

--- a/test/express.text.js
+++ b/test/express.text.js
@@ -1,14 +1,10 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('express.text()', function () {
   before(function () {
@@ -361,13 +357,13 @@ describe('express.text()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var app = express()
       var store = { foo: 'bar' }
 
       app.use(function (req, res, next) {
-        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage = new AsyncLocalStorage()
         req.asyncLocalStorage.run(store, next)
       })
 
@@ -567,12 +563,4 @@ function createApp (options) {
   })
 
   return app
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
 }

--- a/test/express.urlencoded.js
+++ b/test/express.urlencoded.js
@@ -1,14 +1,10 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('..')
 var request = require('supertest')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('express.urlencoded()', function () {
   before(function () {
@@ -606,13 +602,13 @@ describe('express.urlencoded()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var app = express()
       var store = { foo: 'bar' }
 
       app.use(function (req, res, next) {
-        req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        req.asyncLocalStorage = new AsyncLocalStorage()
         req.asyncLocalStorage.run(store, next)
       })
 
@@ -827,13 +823,5 @@ function createApp (options) {
 function expectKeyCount (count) {
   return function (res) {
     assert.strictEqual(Object.keys(JSON.parse(res.text)).length, count)
-  }
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
   }
 }

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -2,7 +2,7 @@
 
 var after = require('after');
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('..');
 var path = require('path')
@@ -10,10 +10,6 @@ var request = require('supertest');
 var utils = require('./support/utils')
 
 var FIXTURES_PATH = path.join(__dirname, 'fixtures')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('res', function(){
   describe('.download(path)', function(){
@@ -91,14 +87,14 @@ describe('res', function(){
       .expect(200, cb);
     })
 
-    describeAsyncHooks('async local storage', function () {
+    describe('async local storage', function () {
       it('should presist store', function (done) {
         var app = express()
         var cb = after(2, done)
         var store = { foo: 'bar' }
 
         app.use(function (req, res, next) {
-          req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+          req.asyncLocalStorage = new AsyncLocalStorage()
           req.asyncLocalStorage.run(store, next)
         })
 
@@ -125,7 +121,7 @@ describe('res', function(){
         var store = { foo: 'bar' }
 
         app.use(function (req, res, next) {
-          req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+          req.asyncLocalStorage = new AsyncLocalStorage()
           req.asyncLocalStorage.run(store, next)
         })
 
@@ -488,11 +484,3 @@ describe('res', function(){
     })
   })
 })
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
-}

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -2,7 +2,7 @@
 
 var after = require('after');
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var Buffer = require('node:buffer').Buffer
 var express = require('../')
   , request = require('supertest')
@@ -10,10 +10,6 @@ var onFinished = require('on-finished');
 var path = require('path');
 var fixtures = path.join(__dirname, 'fixtures');
 var utils = require('./support/utils');
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('res', function(){
   describe('.sendFile(path)', function () {
@@ -267,14 +263,14 @@ describe('res', function(){
         .expect(200, 'got 404 error', done)
     })
 
-    describeAsyncHooks('async local storage', function () {
+    describe('async local storage', function () {
       it('should presist store', function (done) {
         var app = express()
         var cb = after(2, done)
         var store = { foo: 'bar' }
 
         app.use(function (req, res, next) {
-          req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+          req.asyncLocalStorage = new AsyncLocalStorage()
           req.asyncLocalStorage.run(store, next)
         })
 
@@ -300,7 +296,7 @@ describe('res', function(){
         var store = { foo: 'bar' }
 
         app.use(function (req, res, next) {
-          req.asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+          req.asyncLocalStorage = new AsyncLocalStorage()
           req.asyncLocalStorage.run(store, next)
         })
 
@@ -900,12 +896,4 @@ function createApp(path, options, fn) {
   });
 
   return app;
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
 }


### PR DESCRIPTION
with the minimum supported node version set to v18 we can remove the AsyncLocalStorage support check as it was added in v13.10.0 and v12.17.0