### PR TITLE
chore: wider range for query test skip

### DIFF
--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -76,10 +76,10 @@ function getMajorVersion(versionString) {
 }
 
 function shouldSkipQuery(versionString) {
-  // Skipping HTTP QUERY tests on Node 21, it is reported in http.METHODS on 21.7.2 but not supported
-  // update this implementation to run on supported versions of 21 once they exist
+  // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
+  // we could update this implementation to run on supported versions of 21 once they exist
   // upstream tracking https://github.com/nodejs/node/issues/51562
   // express tracking issue: https://github.com/expressjs/express/issues/5615
-  return Number(getMajorVersion(versionString)) === 21
+  return Number(getMajorVersion(versionString)) < 22
 }
 


### PR DESCRIPTION
We don't expect QUERY to be supported on Node < 22, so widen the range we skip this test under just in case

Fixes test failures introduced by Node 20 security release https://github.com/nodejs/node/releases/tag/v20.19.2