### PR TITLE
docs: add codemod captains

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -135,16 +135,16 @@ project for at least 6 months as a committer prior to the request. They should h
 helped with code contributions as well as triaging issues. They are also required to
 have 2FA enabled on both their GitHub and npm accounts.
 
-Any TC member or an existing captain on the **same** repo can nominate another committer 
-to the captain role. To do so, they should submit a PR to this document, updating the 
-**Active Project Captains** section (while maintaining the sort order) with the project 
+Any TC member or an existing captain on the **same** repo can nominate another committer
+to the captain role. To do so, they should submit a PR to this document, updating the
+**Active Project Captains** section (while maintaining the sort order) with the project
 name, the nominee's GitHub handle, and their npm username (if different).
 - Repos can have as many captains as make sense for the scope of work.
-- A TC member or an existing repo captain **on the same project** can nominate a new captain. 
+- A TC member or an existing repo captain **on the same project** can nominate a new captain.
   Repo captains from other projects should not nominate captains for a different project.
 
-The PR will require at least 2 approvals from TC members and 2 weeks hold time to allow 
-for comment and/or dissent.  When the PR is merged, a TC member will add them to the 
+The PR will require at least 2 approvals from TC members and 2 weeks hold time to allow
+for comment and/or dissent.  When the PR is merged, a TC member will add them to the
 proper GitHub/npm groups.
 
 ### Active Projects and Captains
@@ -152,6 +152,7 @@ proper GitHub/npm groups.
 - [`expressjs/badgeboard`](https://github.com/expressjs/badgeboard): @wesleytodd
 - [`expressjs/basic-auth-connect`](https://github.com/expressjs/basic-auth-connect): @ulisesGascon
 - [`expressjs/body-parser`](https://github.com/expressjs/body-parser): @wesleytodd, @jonchurch, @ulisesGascon
+- [`expressjs/codemod`](https://github.com/expressjs/codemod): @bjohansebas (npm: @bsebas), @kjugi
 - [`expressjs/compression`](https://github.com/expressjs/compression): @ulisesGascon
 - [`expressjs/connect-multiparty`](https://github.com/expressjs/connect-multiparty): @ulisesGascon
 - [`expressjs/cookie-parser`](https://github.com/expressjs/cookie-parser): @wesleytodd, @UlisesGascon

--- a/Contributing.md
+++ b/Contributing.md
@@ -152,7 +152,7 @@ proper GitHub/npm groups.
 - [`expressjs/badgeboard`](https://github.com/expressjs/badgeboard): @wesleytodd
 - [`expressjs/basic-auth-connect`](https://github.com/expressjs/basic-auth-connect): @ulisesGascon
 - [`expressjs/body-parser`](https://github.com/expressjs/body-parser): @wesleytodd, @jonchurch, @ulisesGascon
-- [`expressjs/codemod`](https://github.com/expressjs/codemod): @bjohansebas (npm: @bsebas), @kjugi (npm: @filip.kudla)
+- [`expressjs/codemod`](https://github.com/expressjs/codemod): @bjohansebas (npm: `@bsebas`), @kjugi (npm: `@filip.kudla`)
 - [`expressjs/compression`](https://github.com/expressjs/compression): @ulisesGascon
 - [`expressjs/connect-multiparty`](https://github.com/expressjs/connect-multiparty): @ulisesGascon
 - [`expressjs/cookie-parser`](https://github.com/expressjs/cookie-parser): @wesleytodd, @UlisesGascon

--- a/Contributing.md
+++ b/Contributing.md
@@ -152,7 +152,7 @@ proper GitHub/npm groups.
 - [`expressjs/badgeboard`](https://github.com/expressjs/badgeboard): @wesleytodd
 - [`expressjs/basic-auth-connect`](https://github.com/expressjs/basic-auth-connect): @ulisesGascon
 - [`expressjs/body-parser`](https://github.com/expressjs/body-parser): @wesleytodd, @jonchurch, @ulisesGascon
-- [`expressjs/codemod`](https://github.com/expressjs/codemod): @bjohansebas (npm: @bsebas), @kjugi
+- [`expressjs/codemod`](https://github.com/expressjs/codemod): @bjohansebas (npm: @bsebas), @kjugi (npm: @filip.kudla)
 - [`expressjs/compression`](https://github.com/expressjs/compression): @ulisesGascon
 - [`expressjs/connect-multiparty`](https://github.com/expressjs/connect-multiparty): @ulisesGascon
 - [`expressjs/cookie-parser`](https://github.com/expressjs/cookie-parser): @wesleytodd, @UlisesGascon


### PR DESCRIPTION
The captains are added for codemod.

A TC will have to create the team on GitHub for permissions and add @kjugi to the team on npm.