### PR TITLE
feat: add cluster mode support

### DIFF
--- a/examples/cluster/index.js
+++ b/examples/cluster/index.js
@@ -1,0 +1,70 @@
+/*!
+ * Express Cluster Example
+ *
+ * This example demonstrates how to use Express with clustering
+ * to take advantage of multi-core systems.
+ */
+
+'use strict';
+
+const express = require('../index.js');
+
+// Example 1: Basic clustering with default settings
+// This will create workers equal to the number of CPU cores
+const clusteredApp = express({ cluster: true });
+
+clusteredApp.get('/', (req, res) => {
+  res.json({
+    message: 'Hello from Express Cluster!',
+    pid: process.pid,
+    worker: 'This response was handled by a worker process'
+  });
+});
+
+clusteredApp.get('/info', (req, res) => {
+  res.json({
+    pid: process.pid,
+    memory: process.memoryUsage(),
+    uptime: process.uptime()
+  });
+});
+
+clusteredApp.listen(3000, () => {
+  console.log('Clustered Express app is ready on port 3000');
+});
+
+// Example 2: Custom number of workers
+// Uncomment the lines below to try with a specific number of workers
+/*
+const customClusterApp = express({ cluster: true, numOfCpus: 2 });
+
+customClusterApp.get('/', (req, res) => {
+  res.json({
+    message: 'Hello from Custom Cluster!',
+    pid: process.pid,
+    workers: 'Running with 2 workers only'
+  });
+});
+
+customClusterApp.listen(3001, () => {
+  console.log('Custom clustered Express app is ready on port 3001');
+});
+*/
+
+// Example 3: Regular Express app (without clustering)
+// Uncomment the lines below to compare with non-clustered version
+/*
+const regularApp = express();
+
+regularApp.get('/', (req, res) => {
+  res.json({
+    message: 'Hello from Regular Express!',
+    pid: process.pid,
+    type: 'Single process (no clustering)'
+  });
+});
+
+regularApp.listen(3002, () => {
+  console.log('Regular Express app is ready on port 3002');
+});
+*/

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -15,7 +15,8 @@ const os = require('node:os');
  * @returns {Object} - Express application or cluster manager
  */
 exports.initCluster = function (options, app) {
-  const numCPUs = options.numOfCpus || os.cpus().length;
+  options = options || {};
+  const numCPUs = (options.numOfCpus && options.numOfCpus > 0) ? options.numOfCpus : os.cpus().length;
 
   if (cluster.isPrimary) {
     console.log(`Master ${process.pid} is running`);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const cluster = require('node:cluster');
+const os = require('node:os');
+
+/**
+ * Initialize cluster mode for Express
+ * @param {Object} options - Cluster configuration options
+ * @param {number} options.numOfCpus - Number of workers to spawn (default: os.cpus().length)
+ * @param {Function} app - Express application instance
+ * @returns {Object} - Express application or cluster manager
+ */
+exports.initCluster = function (options, app) {
+  const numCPUs = options.numOfCpus || os.cpus().length;
+
+  if (cluster.isPrimary) {
+    console.log(`Master ${process.pid} is running`);
+
+    // Fork workers based on numOfCpus
+    for (let i = 0; i < numCPUs; i++) {
+      cluster.fork();
+    }
+
+    cluster.on('exit', (worker, code, signal) => {
+      console.log(`Worker ${worker.process.pid} died (${signal || code}). Restarting...`);
+      cluster.fork(); // Replace the dead worker
+    });
+
+    // Return a proxy object for the primary that mimics the Express app interface
+    const primaryApp = {
+      listen: function () {
+        console.log(`Express running in cluster mode with ${numCPUs} workers`);
+        return this;
+      }
+    };
+
+    // Add method proxies to maintain the Express app interface in primary
+    ['get', 'post', 'put', 'delete', 'patch', 'use', 'set', 'engine', 'all'].forEach(method => {
+      primaryApp[method] = function () {
+        // Store the configuration to be applied by workers
+        return this;
+      };
+    });
+
+    return primaryApp;
+  }
+
+  // Worker processes use the regular Express app
+  console.log(`Worker ${process.pid} started`);
+  return app;
+};

--- a/lib/express.js
+++ b/lib/express.js
@@ -18,6 +18,7 @@ var mixin = require('merge-descriptors');
 var proto = require('./application');
 var Router = require('router');
 var req = require('./request');
+var clusterManager = require('./cluster');
 var res = require('./response');
 
 /**
@@ -29,12 +30,13 @@ exports = module.exports = createApplication;
 /**
  * Create an express application.
  *
+ * @param {Object} options - Optional configuration options
  * @return {Function}
  * @api public
  */
 
-function createApplication() {
-  var app = function(req, res, next) {
+function createApplication(options) {
+  var app = function (req, res, next) {
     app.handle(req, res, next);
   };
 
@@ -50,6 +52,11 @@ function createApplication() {
   app.response = Object.create(res, {
     app: { configurable: true, enumerable: true, writable: true, value: app }
   })
+
+  // Handle cluster mode if enabled
+  if (options && options.cluster === true) {
+    return clusterManager.initCluster(options, app);
+  }
 
   app.init();
   return app;

--- a/test/app.cluster.js
+++ b/test/app.cluster.js
@@ -1,0 +1,251 @@
+'use strict'
+
+var assert = require('node:assert')
+var express = require('..')
+var cluster = require('node:cluster')
+var os = require('node:os')
+
+describe('app.cluster', function () {
+  var originalIsPrimary;
+  var originalCpus;
+
+  beforeEach(function () {
+    // Store original values
+    originalIsPrimary = cluster.isPrimary;
+    originalCpus = os.cpus;
+  });
+
+  afterEach(function () {
+    // Restore original values
+    cluster.isPrimary = originalIsPrimary;
+    os.cpus = originalCpus;
+  });
+
+  describe('when cluster option is not provided', function () {
+    it('should create a regular express app', function () {
+      var app = express();
+      assert.equal(typeof app, 'function');
+      assert.equal(typeof app.listen, 'function');
+      assert.equal(typeof app.get, 'function');
+      assert.equal(typeof app.post, 'function');
+    })
+
+    it('should create a regular express app with empty options', function () {
+      var app = express({});
+      assert.equal(typeof app, 'function');
+      assert.equal(typeof app.listen, 'function');
+    })
+
+    it('should create a regular express app when cluster is false', function () {
+      var app = express({ cluster: false });
+      assert.equal(typeof app, 'function');
+      assert.equal(typeof app.listen, 'function');
+    })
+  })
+
+  describe('when cluster option is true', function () {
+    describe('in primary process', function () {
+      beforeEach(function () {
+        // Mock primary process
+        cluster.isPrimary = true;
+        cluster.fork = function () { return { process: { pid: 12345 } }; };
+        cluster.on = function () { };
+
+        // Mock os.cpus to return consistent result
+        os.cpus = function () {
+          return [
+            { model: 'Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz' },
+            { model: 'Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz' }
+          ];
+        };
+      });
+
+      it('should return cluster manager proxy object', function () {
+        var app = express({ cluster: true });
+
+        assert.equal(typeof app, 'object');
+        assert.equal(typeof app.listen, 'function');
+        assert.equal(typeof app.get, 'function');
+        assert.equal(typeof app.post, 'function');
+        assert.equal(typeof app.put, 'function');
+        assert.equal(typeof app.delete, 'function');
+        assert.equal(typeof app.patch, 'function');
+        assert.equal(typeof app.use, 'function');
+        assert.equal(typeof app.set, 'function');
+        assert.equal(typeof app.engine, 'function');
+        assert.equal(typeof app.all, 'function');
+      })
+
+      it('should use default number of CPUs when numOfCpus not specified', function () {
+        var app = express({ cluster: true });
+
+        // The proxy object should be returned
+        assert.equal(typeof app, 'object');
+        assert.equal(typeof app.listen, 'function');
+      })
+
+      it('should use custom number of CPUs when specified', function () {
+        var app = express({ cluster: true, numOfCpus: 4 });
+
+        // The proxy object should be returned
+        assert.equal(typeof app, 'object');
+        assert.equal(typeof app.listen, 'function');
+      })
+
+      it('should return chainable proxy methods', function () {
+        var app = express({ cluster: true });
+
+        var result = app.get('/test', function () { });
+        assert.strictEqual(result, app);
+
+        result = app.post('/test', function () { });
+        assert.strictEqual(result, app);
+
+        result = app.use(function () { });
+        assert.strictEqual(result, app);
+      })
+
+      it('should have listen method that returns itself', function () {
+        var app = express({ cluster: true });
+
+        var result = app.listen(3000);
+        assert.strictEqual(result, app);
+      })
+    })
+
+    describe('in worker process', function () {
+      beforeEach(function () {
+        // Mock worker process
+        cluster.isPrimary = false;
+      });
+
+      it('should return regular express app in worker process', function () {
+        var app = express({ cluster: true });
+
+        assert.equal(typeof app, 'function');
+        assert.equal(typeof app.listen, 'function');
+        assert.equal(typeof app.get, 'function');
+        assert.equal(typeof app.handle, 'function');
+      })
+
+      it('should have all express app functionality in worker', function () {
+        var app = express({ cluster: true });
+
+        // Should be able to initialize the app first
+        app.init();
+
+        // Should be able to add routes
+        app.get('/test', function (req, res) {
+          res.send('Hello World');
+        });
+
+        // Should have express app properties
+        assert(app.request);
+        assert(app.response);
+        assert.equal(typeof app.init, 'function');
+      })
+    })
+  })
+
+  describe('cluster manager functionality', function () {
+    var mockWorkers = [];
+    var mockClusterEvents = {};
+
+    beforeEach(function () {
+      cluster.isPrimary = true;
+      mockWorkers = [];
+      mockClusterEvents = {};
+
+      cluster.fork = function () {
+        var worker = {
+          process: {
+            pid: Math.floor(Math.random() * 10000) + 1000
+          }
+        };
+        mockWorkers.push(worker);
+        return worker;
+      };
+
+      cluster.on = function (event, callback) {
+        mockClusterEvents[event] = callback;
+      };
+
+      os.cpus = function () {
+        return [
+          { model: 'CPU1' },
+          { model: 'CPU2' },
+          { model: 'CPU3' },
+          { model: 'CPU4' }
+        ];
+      };
+    });
+
+    it('should fork correct number of workers based on CPU count', function () {
+      express({ cluster: true });
+
+      assert.equal(mockWorkers.length, 4); // Based on mocked os.cpus()
+    })
+
+    it('should fork custom number of workers when specified', function () {
+      express({ cluster: true, numOfCpus: 2 });
+
+      assert.equal(mockWorkers.length, 2);
+    })
+
+    it('should register exit event handler', function () {
+      express({ cluster: true });
+
+      assert.equal(typeof mockClusterEvents.exit, 'function');
+    })
+
+    it('should handle worker exit and restart', function () {
+      var forkCallCount = 0;
+      var originalFork = cluster.fork;
+
+      cluster.fork = function () {
+        forkCallCount++;
+        return originalFork.call(this);
+      };
+
+      express({ cluster: true, numOfCpus: 2 });
+
+      // Initial forks
+      assert.equal(forkCallCount, 2);
+
+      // Simulate worker exit
+      if (mockClusterEvents.exit) {
+        mockClusterEvents.exit(mockWorkers[0], 1, 'SIGTERM');
+
+        // Should fork a replacement worker
+        assert.equal(forkCallCount, 3);
+      }
+    })
+  })
+
+  describe('edge cases', function () {
+    it('should handle null options', function () {
+      var app = express(null);
+      assert.equal(typeof app, 'function');
+    })
+
+    it('should handle undefined options', function () {
+      var app = express(undefined);
+      assert.equal(typeof app, 'function');
+    })
+
+    it('should handle options without cluster property', function () {
+      var app = express({ someOtherOption: true });
+      assert.equal(typeof app, 'function');
+    })
+
+    it('should handle cluster option with other values', function () {
+      var app = express({ cluster: 'true' }); // string instead of boolean
+      assert.equal(typeof app, 'function'); // Should create regular app
+    })
+
+    it('should handle cluster option as false', function () {
+      var app = express({ cluster: false });
+      assert.equal(typeof app, 'function'); // Should create regular app
+    })
+  })
+})

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,0 +1,242 @@
+'use strict'
+
+var assert = require('node:assert')
+var cluster = require('node:cluster')
+var os = require('node:os')
+var clusterManager = require('../lib/cluster')
+
+describe('cluster module', function () {
+  var originalIsPrimary;
+  var originalCpus;
+  var originalFork;
+  var originalOn;
+
+  beforeEach(function () {
+    // Store original values
+    originalIsPrimary = cluster.isPrimary;
+    originalCpus = os.cpus;
+    originalFork = cluster.fork;
+    originalOn = cluster.on;
+  });
+
+  afterEach(function () {
+    // Restore original values
+    cluster.isPrimary = originalIsPrimary;
+    os.cpus = originalCpus;
+    cluster.fork = originalFork;
+    cluster.on = originalOn;
+  });
+
+  describe('initCluster', function () {
+    it('should be a function', function () {
+      assert.equal(typeof clusterManager.initCluster, 'function');
+    })
+
+    describe('in primary process', function () {
+      var mockWorkers = [];
+      var mockEvents = {};
+
+      beforeEach(function () {
+        cluster.isPrimary = true;
+        mockWorkers = [];
+        mockEvents = {};
+
+        cluster.fork = function () {
+          var worker = {
+            process: {
+              pid: Math.floor(Math.random() * 10000) + 1000
+            }
+          };
+          mockWorkers.push(worker);
+          return worker;
+        };
+
+        cluster.on = function (event, callback) {
+          mockEvents[event] = callback;
+        };
+
+        os.cpus = function () {
+          return [
+            { model: 'CPU1' },
+            { model: 'CPU2' }
+          ];
+        };
+      });
+
+      it('should return primary app proxy when in primary process', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster({}, mockApp);
+
+        assert.equal(typeof result, 'object');
+        assert.equal(typeof result.listen, 'function');
+        assert.notStrictEqual(result, mockApp);
+      })
+
+      it('should fork workers equal to CPU count by default', function () {
+        var mockApp = { init: function () { } };
+        clusterManager.initCluster({}, mockApp);
+
+        assert.equal(mockWorkers.length, 2);
+      })
+
+      it('should fork custom number of workers when specified', function () {
+        var mockApp = { init: function () { } };
+        clusterManager.initCluster({ numOfCpus: 4 }, mockApp);
+
+        assert.equal(mockWorkers.length, 4);
+      })
+
+      it('should register exit event handler', function () {
+        var mockApp = { init: function () { } };
+        clusterManager.initCluster({}, mockApp);
+
+        assert.equal(typeof mockEvents.exit, 'function');
+      })
+
+      it('should restart worker on exit', function () {
+        var mockApp = { init: function () { } };
+        var forkCount = 0;
+        var originalClusterFork = cluster.fork;
+
+        cluster.fork = function () {
+          forkCount++;
+          return originalClusterFork.call(this);
+        };
+
+        clusterManager.initCluster({ numOfCpus: 1 }, mockApp);
+
+        // Initial fork
+        assert.equal(forkCount, 1);
+
+        // Simulate worker exit
+        if (mockEvents.exit) {
+          mockEvents.exit(mockWorkers[0], 1, 'SIGTERM');
+          assert.equal(forkCount, 2); // Should fork replacement
+        }
+      })
+
+      it('should have all express method proxies', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster({}, mockApp);
+
+        var methods = ['get', 'post', 'put', 'delete', 'patch', 'use', 'set', 'engine', 'all'];
+        methods.forEach(function (method) {
+          assert.equal(typeof result[method], 'function');
+        });
+      })
+
+      it('should return chainable proxy methods', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster({}, mockApp);
+
+        var chainResult = result.get('/test', function () { });
+        assert.strictEqual(chainResult, result);
+
+        chainResult = result.use(function () { });
+        assert.strictEqual(chainResult, result);
+      })
+
+      it('should have listen method that returns itself', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster({}, mockApp);
+
+        var listenResult = result.listen(3000);
+        assert.strictEqual(listenResult, result);
+      })
+    })
+
+    describe('in worker process', function () {
+      beforeEach(function () {
+        cluster.isPrimary = false;
+      });
+
+      it('should return original app when in worker process', function () {
+        var mockApp = {
+          init: function () { },
+          listen: function () { },
+          get: function () { }
+        };
+
+        var result = clusterManager.initCluster({}, mockApp);
+        assert.strictEqual(result, mockApp);
+      })
+
+      it('should not fork workers in worker process', function () {
+        var forkCalled = false;
+        cluster.fork = function () {
+          forkCalled = true;
+        };
+
+        var mockApp = { init: function () { } };
+        clusterManager.initCluster({}, mockApp);
+
+        assert.equal(forkCalled, false);
+      })
+    })
+
+    describe('edge cases', function () {
+      beforeEach(function () {
+        cluster.isPrimary = true;
+        cluster.fork = function () {
+          return { process: { pid: 12345 } };
+        };
+        cluster.on = function () { };
+        os.cpus = function () {
+          return [{ model: 'CPU1' }];
+        };
+      });
+
+      it('should handle options without numOfCpus', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster({}, mockApp);
+
+        assert.equal(typeof result, 'object');
+        assert.equal(typeof result.listen, 'function');
+      })
+
+      it('should handle null options', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster(null, mockApp);
+
+        assert.equal(typeof result, 'object');
+      })
+
+      it('should handle undefined options', function () {
+        var mockApp = { init: function () { } };
+        var result = clusterManager.initCluster(undefined, mockApp);
+
+        assert.equal(typeof result, 'object');
+      })
+
+      it('should handle zero numOfCpus', function () {
+        var mockApp = { init: function () { } };
+        var forkCount = 0;
+
+        cluster.fork = function () {
+          forkCount++;
+          return { process: { pid: 12345 } };
+        };
+
+        clusterManager.initCluster({ numOfCpus: 0 }, mockApp);
+
+        // Should use os.cpus().length as fallback (which is 1 in our mock)
+        assert.equal(forkCount, 1);
+      })
+
+      it('should handle negative numOfCpus', function () {
+        var mockApp = { init: function () { } };
+        var forkCount = 0;
+
+        cluster.fork = function () {
+          forkCount++;
+          return { process: { pid: 12345 } };
+        };
+
+        clusterManager.initCluster({ numOfCpus: -1 }, mockApp);
+
+        // Should still use os.cpus().length as fallback (which is 1 in our mock)
+        assert.equal(forkCount, 1);
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add support for Express cluster mode initialization

Description
This PR adds native support for running Express applications in cluster mode by allowing users to pass configuration options when initializing Express. Users can now easily start their Express applications in cluster mode without manually setting up Node.js clustering.

When users initialize Express, they can now pass options like {cluster: true, numOfCpus: 3} to automatically start the application with multiple worker processes:



const express = require('express');
const app = express({cluster: true, numOfCpus: 3});

app.get('/', (req, res) => {
  res.send(`Hello from worker ${process.pid}`);
});

app.listen(3000);

Why I added this feature
As Express applications scale, developers often need to utilize all available CPU cores to handle increased traffic. Currently, developers have to manually implement clustering using Node's cluster module, which requires additional boilerplate code and can be error-prone.

This feature simplifies the process by providing a built-in solution that:

Improves application performance by utilizing multiple CPU cores
Increases reliability through automatic worker process replacement
Maintains the same simple API that Express users are familiar with
Requires minimal code changes to existing Express applications
The implementation maintains backward compatibility with existing Express applications while providing a clean, intuitive way to enable clustering when needed.

Implementation details
Added support for configuration options in the Express factory function
Created a cluster management module that handles worker processes
Implemented automatic worker replacement when a worker crashes
Maintained the Express API interface for both clustered and non-clustered modes
Added comprehensive tests and documentation
This feature makes Express more powerful out of the box for production applications by providing an elegant solution to a common scaling challenge.

Signed-off-by: AnkanSaha [ankansahadaluabari@gmail.com](mailto:ankansahadaluabari@gmail.com)