### PR TITLE
chore: replace `methods` dependency with standard library

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ unreleased
 * cleanup: remove AsyncLocalStorage check from tests
 * cleanup: remove unnecessary require for global Buffer
 * perf: use loop for acceptParams
+* Replace `methods` dependency with standard library
 
 5.0.1 / 2024-10-08
 ==========

--- a/lib/application.js
+++ b/lib/application.js
@@ -14,10 +14,10 @@
  */
 
 var finalhandler = require('finalhandler');
-var methods = require('methods');
 var debug = require('debug')('express:application');
 var View = require('./view');
 var http = require('http');
+var methods = require('./utils').methods;
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,12 +12,19 @@
  * @api private
  */
 
+var { METHODS } = require('node:http');
 var contentType = require('content-type');
 var etag = require('etag');
 var mime = require('mime-types')
 var proxyaddr = require('proxy-addr');
 var qs = require('qs');
 var querystring = require('querystring');
+
+/**
+ * A list of lowercased HTTP methods that are supported by Node.js.
+ * @api private
+ */
+exports.methods = METHODS.map((method) => method.toLowerCase());
 
 /**
  * Return strong ETag for `body`.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "fresh": "2.0.0",
     "http-errors": "2.0.0",
     "merge-descriptors": "^2.0.0",
-    "methods": "~1.1.2",
     "mime-types": "^3.0.0",
     "on-finished": "2.4.1",
     "once": "1.4.0",

--- a/test/Route.js
+++ b/test/Route.js
@@ -4,7 +4,7 @@ var after = require('after');
 var assert = require('assert')
 var express = require('../')
   , Route = express.Route
-  , methods = require('methods')
+  , methods = require('../lib/utils').methods
 
 describe('Route', function(){
   it('should work without handlers', function(done) {

--- a/test/Router.js
+++ b/test/Router.js
@@ -3,7 +3,7 @@
 var after = require('after');
 var express = require('../')
   , Router = express.Router
-  , methods = require('methods')
+  , methods = require('../lib/utils').methods
   , assert = require('assert');
 
 describe('Router', function(){

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -4,7 +4,7 @@ var after = require('after');
 var express = require('../')
   , request = require('supertest')
   , assert = require('assert')
-  , methods = require('methods');
+  , methods = require('../lib/utils').methods;
 
 var shouldSkipQuery = require('./support/utils').shouldSkipQuery
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert')
 var express = require('..');
-var methods = require('methods');
+var methods = require('../lib/utils').methods;
 var request = require('supertest');
 var utils = require('./support/utils');
 


### PR DESCRIPTION
Replaces the [`methods`](https://github.com/jshttp/methods/tree/master) dependency with calls to the standard library of Node.js. Since `methods` is mostly a polyfill for `require('node:http').METHODS` in older versions of Node.js that are no longer supported this can be removed.

Works towards closing #4282