### PR TITLE
fix: log error cause chain in logerror function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,16 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') {
+    console.error(err.stack || err.toString());
+
+    // Log the error cause chain if present
+    let currentCause = err.cause;
+    while (currentCause) {
+      console.error('\nCaused by:', currentCause.stack || currentCause.toString());
+      currentCause = currentCause.cause;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #6462

## Problem
The `logerror` function in Express was only logging `err.stack`, which doesn't display the error `cause` property introduced in Node.js 16.9.0. This meant that error chains were not visible in logs, making debugging more difficult.

## Solution
Modified the `logerror()` function to explicitly log the complete error cause chain. When an error has a `cause`, it now logs each error in the chain with a "Caused by:" prefix for clarity.

## Changes
- Updated `lib/application.js` - `logerror()` function now iterates through the error cause chain
- Maintains backward compatibility - errors without `cause` work exactly as before
- All existing tests pass (1236 passing)

## Before
```
Error: Failed to fetch user data
    at ...
```

## After
```
Error: Failed to fetch user data
    at ...

Caused by: Error: Failed to execute query
    at ...

Caused by: Error: Database connection timeout
    at ...
```

## Testing
-  All existing tests pass (1236 passing)
-  Tested with error chains using Node.js Error.cause
-  Backward compatible with errors without cause
-  Requires Node.js 16.9.0+ for Error.cause support