### PR TITLE
Fix: broken CONTRIBUTING.md link in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,7 @@ The Express.js project welcomes all constructive contributions. Contributions ta
 from code for bug fixes and enhancements, to additions and fixes to documentation, additional
 tests, triaging incoming pull requests and issues, and more!
 
-See the [Contributing Guide](https://github.com/expressjs/.github/blob/HEAD/CONTRIBUTING.yml) for more technical details on contributing.
+See the [Contributing Guide](https://github.com/expressjs/.github/blob/master/CONTRIBUTING.md) for more technical details on contributing.
 
 ### Security Issues
 


### PR DESCRIPTION
### What this PR does

Fixes a broken link to the CONTRIBUTING guide in the Readme.  
Previously, clicking the "Contributing" link resulted in a 404 page.

### Why it's needed

This update helps new contributors find the correct guidelines.

closes #6593 