### PR TITLE
Automatically close PRs named "Update Readme.md" 

### DIFF
--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -7,6 +7,8 @@ jobs:
   check-pr-title:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Check PR title
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"

--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check PR title
         run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
           PR_TITLE_LC="$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')"
           if [ "$PR_TITLE_LC" = "update readme.md" ]; then
             echo "PR titled 'Update Readme.md' detected. Closing PR."

--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -15,7 +15,7 @@ jobs:
           PR_TITLE_LC="$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')"
           if [ "$PR_TITLE_LC" = "update readme.md" ]; then
             echo "PR titled 'Update Readme.md' detected. Closing PR."
-            gh pr comment ${{ github.event.pull_request.number }} --body "This PR titled 'Update Readme.md' is not allowed as it likely only adds trivial changes. Please review our contribution guidelines in CONTRIBUTING.md. Closing PR."
+            gh pr comment ${{ github.event.pull_request.number }} --body "This PR titled 'Update Readme.md' is not allowed as it likely only adds trivial changes. Please review our contribution guidelines. Closing PR."
             gh pr close ${{ github.event.pull_request.number }}
             exit 1
           fi

--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -2,7 +2,7 @@ name: Close Trivial README PRs
 on:
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -1,0 +1,20 @@
+name: Close Trivial README PRs
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if [ "$PR_TITLE" = "Update Readme.md" ]; then
+            echo "PR titled 'Update Readme.md' detected. Closing PR."
+            gh pr comment ${{ github.event.pull_request.number }} --body "This PR titled 'Update Readme.md' is not allowed as it likely only adds trivial changes. Please review our contribution guidelines in CONTRIBUTING.md. Closing PR."
+            gh pr close ${{ github.event.pull_request.number }}
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close_trivial_pr.yaml
+++ b/.github/workflows/close_trivial_pr.yaml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Check PR title
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          if [ "$PR_TITLE" = "Update Readme.md" ]; then
+          PR_TITLE_LC="$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')"
+          if [ "$PR_TITLE_LC" = "update readme.md" ]; then
             echo "PR titled 'Update Readme.md' detected. Closing PR."
             gh pr comment ${{ github.event.pull_request.number }} --body "This PR titled 'Update Readme.md' is not allowed as it likely only adds trivial changes. Please review our contribution guidelines in CONTRIBUTING.md. Closing PR."
             gh pr close ${{ github.event.pull_request.number }}


### PR DESCRIPTION
I don't use express JS but feel bad for the genuine contributors who have to close all the "Update Readme.md" spam that gets shoveled into their inbox.

I've noticed that 95% of the spam on this repo all have the same name "Update README.md", why not save the maintainers some time and automatically close them?

<img width="888" height="1008" alt="image" src="https://github.com/user-attachments/assets/323be2da-cc6b-427f-905d-141a853f2897" />


I've tested this locally, and my PR which was named "Update README.md" was automatically closed

Example PR on my fork: https://github.com/maximosnolan/express/pull/5

Don't want to overcomplicate it since all of the spam follows the same pattern. Suppose we can adapt when they learn how to change a PR title xd 

Do whatever you want with this, GL! 