### PR TITLE
fix: update online example to support Redis v4+ and remove outdated dependency

### DIFF
--- a/examples/online/online-tracker.js
+++ b/examples/online/online-tracker.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { createClient } = require('redis');
+
+/**
+ * Factory function to create an OnlineTracker instance
+ *
+ * @param {Object} redisClient - The Redis client instance.
+ * @returns {Object} An object with methods for user activity tracking.
+ */
+
+function createOnlineTracker(redisClient) {
+  // Method to add a user's activity
+  async function add(user) {
+    const now = Date.now();
+    try {
+      await redisClient.hSet('online_users', user, now.toString());
+    } catch (err) {
+      console.error('Error setting user activity:', err);
+    }
+  }
+
+  // Method to get the list of users active in the last N minutes
+  async function last(minutes) {
+    const threshold = Date.now() - minutes * 60 * 1000;
+    try {
+      const users = await redisClient.hGetAll('online_users');
+      return Object.entries(users || {}).filter(([_, lastActive]) => {
+        return parseInt(lastActive, 10) >= threshold;
+      }).map(([id]) => id);
+    } catch (err) {
+      console.error('Error retrieving active users:', err);
+      throw err;
+    }
+  }
+
+  return {
+    add,
+    last,
+  };
+}
+
+// Export the factory function
+module.exports = createOnlineTracker;


### PR DESCRIPTION
This PR updates the Search example to address issues caused by breaking changes in Redis v4+.

The online example was broken due to Redis updates and its reliance on the outdated [online](https://www.npmjs.com/package/online) package by TJ Holowaychuk, which is no longer maintained and has only 24 weekly downloads.

I considered removing the example or replacing `online` with another library but opted to add a new file that substitutes the dependency. 

Key changes:
- Removed dependency on `online` by creating a new file, `online-tracker.js`, which replicates the original functionality.
- Switched from callbacks to promises.
- Updated Redis commands and added `try/catch` for error handling.
- Refactored Redis initialization into a dedicated function `initializeRedis` to make sure that it completes before the server starts.

Note: the original `online` module was optimized for performance. The substitute file prioritizes simplicity to make it easier to understand, considering it is now part of an example rather than a standalone module. 

Tested locally with:
- Redis 7.0.15
- Node.js 22.12.0
- Express 5.0.1
- Debian 12

Let me know if any changes are needed!

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->