### PR TITLE
Update multiple links to use `https` instead of `http`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/Charter.md
+++ b/Charter.md
@@ -20,11 +20,11 @@ alike.
 
 Express is made of many modules spread between three GitHub Orgs:
 
-- [expressjs](http://github.com/expressjs/): Top level middleware and
+- [expressjs](https://github.com/expressjs/): Top level middleware and
   libraries
-- [pillarjs](http://github.com/pillarjs/): Components which make up
+- [pillarjs](https://github.com/pillarjs/): Components which make up
   Express but can also be used for other web frameworks
-- [jshttp](http://github.com/jshttp/): Low level HTTP libraries
+- [jshttp](https://github.com/jshttp/): Low level HTTP libraries
 
 ### 1.2: Out-of-Scope
 

--- a/Collaborator-Guide.md
+++ b/Collaborator-Guide.md
@@ -7,7 +7,7 @@ Open issues for the expressjs.com website in https://github.com/expressjs/expres
 ## PRs and Code contributions
 
 * Tests must pass.
-* Follow the [JavaScript Standard Style](http://standardjs.com/) and `npm run lint`.
+* Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
 * If you fix a bug, add a test.
 
 ## Branches

--- a/Release-Process.md
+++ b/Release-Process.md
@@ -31,7 +31,7 @@ Before publishing, the following preconditions should be met:
   below) will exist documenting:
   - the proposed changes
   - the type of release: patch, minor or major
-  - the version number (according to semantic versioning - http://semver.org)
+  - the version number (according to semantic versioning - https://semver.org)
 - The proposed changes should be complete.
 
 There are two main release flows: patch and non-patch.


### PR DESCRIPTION
Updated multiple links in our docs to use `https` instead of `http`. I intentionally did not change the links in `History.md` because most of them are outdated anyway.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->