### PR TITLE
fix: usage of `Invalid action input 'persist-credentials'` for `actions/setup-node@v4` in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          persist-credentials: false
 
       - name: Install dependencies
         run: npm install --ignore-scripts --only=dev


### PR DESCRIPTION
Fixes #6255