### PR TITLE
ci: updated github actions ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     paths-ignore:
       - '*.md'
 
+permissions:
+  contents: read
+
 # Cancel in progress workflows
 # in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
 concurrency:
@@ -26,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js {{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: Install dependencies
-        run: npm install --ignore-scripts --only=dev
+        run: npm install --ignore-scripts --inlcude=dev
 
       - name: Run lint
         run: npm run lint
@@ -73,44 +76,39 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: |
-          npm run test-ci
-          cp coverage/lcov.info "coverage/${{ matrix.node-version }}.lcov"
-
-      - name: Collect code coverage
-        run: |
-          mv ./coverage "./${{ matrix.node-version }}"
-          mkdir ./coverage
-          mv "./${{ matrix.node-version }}" "./coverage/${{ matrix.node-version }}"
+        run: npm run test-ci
 
       - name: Upload code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
-          path: ./coverage
+          name: coverage-node-${{ matrix.node-version }}-${{ matrix.os }}
+          path: ./coverage/lcov.info
           retention-days: 1
 
   coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install lcov
-      shell: bash
-      run: sudo apt-get -y install lcov
+      - name: Install lcov
+        shell: bash
+        run: sudo apt-get -y install lcov
 
-    - name: Collect coverage reports
-      uses: actions/download-artifact@v3
-      with:
-        name: coverage
-        path: ./coverage
+      - name: Collect coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          path: ./coverage
+          pattern: coverage-node-*
 
-    - name: Merge coverage reports
-      shell: bash
-      run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./coverage/lcov.info
+      - name: Merge coverage reports
+        shell: bash
+        run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./lcov.info
 
-    - name: Upload coverage report
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage report
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ./lcov.info

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -14,6 +14,9 @@ on:
     paths-ignore:
       - '*.md'
 
+permissions:
+  contents: read
+
 # Cancel in progress workflows
 # in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
 concurrency:
@@ -57,44 +60,39 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: |
-          npm run test-ci
-          cp coverage/lcov.info "coverage/${{ matrix.node-version }}.lcov"
-
-      - name: Collect code coverage
-        run: |
-          mv ./coverage "./${{ matrix.node-version }}"
-          mkdir ./coverage
-          mv "./${{ matrix.node-version }}" "./coverage/${{ matrix.node-version }}"
+        run: npm run test-ci
 
       - name: Upload code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
-          path: ./coverage
+          name: coverage-node-${{ matrix.node-version }}-${{ matrix.os }}
+          path: ./coverage/lcov.info
           retention-days: 1
 
   coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install lcov
-      shell: bash
-      run: sudo apt-get -y install lcov
+      - name: Install lcov
+        shell: bash
+        run: sudo apt-get -y install lcov
 
-    - name: Collect coverage reports
-      uses: actions/download-artifact@v3
-      with:
-        name: coverage
-        path: ./coverage
+      - name: Collect coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          path: ./coverage
+          pattern: coverage-node-*
 
-    - name: Merge coverage reports
-      shell: bash
-      run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./coverage/lcov.info
+      - name: Merge coverage reports
+        shell: bash
+        run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./lcov.info
 
-    - name: Upload coverage report
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage report
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ./lcov.info


### PR DESCRIPTION
I noticed that the current CI workflow in this repository could benefit from some updates. Specifically:

1. **Deprecation of Artifact Actions v3:**
   - The `actions/upload-artifact@v3` and `actions/download-artifact@v3` actions are being deprecated as of **November 30, 2024** ([GitHub Deprecation Notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)).
   - These actions should be updated to their latest versions to ensure continued functionality in the CI workflow.
   - CI Runs are currently failing like in PR #6313 

2. **The Coverage setup could also be optimized**:
    - Currently, the workflow uses the `coverallsapp/github-action@master` which points to v1 of this action. This v1 action uses `node16` as runtime which is deprecated.

3. **Minimum token permissions for the GITHUB_TOKEN**:
    - GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes. 
    - It is a best practice to reduce the scopes to the minimum needed for each workflow / step.
    - GitHub recommends defining minimum GITHUB_TOKEN permissions. https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
    - The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

4. **lint step install only dev dependencies**
    - the `lint` step currently tries to install only the dev dependencies with the `--only=dev` cli argument. `--only=dev` has been replaced with `--include=dev` since npm v7. https://docs.npmjs.com/cli/v11/commands/npm-install#include