### PR TITLE
replace on-finished with node:stream's finished

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 unreleased
 ========================
 
+* replace `on-finished` with `node:stream`'s `finished`
 * Remove `utils-merge` dependency - use spread syntax instead
 * Remove `Object.setPrototypeOf` polyfill
 * cleanup: remove AsyncLocalStorage check from tests

--- a/lib/response.js
+++ b/lib/response.js
@@ -17,7 +17,6 @@ var createError = require('http-errors')
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
 var http = require('node:http');
-var onFinished = require('on-finished');
 var mime = require('mime-types')
 var path = require('node:path');
 var pathIsAbsolute = require('node:path').isAbsolute;
@@ -31,6 +30,7 @@ var send = require('send');
 var extname = path.extname;
 var resolve = path.resolve;
 var vary = require('vary');
+const { finished } = require('node:stream');
 
 /**
  * Response prototype.
@@ -955,7 +955,7 @@ function sendfile(res, file, options, callback) {
 
   // finished
   function onfinish(err) {
-    if (err && err.code === 'ECONNRESET') return onaborted();
+    if (err && err.code === 'ERR_STREAM_PREMATURE_CLOSE') return onaborted();
     if (err) return onerror(err);
     if (done) return;
 
@@ -981,7 +981,7 @@ function sendfile(res, file, options, callback) {
   file.on('error', onerror);
   file.on('file', onfile);
   file.on('stream', onstream);
-  onFinished(res, onfinish);
+  finished(res, onfinish);
 
   if (options.headers) {
     // set headers on successful transfer

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "http-errors": "^2.0.0",
     "merge-descriptors": "^2.0.0",
     "mime-types": "^3.0.0",
-    "on-finished": "^2.4.1",
     "once": "^1.4.0",
     "parseurl": "^1.3.3",
     "proxy-addr": "^2.0.7",

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -6,10 +6,10 @@ var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
 
 var express = require('../')
   , request = require('supertest')
-var onFinished = require('on-finished');
 var path = require('node:path');
 var fixtures = path.join(__dirname, 'fixtures');
 var utils = require('./support/utils');
+const { finished } = require('node:stream');
 
 describe('res', function(){
   describe('.sendFile(path)', function () {
@@ -210,7 +210,7 @@ describe('res', function(){
       var app = express();
 
       app.use(function (req, res) {
-        onFinished(res, function () {
+        finished(res, function () {
           res.sendFile(path.resolve(fixtures, 'name.txt'), function (err) {
             assert.ok(err)
             assert.strictEqual(err.code, 'ECONNABORTED')


### PR DESCRIPTION
This is part of supporting HTTP/2 within Express and also using native APIs.  

I'm not sure if this is a breaking change. All tests are passing, although errors could change, so I would say it might be a breaking change. What do you think?