### PR TITLE
5.1.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,32 +1,25 @@
-unreleased
+5.1.0 / 2025-03-31
 ========================
 
-* Remove `utils-merge` dependency - use spread syntax instead
-* Remove `Object.setPrototypeOf` polyfill
-* cleanup: remove AsyncLocalStorage check from tests
-* cleanup: remove unnecessary require for global Buffer
+* Add support for `Uint8Array` in `res.send()`
+* Add support for ETag option in `res.sendFile()`
+* Add support for multiple links with the same rel in `res.links()`
+* Add funding field to package.json
 * perf: use loop for acceptParams
-* Replace `methods` dependency with standard library
 * refactor: prefix built-in node module imports
-* Remove unused `depd` dependency
-* Add support for `Uint8Array` in `res.send`
-* Add support for ETag option in res.sendFile
-* Extend res.links() to allow adding multiple links with the same rel
-* deps: debug@^4.4.0
-* deps: body-parser@^2.2.0
-* deps: router@^2.2.0
-* deps: nyc@^17.1.0
-* deps: mocha@^10.7.3
-* deps: marked@^15.0.3
-* deps: express-session@^1.18.1
-* deps: ejs@^3.1.10
-* deps: content-type@^1.0.5
-* deps: connect-redis@^8.0.1
-* deps: supertest@^6.3.4
-* deps: finalhandler@^2.1.0
-* deps: qs@^6.14.0
-* deps: server-static@2.2.0
-* deps: type-is@2.0.1
+* deps: remove `setprototypeof`
+* deps: remove `safe-buffer`
+* deps: remove `utils-merge`
+* deps: remove `methods`
+* deps: remove `depd`
+* deps: `debug@^4.4.0`
+* deps: `body-parser@^2.2.0`
+* deps: `router@^2.2.0`
+* deps: `content-type@^1.0.5`
+* deps: `finalhandler@^2.1.0`
+* deps: `qs@^6.14.0`
+* deps: `server-static@2.2.0`
+* deps: `type-is@2.0.1`
 
 5.0.1 / 2024-10-08
 ==========

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express",
   "description": "Fast, unopinionated, minimalist web framework",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",


