### PR TITLE
ci: add dependabot for gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Helo,

Purpose of this PR is to add the `dependabot.yml` in update mode, and configure it to target **github-actions**. 

- Why ?

According to this PR #6141 it seems you are going in the direction of pinning gh-actions dependencies in the workflows, which is great, and will improve the ossf scorecard. To avoid adding too much burden on the maintenance side (tracking each gh-action to update them one by one), dependabot can do it for you according to this docs => https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions

You can even add some defaults reviewers and labels to the PR that will be automatically open, but I prefer let you review the minimal default configuration first and LMK if you want to modify the config according to your needs.

Hope it could help you, cheers!
