### PR TITLE
chore: ignore yarn.lock file and update example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ npm-shrinkwrap.json
 *.log
 *.gz
 
+# Yarn
+yarn-error.log
+yarn.lock
+
 # Coveralls
 .nyc_output
 coverage

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,9 @@ app.get('/', (req, res) => {
   res.send('Hello World')
 })
 
-app.listen(3000)
+app.listen(3000, () => {
+  console.log('Server is running on http://localhost:3000')
+})
 ```
 
 ## Installation

--- a/Readme.md
+++ b/Readme.md
@@ -40,9 +40,7 @@ app.get('/', (req, res) => {
   res.send('Hello World')
 })
 
-app.listen(3000, () => {
-  console.log('Server is running on http://localhost:3000')
-})
+app.listen(3000)
 ```
 
 ## Installation


### PR DESCRIPTION
When I used yarn then `yarn.lock` generated, our existing `.npmrc` working for `npm and pnpm` but for yarn we have to delete it after install.

This will allow us to use above package manager without conflict of lock files