### PR TITLE
lib: use req.socket over deprecated req.connection

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -282,12 +282,12 @@ req.is = function is(types) {
  */
 
 defineGetter(req, 'protocol', function protocol(){
-  var proto = this.connection.encrypted
+  var proto = this.socket.encrypted
     ? 'https'
     : 'http';
   var trust = this.app.get('trust proxy fn');
 
-  if (!trust(this.connection.remoteAddress, 0)) {
+  if (!trust(this.socket.remoteAddress, 0)) {
     return proto;
   }
 
@@ -406,7 +406,7 @@ defineGetter(req, 'host', function host(){
   var trust = this.app.get('trust proxy fn');
   var val = this.get('X-Forwarded-Host');
 
-  if (!val || !trust(this.connection.remoteAddress, 0)) {
+  if (!val || !trust(this.socket.remoteAddress, 0)) {
     val = this.get('Host');
   } else if (val.indexOf(',') !== -1) {
     // Note: X-Forwarded-Host is normally only ever a

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -39,7 +39,7 @@ describe('req', function(){
         app.enable('trust proxy');
 
         app.use(function(req, res){
-          req.connection.encrypted = true;
+          req.socket.encrypted = true;
           res.end(req.protocol);
         });
 


### PR DESCRIPTION
`req.connection` was only deprecated in the documentation, but it’s possible that a runtime deprecation will be added since internally it calls socket, so it’s better to start migrating.

https://nodejs.org/dist/latest/docs/api/deprecations.html#DEP0133