### PR TITLE
refactor and fix: improve parsing logic in acceptParams function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,34 +89,29 @@ exports.normalizeTypes = function(types){
  * @api private
  */
 
-function acceptParams (str) {
-  var length = str.length;
-  var colonIndex = str.indexOf(';');
-  var index = colonIndex === -1 ? length : colonIndex;
-  var ret = { value: str.slice(0, index).trim(), quality: 1, params: {} };
+function acceptParams(str) {
+  const ret = { value: '', quality: 1, params: {} };
 
-  while (index < length) {
-    var splitIndex = str.indexOf('=', index);
-    if (splitIndex === -1) break;
+  if (!str) return ret;
 
-    var colonIndex = str.indexOf(';', index);
-    var endIndex = colonIndex === -1 ? length : colonIndex;
+  const parts = str.split(';').map(part => part.trim()).filter(Boolean);
+  ret.value = parts.shift();
 
-    if (splitIndex > endIndex) {
-      index = str.lastIndexOf(';', splitIndex - 1) + 1;
-      continue;
-    }
+  for (const part of parts) {
+    if (!part.includes('=')) continue;
 
-    var key = str.slice(index, splitIndex).trim();
-    var value = str.slice(splitIndex + 1, endIndex).trim();
+    const [key, ...valueParts] = part.split('=');
+    const keyTrimmed = key.trim();
+    const value = valueParts.length > 0 ? valueParts.join('=').trim() : '';
 
-    if (key === 'q') {
-      ret.quality = parseFloat(value);
+    if (!keyTrimmed) continue;
+
+    if (keyTrimmed === 'q') {
+      const quality = parseFloat(value);
+      ret.quality = isNaN(quality) ? 1 : quality;
     } else {
-      ret.params[key] = value;
+      ret.params[keyTrimmed] = value;
     }
-
-    index = endIndex + 1;
   }
 
   return ret;


### PR DESCRIPTION
- Refactored acceptParams to use split(';') and map/trim for cleaner parsing.
- Replaced manual index tracking with array operations for better readability.
- Ensured q parameter correctly updates quality with a fallback to 1.
- Fixed potential issues with key-value extraction.