### PR TITLE
ci: reorder `npm i` steps to fix ci for older node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,12 @@ jobs:
           npm config set loglevel error
         shell: bash
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Install Node version specific dev deps
         if: ${{ matrix.npm-i != '' }}
         run: npm install --save-dev ${{ matrix.npm-i }}
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Remove non-test dependencies
         run: npm rm --silent --save-dev connect-redis

--- a/package.json
+++ b/package.json
@@ -75,11 +75,11 @@
     "hbs": "4.2.0",
     "marked": "0.7.0",
     "method-override": "3.0.0",
-    "mocha": "10.2.0",
+    "mocha": "^6.2.2",
     "morgan": "1.10.0",
-    "nyc": "15.1.0",
+    "nyc": "^14.1.1",
     "pbkdf2-password": "1.2.1",
-    "supertest": "6.3.0",
+    "supertest": "^6.1.6",
     "vhost": "~3.0.2"
   },
   "engines": {


### PR DESCRIPTION
@wesleytodd That should fix the CI workflow for older node versions

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->