### PR TITLE
doc: fix CONTRIBUTING link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,7 @@ The Express.js project welcomes all constructive contributions. Contributions ta
 from code for bug fixes and enhancements, to additions and fixes to documentation, additional
 tests, triaging incoming pull requests and issues, and more!
 
-See the [Contributing Guide](https://github.com/expressjs/.github/blob/HEAD/CONTRIBUTING.yml) for more technical details on contributing.
+See the [Contributing Guide](https://github.com/expressjs/.github/blob/HEAD/CONTRIBUTING.md) for more technical details on contributing.
 
 ### Security Issues
 


### PR DESCRIPTION
# The Problem

The Contributing link in the readme was pointing to `CONTRIBUTING.yml` in the `.github` repo not `.md`, and 404ing.

# The solution
The PR now just updates the link to be correct, no new shim file

~The PR updates the readme link to a shim` CONTRIBUTING.md` file in the repo, which links out to the correct file in the .github repo. I prefer this for visibility, personally, but wont block on it being like this. We just want to ensure the link is correct at the end of the day.~

## Context
~I swapped from `/blob/HEAD` to `/blob/master` because Github UI will auto expand to the SHA when using the HEAD form. I don't want folks to copy that and save the URL, because that would mean their links will never see updates to the file. Folks can intentionally get the SHA link when and if they want it.~

Now I can't repro this `¯\_(ツ)_/¯`