### PR TITLE
lint: add --fix flag to automatic fix linting issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "lib/"
   ],
   "scripts": {
-    "lint": "eslint . --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "mocha --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
     "test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=html --reporter=text npm test",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "lib/"
   ],
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --fix",
     "test": "mocha --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
     "test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=html --reporter=text npm test",


### PR DESCRIPTION
The `lint` script has been updated to automatically fix linting issues when running ESLint.