### PR TITLE
refactor: modernize View#lookup

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -98,28 +98,25 @@ function View(name, options) {
  * Lookup view by the given `name`
  *
  * @param {string} name
+ * @returns {(string|undefined)} The resolved absolute file path if found, otherwise `undefined`.
  * @private
  */
 
 View.prototype.lookup = function lookup(name) {
-  var path;
-  var roots = [].concat(this.root);
+  const roots = [].concat(this.root);
 
   debug('lookup "%s"', name);
 
-  for (var i = 0; i < roots.length && !path; i++) {
-    var root = roots[i];
+  for (const root of roots) {
+    const loc = resolve(root, name);
+    const dir = dirname(loc);
+    const file = basename(loc);
 
-    // resolve the path
-    var loc = resolve(root, name);
-    var dir = dirname(loc);
-    var file = basename(loc);
-
-    // resolve the file
-    path = this.resolve(dir, file);
+    const found = this.resolve(dir, file);
+    if (found) return found;
   }
 
-  return path;
+  return undefined;
 };
 
 /**


### PR DESCRIPTION
- Replace `var` loop with `for...of` for clarity and readability
- Use `const` instead of `var` to prevent accidental reassignment
- Introduce explicit `found` variable to avoid shadowing Node's `path` module
- Add JSDoc to clarify input and return type