### PR TITLE
test: enhance req.is() tests with additional cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "mocha --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+    "test": "mocha --require test/support/env  --exit --reporter spec --check-leaks test/ test/acceptance/",
     "test-ci": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --exclude examples --exclude test --exclude benchmarks --reporter=html --reporter=text npm test",
     "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"

--- a/test/req.is.js
+++ b/test/req.is.js
@@ -2,6 +2,7 @@
 
 var express = require('..')
 var request = require('supertest')
+var after = require('after')
 
 describe('req.is()', function () {
   describe('when given a mime type', function () {
@@ -27,10 +28,24 @@ describe('req.is()', function () {
       })
 
       request(app)
-      .post('/')
-      .type('application/json')
-      .send('{}')
-      .expect(200, 'false', done)
+        .post('/')
+        .type('application/json')
+        .send('{}')
+        .expect(200, 'false', done)
+    })
+
+    it('should return false when none in list matches', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['image/jpeg', 'text/html']))
+      })
+
+      request(app)
+        .post('/')
+        .type('application/json')
+        .send('{}')
+        .expect(200, 'false', done)
     })
 
     it('should ignore charset', function (done) {
@@ -41,15 +56,15 @@ describe('req.is()', function () {
       })
 
       request(app)
-      .post('/')
-      .type('application/json; charset=UTF-8')
-      .send('{}')
-      .expect(200, '"application/json"', done)
+        .post('/')
+        .type('application/json; charset=UTF-8')
+        .send('{}')
+        .expect(200, '"application/json"', done)
     })
   })
 
   describe('when content-type is not present', function(){
-    it('should return false', function (done) {
+    it('should return false for single type', function (done) {
       var app = express()
 
       app.use(function (req, res) {
@@ -61,6 +76,19 @@ describe('req.is()', function () {
       .send('{}')
       .expect(200, 'false', done)
     })
+
+    it('should return false for multiple types', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['application/json', 'image/jpeg']))
+      })
+
+      request(app)
+        .post('/')
+        .send('{}')
+        .expect(200, 'false', done)
+    })  
   })
 
   describe('when given an extension', function(){
@@ -76,6 +104,27 @@ describe('req.is()', function () {
       .type('application/json')
       .send('{}')
       .expect(200, '"json"', done)
+    })
+
+  it('should lookup the first matching extension from list', function (done) {
+      var app = express()
+      var cb = after(2, done)
+
+      app.use(function (req, res) {
+        res.json(req.is(['json', 'html']))
+      })
+
+      request(app)
+        .post('/')
+        .type('application/json')
+        .send('{}')
+        .expect(200, '"json"', cb)
+
+      request(app)
+        .post('/')
+        .type('text/html')
+        .send('{}')
+        .expect(200, '"html"', cb)
     })
   })
 
@@ -165,5 +214,32 @@ describe('req.is()', function () {
       .send('{}')
       .expect(200, '"application/json"', done)
     })
+  })
+
+  it('should match wildcards in list and return full type or false', function (done){
+    var app = express()      
+    var cb = after(3, done)
+    
+    app.use(function (req, res) {
+      res.json(req.is(['application/*', '*/jpeg']))
+    })
+
+    request(app)
+      .post('/')
+      .type('image/jpeg')
+      .send('{}')
+      .expect(200, '"image/jpeg"', cb)
+
+    request(app)
+      .post('/')
+      .type('text/html')
+      .send('{}')
+      .expect(200, 'false', cb)
+
+    request(app)
+      .post('/')
+      .type('application/json')
+      .send('{}')
+      .expect(200, '"application/json"', cb)
   })
 })

--- a/test/req.is.js
+++ b/test/req.is.js
@@ -88,7 +88,7 @@ describe('req.is()', function () {
         .post('/')
         .send('{}')
         .expect(200, 'false', done)
-    })  
+    })
   })
 
   describe('when given an extension', function(){
@@ -106,7 +106,7 @@ describe('req.is()', function () {
       .expect(200, '"json"', done)
     })
 
-  it('should lookup the first matching extension from list', function (done) {
+    it('should lookup the first matching extension from list', function (done) {
       var app = express()
       var cb = after(2, done)
 
@@ -217,9 +217,9 @@ describe('req.is()', function () {
   })
 
   it('should match wildcards in list and return full type or false', function (done){
-    var app = express()      
+    var app = express()
     var cb = after(3, done)
-    
+
     app.use(function (req, res) {
       res.json(req.is(['application/*', '*/jpeg']))
     })


### PR DESCRIPTION
Basically, we support an array as an argument for req.is. This hasn’t been documented, and we should document it on the website.

Ref: https://github.com/expressjs/express/blob/8f21493cc57dc32fe059d47abb4210d5b383cc31/lib/request.js#L260