### PR TITLE
Refactor res.send() into helper functions

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -123,106 +123,97 @@ res.links = function(links) {
  */
 
 res.send = function send(body) {
-  var chunk = body;
-  var encoding;
-  var req = this.req;
-  var type;
+  const req = this.req;
+  const app = this.app;
 
-  // settings
-  var app = this.app;
+  let chunk = body;
+  let encoding;
+  let type;
 
-  switch (typeof chunk) {
-    // string defaulting to html
-    case 'string':
-      if (!this.get('Content-Type')) {
-        this.type('html');
-      }
-      break;
-    case 'boolean':
-    case 'number':
-    case 'object':
-      if (chunk === null) {
-        chunk = '';
-      } else if (ArrayBuffer.isView(chunk)) {
-        if (!this.get('Content-Type')) {
-          this.type('bin');
-        }
-      } else {
-        return this.json(chunk);
-      }
-      break;
+  if (typeof chunk === 'string') {
+    if (!this.get('Content-Type')) this.type('html');
+    encoding = 'utf8';
+  } else if (typeof chunk === 'boolean' || typeof chunk === 'number' || chunk === null) {
+    chunk = chunk === null ? '' : chunk;
+  } else if (typeof chunk === 'object') {
+    if (ArrayBuffer.isView(chunk)) {
+      if (!this.get('Content-Type')) this.type('bin');
+    } else {
+      return this.json(chunk);
+    }
   }
 
-  // write strings in utf-8
   if (typeof chunk === 'string') {
-    encoding = 'utf8';
     type = this.get('Content-Type');
-
-    // reflect this in content-type
     if (typeof type === 'string') {
       this.set('Content-Type', setCharset(type, 'utf-8'));
     }
   }
 
-  // determine if ETag should be generated
-  var etagFn = app.get('etag fn')
-  var generateETag = !this.get('ETag') && typeof etagFn === 'function'
+  chunk = prepareChunk(this, chunk, encoding);
 
-  // populate Content-Length
-  var len
-  if (chunk !== undefined) {
-    if (Buffer.isBuffer(chunk)) {
-      // get length of Buffer
-      len = chunk.length
-    } else if (!generateETag && chunk.length < 1000) {
-      // just calculate length when no ETag + small chunk
-      len = Buffer.byteLength(chunk, encoding)
-    } else {
-      // convert chunk to Buffer and calculate
-      chunk = Buffer.from(chunk, encoding)
-      encoding = undefined;
-      len = chunk.length
-    }
+  setETagHeader(this, chunk, encoding);
 
-    this.set('Content-Length', len);
-  }
-
-  // populate ETag
-  var etag;
-  if (generateETag && len !== undefined) {
-    if ((etag = etagFn(chunk, encoding))) {
-      this.set('ETag', etag);
-    }
-  }
-
-  // freshness
   if (req.fresh) this.status(304);
-
-  // strip irrelevant headers
-  if (204 === this.statusCode || 304 === this.statusCode) {
-    this.removeHeader('Content-Type');
-    this.removeHeader('Content-Length');
-    this.removeHeader('Transfer-Encoding');
-    chunk = '';
-  }
-
-  // alter headers for 205
-  if (this.statusCode === 205) {
-    this.set('Content-Length', '0')
-    this.removeHeader('Transfer-Encoding')
-    chunk = ''
-  }
+  stripBodyIfNotAllowed(this);
 
   if (req.method === 'HEAD') {
-    // skip body for HEAD
     this.end();
   } else {
-    // respond
     this.end(chunk, encoding);
   }
 
   return this;
 };
+
+function prepareChunk(res, chunk, encoding) {
+  const app = res.app;
+  const etagFn = app.get('etag fn');
+  const shouldGenerateETag = !res.get('ETag') && typeof etagFn === 'function';
+
+  if (chunk === undefined) return chunk;
+
+  let len;
+
+  if (Buffer.isBuffer(chunk)) {
+    len = chunk.length;
+  } else if (!shouldGenerateETag && chunk.length < 1000) {
+    len = Buffer.byteLength(chunk, encoding);
+  } else {
+    chunk = Buffer.from(chunk, encoding);
+    encoding = undefined;
+    len = chunk.length;
+  }
+
+  res.set('Content-Length', len);
+  return chunk;
+}
+
+function setETagHeader(res, chunk, encoding) {
+  const etagFn = res.app.get('etag fn');
+  if (!res.get('ETag') && typeof etagFn === 'function' && chunk != null) {
+    const etag = etagFn(chunk, encoding);
+    if (etag) res.set('ETag', etag);
+  }
+}
+
+function stripBodyIfNotAllowed(res) {
+  const status = res.statusCode;
+
+  if (status === 204 || status === 304) {
+    res.removeHeader('Content-Type');
+    res.removeHeader('Content-Length');
+    res.removeHeader('Transfer-Encoding');
+    return res.end('');
+  }
+
+  if (status === 205) {
+    res.set('Content-Length', '0');
+    res.removeHeader('Transfer-Encoding');
+    return res.end('');
+  }
+}
+
 
 /**
  * Send JSON response.


### PR DESCRIPTION
### Summary

Refactored `res.send()` in `response.js` to improve readability and maintainability. Broke up the large method into smaller helper functions:
- `prepareChunk`
- `setETagHeader`
- `stripBodyIfNotAllowed`

Behavior is preserved 100%. This helps future contributors understand and modify `res.send()` more easily.

---

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
