### PR TITLE
refactor: replace `once` package with internal implementation

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -22,7 +22,7 @@ var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
 var resolve = require('node:path').resolve;
-var once = require('once')
+var once = require('./utils').once;
 var Router = require('router');
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -267,3 +267,23 @@ function parseExtendedQueryString(str) {
     allowPrototypes: true
   });
 }
+
+/**
+ * Wraps a function so that it can only be called once.
+ * Subsequent calls return the result of the first invocation.
+ *
+ * @param {Function} fn - The function to wrap.
+ * @returns {Function} A new function that will only call `fn` once.
+ * @private
+ */
+exports.once = function once(fn) {
+  let called = false;
+  let result;
+  return function (...args) {
+    if (!called) {
+      called = true;
+      result = fn.apply(this, args);
+    }
+    return result;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "merge-descriptors": "^2.0.0",
     "mime-types": "^3.0.0",
     "on-finished": "^2.4.1",
-    "once": "^1.4.0",
     "parseurl": "^1.3.3",
     "proxy-addr": "^2.0.7",
     "qs": "^6.14.0",


### PR DESCRIPTION
This PR removes the external [`once`](https://www.npmjs.com/package/once) package and replaces it with a modern, internal utility function. The goal is to reduce unnecessary dependencies and simplify the codebase without altering runtime behavior.

- Removes two dependencies from the dependency tree: `once` and `wrappy`  
- Updates server startup logic (e.g., `app.listen`) to use the new local `once` function

No functional changes expected — behavior remains consistent with the previous implementation.

> 🔎 Originally introduced in [expressjs/express#3216](https://github.com/expressjs/express/pull/3216)
