### PR TITLE
fix: added a missing semicolon in css styles in examples/auth

### DIFF
--- a/examples/auth/views/head.ejs
+++ b/examples/auth/views/head.ejs
@@ -10,7 +10,7 @@
         font: 13px Helvetica, Arial, sans-serif;
       }
       .error {
-          color: red
+          color: red;
       }
       .success {
           color: green;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
This is a fix for #6296 i.e. Missing semi colon in css styles for error class in `examples/auth/views/head.ejs`.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole by me and I
    have the right to submit it under the open source license
    indicated in the file.

(b) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.