### PR TITLE
chore(deps): update `debug` to ^4.4.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@ unreleased
 * refactor: prefix built-in node module imports
 * Remove unused `depd` dependency
 * Add support for `Uint8Array` in `res.send`
+* deps: debug@^4.4.0
 
 5.0.1 / 2024-10-08
 ==========

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "content-type": "^1.0.4",
     "cookie": "^0.7.1",
     "cookie-signature": "^1.2.1",
-    "debug": "^4.3.6",
+    "debug": "^4.4.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",


### PR DESCRIPTION
This PR addresses the issue of multiple versions of the `debug` package being installed when using Express v5, which currently results in **four different versions** of `debug`. By updating the `debug` dependency within `express`, we can eliminate one of these redundant versions.

[Dependency Graph for Express v5](https://npmgraph.js.org/?q=express%405)

Related to:  
* https://github.com/expressjs/body-parser/pull/579
* https://github.com/pillarjs/finalhandler/pull/78