### PR TITLE
Fix missing semicolon

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -23,7 +23,7 @@ var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
 var merge = require('utils-merge');
 var resolve = require('path').resolve;
-var once = require('once')
+var once = require('once');
 var Router = require('router');
 
 /**


### PR DESCRIPTION
Added a semicolon after `var once = require('once')` in the `express` module code.