### PR DESCRIPTION
## What's Changed
* Update captains by @UlisesGascon in https://github.com/expressjs/express/pull/6027
* build: Node.js 23.0 by @bjohansebas in https://github.com/expressjs/express/pull/6075
* Add funding field (v5) by @bjohansebas in https://github.com/expressjs/express/pull/6064
* ✅ add discarded middleware test by @ctcpip in https://github.com/expressjs/express/pull/5819
* update homepage link http to https by @bjohansebas in https://github.com/expressjs/express/pull/5920
* Improve readme by @bjohansebas in https://github.com/expressjs/express/pull/5994
* Add bjohansebas as repo captain for expressjs.com by @crandmck in https://github.com/expressjs/express/pull/6058
* Remove Object.setPrototypeOf polyfill by @Phillip9587 in https://github.com/expressjs/express/pull/6081
* fix(buffer): use node:buffer instead of safe-buffer by @bhavya3024 in https://github.com/expressjs/express/pull/6071
* docs: Add DCO by @UlisesGascon in https://github.com/expressjs/express/pull/6048
* cleanup: remove promise support check from tests by @Phillip9587 in https://github.com/expressjs/express/pull/6148
* Use loop for acceptParams by @blakeembrey in https://github.com/expressjs/express/pull/6066
* Improve documentation step in release process by @bjohansebas in https://github.com/expressjs/express/pull/6150
* cleanup: remove unnecessary require for global Buffer by @Phillip9587 in https://github.com/expressjs/express/pull/6146
* cleanup: remove AsyncLocalStorage check by @Phillip9587 in https://github.com/expressjs/express/pull/6147
* update history.md for acceptParams change by @jonchurch in https://github.com/expressjs/express/pull/6177
* docs: add @rxmarbles to the triage team by @UlisesGascon in https://github.com/expressjs/express/pull/6151
* refactor: improve readability by @sazk07 in https://github.com/expressjs/express/pull/6173
* docs: clarify the security process in the triage role by @bjohansebas in https://github.com/expressjs/express/pull/6217
* chore: replace `methods` dependency with standard library by @jonkoops in https://github.com/expressjs/express/pull/6196
* Remove `utils-merge` dependency - use spread syntax instead by @Phillip9587 in https://github.com/expressjs/express/pull/6091
* fix(securite): fix vulnerabilities by @Abdel-Monaam-Aouini in https://github.com/expressjs/express/pull/6211
* refactor: prefix built-in node module imports by @slagiewka in https://github.com/expressjs/express/pull/6236
* fix: remove download size badges by @wesleytodd in https://github.com/expressjs/express/pull/6266
* Remove unused `depd` dependency by @jonkoops in https://github.com/expressjs/express/pull/6197
* fix: usage of `Invalid action input 'persist-credentials'` for `actions/setup-node@v4` in `ci.yml` by @hamirmahal in https://github.com/expressjs/express/pull/6256
* Add support for OSSF scorecard reporting by @UlisesGascon in https://github.com/expressjs/express/pull/5431
* docs: add @Phillip9587 to the triage team by @bjohansebas in https://github.com/expressjs/express/pull/6276
* fix: added a missing semicolon in css styles in examples/auth by @pr4j3sh in https://github.com/expressjs/express/pull/6297
* docs: include team email in the security policy by @UlisesGascon in https://github.com/expressjs/express/pull/6278
* refactor: simplify `normalizeTypes` function by @Ayoub-Mabrouk in https://github.com/expressjs/express/pull/6097
* ci: updated github actions ci workflow by @Phillip9587 in https://github.com/expressjs/express/pull/6314
* ci: fix npm install --include typo by @Phillip9587 in https://github.com/expressjs/express/pull/6324
* ci: updated scorecard actions by @Phillip9587 in https://github.com/expressjs/express/pull/6322
* build(deps): use carat notation for dependency versions by @dpopp07 in https://github.com/expressjs/express/pull/6317
* chore(deps): update `debug` to ^4.4.0 by @Phillip9587 in https://github.com/expressjs/express/pull/6313
* docs: retroactively note 5.0.0-beta.1 api change in history file by @dpopp07 in https://github.com/expressjs/express/pull/6333
* feat(deps): body-parser@^2.1.0 by @wesleytodd in https://github.com/expressjs/express/pull/6332
* feat(deps): router@^2.1.0 by @wesleytodd in https://github.com/expressjs/express/pull/6331
* Update repo captains by @UlisesGascon in https://github.com/expressjs/express/pull/6234
* deps: upgrade nyc by @agungjati in https://github.com/expressjs/express/pull/6122
* fix (deps): update deps by @wesleytodd in https://github.com/expressjs/express/pull/6337
* response: add support for ETag option in res.sendFile by @juanarbol in https://github.com/expressjs/express/pull/6073
* Update multiple links to use `https` instead of `http` by @Phillip9587 in https://github.com/expressjs/express/pull/6338
* Extend res.links() to allow adding multiple links with the same rel #2729 by @andvea in https://github.com/expressjs/express/pull/4885
* docs: update emeritus triagers by @UlisesGascon in https://github.com/expressjs/express/pull/6345
* docs: update guidance for triager nominations by @bjohansebas in https://github.com/expressjs/express/pull/6349
* docs: clarify guidelines for becoming a committer by @bjohansebas in https://github.com/expressjs/express/pull/6364
* Nominate @dpopp07 to the triage team by @UlisesGascon in https://github.com/expressjs/express/pull/6352
* fix(deps): qs@^6.14.0 by @wesleytodd in https://github.com/expressjs/express/pull/6374
* Add dependabot by @UlisesGascon in https://github.com/expressjs/express/pull/5435
* fix dependabot config by @bjohansebas in https://github.com/expressjs/express/pull/6392
* build(deps): bump github/codeql-action from 3.24.7 to 3.28.11 by @dependabot in https://github.com/expressjs/express/pull/6398
* build(deps): bump ossf/scorecard-action from 2.4.0 to 2.4.1 by @dependabot in https://github.com/expressjs/express/pull/6397
* feat(deps): finalhandler@2.1.0 by @wesleytodd in https://github.com/expressjs/express/pull/6373
* build(deps-dev): bump cookie-session from 2.0.0 to 2.1.0 by @dependabot in https://github.com/expressjs/express/pull/6399
* deps: body-parser@^2.2.0 by @UlisesGascon in https://github.com/expressjs/express/pull/6419
* deps: type-is@^2.0.1 by @UlisesGascon in https://github.com/expressjs/express/pull/6420
* deps: router@^2.2.0 by @UlisesGascon in https://github.com/expressjs/express/pull/6417
* ci: use full SHAs for github action versions by @Phillip9587 in https://github.com/expressjs/express/pull/6415
* doc: remove @mertcanaltin from Triagers by @mertcanaltin in https://github.com/expressjs/express/pull/6408
* deps: serve-static@^2.2.0 by @UlisesGascon in https://github.com/expressjs/express/pull/6418

## New Contributors
* @bhavya3024 made their first contribution in https://github.com/expressjs/express/pull/6071
* @jonkoops made their first contribution in https://github.com/expressjs/express/pull/6196
* @Abdel-Monaam-Aouini made their first contribution in https://github.com/expressjs/express/pull/6211
* @slagiewka made their first contribution in https://github.com/expressjs/express/pull/6236
* @hamirmahal made their first contribution in https://github.com/expressjs/express/pull/6256
* @pr4j3sh made their first contribution in https://github.com/expressjs/express/pull/6297
* @Ayoub-Mabrouk made their first contribution in https://github.com/expressjs/express/pull/6097
* @dpopp07 made their first contribution in https://github.com/expressjs/express/pull/6317
* @agungjati made their first contribution in https://github.com/expressjs/express/pull/6122
* @andvea made their first contribution in https://github.com/expressjs/express/pull/4885
* @dependabot made their first contribution in https://github.com/expressjs/express/pull/6398

**Full Changelog**: https://github.com/expressjs/express/compare/5.0.1...master