### PR TITLE
add deprecation warnings for redirect arguments undefined

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,6 +14,7 @@
 
 var contentDisposition = require('content-disposition');
 var createError = require('http-errors')
+var deprecate = require('depd')('express');
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
 var http = require('node:http');
@@ -823,6 +824,18 @@ res.redirect = function redirect(url) {
   if (arguments.length === 2) {
     status = arguments[0]
     address = arguments[1]
+  }
+
+  if (!address) {
+    deprecate('Provide a url argument');
+  }
+
+  if (typeof address !== 'string') {
+    deprecate('Url must be a string');
+  }
+
+  if (typeof status !== 'number') {
+    deprecate('Status must be a number');
   }
 
   // Set location header

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cookie": "^0.7.1",
     "cookie-signature": "^1.2.1",
     "debug": "^4.4.0",
+    "depd": "^2.0.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",


### PR DESCRIPTION
---

**:stop_sign:  No Merge before #6404 has landed in v6**

---

With this, those arguments are deprecated when they are undefined or different from their data type

Related #6404
Closes #6391