### PR TITLE
Updated require statements in examples for clarity

### DIFF
--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var hash = require('pbkdf2-password')()
 var path = require('node:path');
 var session = require('express-session');

--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -5,7 +5,7 @@
  */
 
 var escapeHtml = require('escape-html');
-var express = require('../..');
+var express = require('express');
 var fs = require('node:fs');
 var marked = require('marked');
 var path = require('node:path');

--- a/examples/multi-router/index.js
+++ b/examples/multi-router/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var express = require('../..');
+var express = require('express');
 
 var app = module.exports = express();
 

--- a/examples/mvc/index.js
+++ b/examples/mvc/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var logger = require('morgan');
 var path = require('node:path');
 var session = require('express-session');

--- a/examples/online/index.js
+++ b/examples/online/index.js
@@ -11,7 +11,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var online = require('online');
 var redis = require('redis');
 var db = redis.createClient();

--- a/examples/route-separation/index.js
+++ b/examples/route-separation/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var path = require('node:path');
 var app = express();
 var logger = require('morgan');

--- a/examples/search/index.js
+++ b/examples/search/index.js
@@ -11,7 +11,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var path = require('node:path');
 var redis = require('redis');
 

--- a/examples/session/index.js
+++ b/examples/session/index.js
@@ -7,7 +7,7 @@
 // $ npm install redis
 // $ redis-server
 
-var express = require('../..');
+var express = require('express');
 var session = require('express-session');
 
 var app = express();

--- a/examples/session/redis.js
+++ b/examples/session/redis.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var logger = require('morgan');
 var session = require('express-session');
 

--- a/examples/static-files/index.js
+++ b/examples/static-files/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var logger = require('morgan');
 var path = require('node:path');
 var app = express();

--- a/examples/vhost/index.js
+++ b/examples/vhost/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var logger = require('morgan');
 var vhost = require('vhost');
 

--- a/examples/view-locals/index.js
+++ b/examples/view-locals/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var express = require('../..');
+var express = require('express');
 var path = require('node:path');
 var User = require('./user');
 var app = express();


### PR DESCRIPTION
Updated the examples to use require('express') instead of require('../..') for better clarity. This makes it easier for new developers to copy-paste and use the examples without confusion.