### PR TITLE
ci: run CI when the markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
     paths-ignore:
       - '*.md'
   pull_request:
-    paths-ignore:
-      - '*.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
When there are changes in a markdown file, the CI does not run, which means the PR cannot be merged without bypassing the branch protections.