### PR TITLE
fix: remove download size badges

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,6 @@
 
 
 [![NPM Version][npm-version-image]][npm-url]
-[![NPM Install Size][npm-install-size-image]][npm-install-size-url]
 [![NPM Downloads][npm-downloads-image]][npm-downloads-url]
 [![OpenSSF Scorecard Badge][ossf-scorecard-badge]][ossf-scorecard-visualizer]
 
@@ -257,8 +256,6 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
 [github-actions-ci-url]: https://github.com/expressjs/express/actions/workflows/ci.yml
 [npm-downloads-image]: https://badgen.net/npm/dm/express
 [npm-downloads-url]: https://npmcharts.com/compare/express?minimal=true
-[npm-install-size-image]: https://badgen.net/packagephobia/install/express
-[npm-install-size-url]: https://packagephobia.com/result?p=express
 [npm-url]: https://npmjs.org/package/express
 [npm-version-image]: https://badgen.net/npm/v/express
 [ossf-scorecard-badge]: https://api.scorecard.dev/projects/github.com/expressjs/express/badge


### PR DESCRIPTION
I missed that this was added in https://github.com/expressjs/express/pull/5619 and would have opposed it if I had noticed. These badges are misleading in too many cases to make it worth including. Having seen some of the most wild projects and the impact of install time, I can confidently say that publishing more versions (aka the packument gets larger) is much worse of a problem than all but the most absurd cases of tarball size.

Anyway, [it came up here](https://github.com/expressjs/compression/pull/209#discussion_r1907956469) so I thought I would open this PR to discuss. 