### PR TITLE
enhancement: added script to auto block spam readme changes

### DIFF
--- a/.github/workflows/spam-readme.yml
+++ b/.github/workflows/spam-readme.yml
@@ -1,0 +1,58 @@
+name: Auto-close spam readme pr 
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-readme-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR files
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.author_association;
+
+            // Allow internal contributors,members.
+            if (["OWNER", "MEMBER", "COLLABORATOR"].includes(author)) {
+              console.log("Internal contributor — allow PR");
+              return;
+            }
+
+            // Get list of changed files
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            // Check if any file contains "readme.md" (case-insensitive)
+            const hasReadme = files.data.some(f => f.filename.toLowerCase().includes("readme.md"));
+
+            if (hasReadme) {
+              console.log("README.md change detected — closing PR");
+
+              // Comment on the PR
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: "🚫 **This PR changes README.md and will be closed automatically.**"
+              });
+
+              // Close the PR
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: "closed"
+              });
+            } else {
+              console.log("No README.md change — PR allowed");
+            }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Hey Express, 

I looked at #6805 and tried a slightly different way to do the GitHub Action.  
It does the same thing but is a bit safer and uses fewer permissions. 

Thanks!
