### PR TITLE
cleanup: remove promise support check from tests

### DIFF
--- a/test/app.route.js
+++ b/test/app.route.js
@@ -3,8 +3,6 @@
 var express = require('../');
 var request = require('supertest');
 
-var describePromises = global.Promise ? describe : describe.skip
-
 describe('app.route', function(){
   it('should return a new route', function(done){
     var app = express();
@@ -64,7 +62,7 @@ describe('app.route', function(){
     .expect(404, done);
   });
 
-  describePromises('promise support', function () {
+  describe('promise support', function () {
     it('should pass rejected promise value', function (done) {
       var app = express()
       var route = app.route('/foo')

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -6,7 +6,6 @@ var express = require('../')
   , assert = require('assert')
   , methods = require('methods');
 
-var describePromises = global.Promise ? describe : describe.skip
 var shouldSkipQuery = require('./support/utils').shouldSkipQuery
 
 describe('app.router', function(){
@@ -963,7 +962,7 @@ describe('app.router', function(){
     })
   })
 
-  describePromises('promise support', function () {
+  describe('promise support', function () {
     it('should pass rejected promise value', function (done) {
       var app = express()
       var router = new express.Router()


### PR DESCRIPTION
Promises are supported in all supported Node.js version so the check is unnecessary