### PR TITLE
fix: display the correct message when passing a `bigint` to `res.status`.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -62,6 +62,10 @@ module.exports = res
  */
 
 res.status = function status(code) {
+  // Prevent BigInt serialization error
+  if (typeof code !== 'number') {
+    throw new TypeError(`Invalid status code: ${code} (${typeof code}). Status code must be a number.`);
+  }
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
     throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
@@ -326,9 +330,6 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
-  if (typeof statusCode !== 'number') {
-    throw new TypeError('Invalid status code: ' + statusCode);
-  }
   var body = statuses.message[statusCode] || String(statusCode)
 
   this.status(statusCode);

--- a/lib/response.js
+++ b/lib/response.js
@@ -62,10 +62,6 @@ module.exports = res
  */
 
 res.status = function status(code) {
-  // Prevent BigInt serialization error
-  if (typeof code !== 'number') {
-    throw new TypeError(`Invalid status code: ${code} (${typeof code}). Status code must be a number.`);
-  }
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
     throw new TypeError(`Invalid status code: ${typeof code === "bigint" ? code : JSON.stringify(code)}. Status code must be an integer.`);

--- a/lib/response.js
+++ b/lib/response.js
@@ -326,6 +326,9 @@ res.jsonp = function jsonp(obj) {
  */
 
 res.sendStatus = function sendStatus(statusCode) {
+  if (typeof statusCode !== 'number') {
+    throw new TypeError('Invalid status code: ' + statusCode);
+  }
   var body = statuses.message[statusCode] || String(statusCode)
 
   this.status(statusCode);

--- a/lib/response.js
+++ b/lib/response.js
@@ -68,7 +68,7 @@ res.status = function status(code) {
   }
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
-    throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
+    throw new TypeError(`Invalid status code: ${typeof code === "bigint" ? code : JSON.stringify(code)}. Status code must be an integer.`);
   }
   // Check if the status code is outside of Node's valid range
   if (code < 100 || code > 999) {

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -40,5 +40,17 @@ describe('res', function () {
         .get('/')
         .expect(500, /TypeError: Invalid status code/, done)
     })
+
+    it('should raise error for BigInt status code', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.sendStatus(200n)
+      })
+
+      request(app)
+        .get('/')
+        .expect(500, /TypeError.*Invalid status code/, done)
+    })
   })
 })

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -40,17 +40,5 @@ describe('res', function () {
         .get('/')
         .expect(500, /TypeError: Invalid status code/, done)
     })
-
-    it('should raise error for BigInt status code', function (done) {
-      var app = express()
-
-      app.use(function (req, res) {
-        res.sendStatus(200n)
-      })
-
-      request(app)
-        .get('/')
-        .expect(500, /TypeError.*Invalid status code/, done)
-    })
   })
 })

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -200,6 +200,18 @@ describe('res', function () {
           .get('/')
           .expect(500, /Invalid status code/, done);
       });
+
+      it('should raise error for BigInt status code', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.status(200n).end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done)
+      })
     });
   });
 });


### PR DESCRIPTION
Fixes #6756

This PR adds type validation to `res.sendStatus()` to prevent uncaught TypeError when BigInt values are passed as status codes.

**Problem:**
- `res.sendStatus(200n)` caused uncaught `"Do not know how to serialize a BigInt"` error
- Error occurred when `sendStatus()` called `this.status()` which internally uses `JSON.stringify()`

**Solution:**
- Add type checking at the beginning of `sendStatus()` method  
- Throw consistent `TypeError: Invalid status code` for non-number inputs
- Matches existing error handling patterns in Express

**Changes:**
- Add type validation in `lib/response.js` 
- Add test case for BigInt input in `test/res.sendStatus.js`
- All existing tests pass (1239 passing)
- Follows existing error message format
- No linting errors

**Testing:**
```bash
npm test  # All 1239 tests pass
npm run lint  # No errors