### PR TITLE
Use loop for acceptParams (4.x backport)

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ unreleased
 
   * deps: path-to-regexp@0.1.11
     - Throws an error on invalid path values
+  * perf: use loop for accceptParams
 
 4.21.1 / 2024-10-08
 ==========

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,16 +124,33 @@ exports.contentDisposition = deprecate.function(contentDisposition,
  */
 
 function acceptParams (str) {
-  var parts = str.split(/ *; */);
-  var ret = { value: parts[0], quality: 1, params: {} }
+  var length = str.length;
+  var colonIndex = str.indexOf(';');
+  var index = colonIndex === -1 ? length : colonIndex;
+  var ret = { value: str.slice(0, index).trim(), quality: 1, params: {} };
 
-  for (var i = 1; i < parts.length; ++i) {
-    var pms = parts[i].split(/ *= */);
-    if ('q' === pms[0]) {
-      ret.quality = parseFloat(pms[1]);
-    } else {
-      ret.params[pms[0]] = pms[1];
+  while (index < length) {
+    var splitIndex = str.indexOf('=', index);
+    if (splitIndex === -1) break;
+
+    var colonIndex = str.indexOf(';', index);
+    var endIndex = colonIndex === -1 ? length : colonIndex;
+
+    if (splitIndex > endIndex) {
+      index = str.lastIndexOf(';', splitIndex - 1) + 1;
+      continue;
     }
+
+    var key = str.slice(index, splitIndex).trim();
+    var value = str.slice(splitIndex + 1, endIndex).trim();
+
+    if (key === 'q') {
+      ret.quality = parseFloat(value);
+    } else {
+      ret.params[key] = value;
+    }
+
+    index = endIndex + 1;
   }
 
   return ret;


### PR DESCRIPTION
cherry-pick #6066 into 4.x

https://github.com/expressjs/express/pull/6066#issuecomment-2425069285
> @UlisesGascon: Should we also backport it to v4?

Not worth a release on its own, but when it's as easy a cherry-pick and no other changes, hard not to backport.