### PR TITLE
Remove history.md from being packaged on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "files": [
     "LICENSE",
-    "History.md",
     "Readme.md",
     "index.js",
     "lib/"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

Remove History.md file from being published.

This would reduce the size of the package by ~ 56% (loosing 29851 kb) and for 48M downloads/weeks this would save ~1.4 Tb of transfer per week. (unzip)
- previous gzip: 52,415 kb
- new gzip: 22,564 kb
- previous unzip: 221 kb
- new unzip: 98 kb

This PR completely remove this document from the tarball published but we could also
- keep the document and dynamically add the link to the history.md file in the repo
- only keep the content of the latest release (and maybe with a link)

I would recommend to drop the file completely and let people reading it on github

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
