### PR TITLE
chore: improve regexes in examples

### DIFF
--- a/examples/markdown/index.js
+++ b/examples/markdown/index.js
@@ -17,7 +17,7 @@ var app = module.exports = express();
 app.engine('md', function(path, options, fn){
   fs.readFile(path, 'utf8', function(err, str){
     if (err) return fn(err);
-    var html = marked.parse(str).replace(/\{([^}]+)\}/g, function(_, name){
+    var html = marked.parse(str).replace(/\{([^{}]+)\}/g, function(_, name){
       return escapeHtml(options[name] || '');
     });
     fn(null, html);

--- a/examples/view-constructor/index.js
+++ b/examples/view-constructor/index.js
@@ -14,7 +14,7 @@ var app = module.exports = express();
 app.engine('md', function(str, options, fn){
   try {
     var html = md(str);
-    html = html.replace(/\{([^}]+)\}/g, function(_, name){
+    html = html.replace(/\{([^{}]+)\}/g, function(_, name){
       return options[name] || '';
     });
     fn(null, html);


### PR DESCRIPTION
Improve a regular expression that appears twice in the examples which could lead to quadratic runtime if the input is crafted to match `/\{+/` plus some rejecting suffix. In these examples this is unlikely since the markdown files are probably trusted. This change is mostly focused towards anyone that starts from the examples and expands to cases where the markdown files may not be trusted (i.e., user-provided templates).

Technically this changes the behavior of these examples, because names can no longer contain a `{`, but given they're just examples this "breaking change" seems acceptable to me.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
