### PR TITLE
fix(req): validate req.range size

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -195,10 +195,14 @@ req.acceptsLanguages = function(...languages) {
  * @param {object} [options]
  * @param {boolean} [options.combine=false]
  * @return {number|array}
+ * @throws {TypeError}
  * @public
  */
 
 req.range = function range(size, options) {
+  if (!Number.isInteger(size) || size < 0) {
+    throw new TypeError('size must be a non-negative integer to req.range');
+  }
   var range = this.get('Range');
   if (!range) return;
   return parseRange(size, range, options);

--- a/test/req.range.js
+++ b/test/req.range.js
@@ -44,6 +44,26 @@ describe('req', function(){
       .expect(200, '[{"start":0,"end":74}]', done)
     })
 
+    it('should throw TypeError for invalid size', function () {
+      var app = express();
+
+      app.use(function (req, res) {
+        try {
+          req.range(-1);
+        } catch (err) {
+          res.status(500).send(err.name + ': ' + err.message);
+          return;
+        }
+        res.send('no error');
+      });
+
+      return request(app)
+        .get('/')
+        .set('Range', 'bytes=0-10')
+        .expect(500)
+        .expect(/TypeError: size must be a non-negative integer to req\.range/);
+    });
+
     it('should have a .type', function (done) {
       var app = express()
 


### PR DESCRIPTION
the `req.range` function to ensure the `size` parameter is a non-negative integer. If invalid, a `TypeError` is thrown with a descriptive message.