### PR TITLE
chore: enforce explicit `Buffer` import and add lint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,3 +8,7 @@ rules:
   indent: [error, 2, { MemberExpression: "off", SwitchCase: 1 }]
   no-trailing-spaces: error
   no-unused-vars: [error, { vars: all, args: none, ignoreRestSiblings: true }]
+  no-restricted-globals:
+    - error
+    - name: Buffer
+      message: Use `import { Buffer } from "node:buffer"` instead of the global Buffer.

--- a/lib/response.js
+++ b/lib/response.js
@@ -31,6 +31,7 @@ var send = require('send');
 var extname = path.extname;
 var resolve = path.resolve;
 var vary = require('vary');
+const { Buffer } = require('node:buffer');
 
 /**
  * Response prototype.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ var mime = require('mime-types')
 var proxyaddr = require('proxy-addr');
 var qs = require('qs');
 var querystring = require('querystring');
+const { Buffer } = require('node:buffer');
 
 /**
  * A list of lowercased HTTP methods that are supported by Node.js.

--- a/test/express.json.js
+++ b/test/express.json.js
@@ -2,6 +2,7 @@
 
 var assert = require('node:assert')
 var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const { Buffer } = require('node:buffer');
 
 var express = require('..')
 var request = require('supertest')

--- a/test/express.raw.js
+++ b/test/express.raw.js
@@ -5,6 +5,7 @@ var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
 
 var express = require('..')
 var request = require('supertest')
+const { Buffer } = require('node:buffer');
 
 describe('express.raw()', function () {
   before(function () {

--- a/test/express.static.js
+++ b/test/express.static.js
@@ -3,6 +3,8 @@
 var assert = require('node:assert')
 var express = require('..')
 var path = require('node:path')
+const { Buffer } = require('node:buffer');
+
 var request = require('supertest')
 var utils = require('./support/utils')
 

--- a/test/express.text.js
+++ b/test/express.text.js
@@ -2,7 +2,7 @@
 
 var assert = require('node:assert')
 var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
-
+const { Buffer } = require('node:buffer');
 var express = require('..')
 var request = require('supertest')
 

--- a/test/express.urlencoded.js
+++ b/test/express.urlencoded.js
@@ -2,6 +2,7 @@
 
 var assert = require('node:assert')
 var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const { Buffer } = require('node:buffer');
 
 var express = require('..')
 var request = require('supertest')

--- a/test/res.attachment.js
+++ b/test/res.attachment.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('node:buffer');
+
 var express = require('../')
   , request = require('supertest');
 

--- a/test/res.download.js
+++ b/test/res.download.js
@@ -3,6 +3,7 @@
 var after = require('after');
 var assert = require('node:assert')
 var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const { Buffer } = require('node:buffer');
 
 var express = require('..');
 var path = require('node:path')

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var assert = require('node:assert')
+const { Buffer } = require('node:buffer');
 var express = require('..');
 var methods = require('../lib/utils').methods;
 var request = require('supertest');

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -3,6 +3,7 @@
 var after = require('after');
 var assert = require('node:assert')
 var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const { Buffer } = require('node:buffer');
 
 var express = require('../')
   , request = require('supertest')

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -5,6 +5,7 @@
  */
 
 var assert = require('node:assert');
+const { Buffer } = require('node:buffer');
 
 /**
  * Module exports.

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var assert = require('node:assert');
+const { Buffer } = require('node:buffer');
 var utils = require('../lib/utils');
 
 describe('utils.etag(body, encoding)', function(){


### PR DESCRIPTION
explicitly import Buffer using `const { Buffer } = require('node:buffer')` for clarity and future compatibility, following Node.js best practices.