### PR TITLE
docs: clarify the security process in the triage role

### DIFF
--- a/Triager-Guide.md
+++ b/Triager-Guide.md
@@ -68,3 +68,5 @@ If you have questions feel free to reach out to any of the TC members.
 - For recurring issues, it is helpful to create functional examples to demonstrate (publish as gists or a repo)
 - Review and identify the maintainers. If necessary, at-mention one or more of them if you are unsure what to do
 - Make sure all your interactions are professional, welcoming, and respectful to the parties involved.
+- When an issue refers to security concerns, responsibility is delegated to the repository captain or the security group in any public communication. 
+  - If an issue has been open for a long time, the person in charge should be contacted internally through the private Slack chat.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

As discussed in the recent TC meeting, it is important to clarify what to do as a triager regarding security matters.

cc: @expressjs/express-tc @expressjs/triagers 