### PR TITLE
enhancement: Added Block readme github action

### DIFF
--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -1,0 +1,34 @@
+name: Block README PRs
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  check-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Get list of changed files
+        id: changes
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} > changed_files.txt
+          cat changed_files.txt
+
+      - name: Block PR if README is changed
+        run: |
+          USER_PERMISSION="${{ github.event.pull_request.author_association }}"
+
+          if [[ "$USER_PERMISSION" == "OWNER" ]] || [[ "$USER_PERMISSION" == "MEMBER" ]] || [[ "$USER_PERMISSION" == "COLLABORATOR" ]]; then
+            echo "User has write access. Allowing PR."
+            exit 0
+          fi
+
+          # Check if only README.md was changed
+          if [ "$(wc -l < changed_files.txt)" -eq 1 ] && grep -q "^README.md$" changed_files.txt; then
+            echo "PR only changes README.md from external contributor. Blocking..."
+            exit 1
+          else
+            echo "PR modifies more than just README.md. Allowed."
+          fi

--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -2,32 +2,45 @@ name: Block README PRs
 on:
   pull_request:
     types: [opened, edited, synchronize]
+permissions:
+  pull-requests: write
+  contents: read
 jobs:
   check-readme:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
       - name: Get list of changed files
         id: changes
         run: |
           git fetch origin ${{ github.base_ref }}
           git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} > changed_files.txt
           cat changed_files.txt
-
       - name: Block PR if README is changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           USER_PERMISSION="${{ github.event.pull_request.author_association }}"
-
           if [[ "$USER_PERMISSION" == "OWNER" ]] || [[ "$USER_PERMISSION" == "MEMBER" ]] || [[ "$USER_PERMISSION" == "COLLABORATOR" ]]; then
             echo "User has write access. Allowing PR."
             exit 0
           fi
-
           # Check if only README.md was changed
           if [ "$(wc -l < changed_files.txt)" -eq 1 ] && grep -q "^Readme.md$" changed_files.txt; then
             echo "PR only changes README.md from external contributor. Blocking..."
+            gh pr comment ${{ github.event.pull_request.number }} --body "**This PR has been automatically closed.**
+
+          This PR only modifies the README file. We appreciate your interest in contributing, but we're currently not accepting README-only changes from external contributors.
+
+          If you'd like to contribute, please consider:
+          - Fixing bugs
+          - Adding new features
+          - Improving documentation beyond just the README
+          - Writing tests
+
+          Thank you for your understanding!"
+            gh pr close ${{ github.event.pull_request.number }}
             exit 1
           else
             echo "PR modifies more than just README.md. Allowed."

--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  issues: write
 jobs:
   check-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -1,6 +1,6 @@
 name: Block README PRs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 permissions:
   pull-requests: write
@@ -10,9 +10,10 @@ jobs:
   check-readme:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout PR
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Get list of changed files
@@ -24,14 +25,14 @@ jobs:
 
       - name: Block PR if README is changed
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           USER_PERMISSION="${{ github.event.pull_request.author_association }}"
           if [[ "$USER_PERMISSION" == "OWNER" ]] || [[ "$USER_PERMISSION" == "MEMBER" ]] || [[ "$USER_PERMISSION" == "COLLABORATOR" ]]; then
             echo "User has write access. Allowing PR."
             exit 0
           fi
-          # Check if only README.md was changed
+
           if [ "$(wc -l < changed_files.txt)" -eq 1 ] && grep -q "^Readme.md$" changed_files.txt; then
             echo "PR only changes README.md from external contributor. Blocking..."
             gh pr comment ${{ github.event.pull_request.number }} --body "**This PR has been automatically closed.**

--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
           # Check if only README.md was changed
-          if [ "$(wc -l < changed_files.txt)" -eq 1 ] && grep -q "^README.md$" changed_files.txt; then
+          if [ "$(wc -l < changed_files.txt)" -eq 1 ] && grep -q "^Readme.md$" changed_files.txt; then
             echo "PR only changes README.md from external contributor. Blocking..."
             exit 1
           else

--- a/.github/workflows/block-readme-prs.yml
+++ b/.github/workflows/block-readme-prs.yml
@@ -10,13 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Get list of changed files
         id: changes
         run: |
           git fetch origin ${{ github.base_ref }}
-          git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} > changed_files.txt
+          git diff --name-only origin/${{ github.base_ref }}..HEAD > changed_files.txt
           cat changed_files.txt
+
       - name: Block PR if README is changed
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Added block readme github action to block spam readme prs. Seeing it from a very long time spam pullrequests have been made and closed.
Thanks.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
