### PR TITLE
Reduce README.md spam using automated checks

### DIFF
--- a/.github/workflows/reduce_readme_spam.yml
+++ b/.github/workflows/reduce_readme_spam.yml
@@ -32,11 +32,14 @@ jobs:
             const smallChange = nonEmpty < 3;
 
             if (readme && smallChange && !otherFiles) {
+              if (nonEmpty == 0) {
+                return
+              }
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body: "Closing automatically — only tiny README edits detected."
+                body: "Closing automatically — suspected as README.md spam (" + nonEmpty.toString() + " lines edited)."
               });
               await github.rest.pulls.update({
                 owner: context.repo.owner,

--- a/.github/workflows/reduce_readme_spam.yml
+++ b/.github/workflows/reduce_readme_spam.yml
@@ -1,0 +1,47 @@
+name: Reduce README.md spam
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number }
+            );
+
+            const readme = files.find(f => f.filename.toLowerCase().includes('readme.md'));
+            if (!readme) return; // no README.md -> keep open
+
+            const nonEmpty = (readme.patch || '')
+              .split('\n')
+              .filter(l => /^[+-]/.test(l) && l.trim().length > 1 && !/^\+\+\+|---/.test(l))
+              .length;
+
+            const otherFiles = files.length > 1;
+            const smallChange = nonEmpty < 3;
+
+            if (readme && smallChange && !otherFiles) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: "Closing automatically — only tiny README edits detected."
+              });
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: "closed"
+              });
+            }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR adds a new automated check (workflow) to close spam PRs automatically (the kind that just add one line to the README.md file and call it a day).
If a PR  fails to meet **atleast one** of the following criteria, it's automatically closed:
* Must not edit README.md at all (added empty lines doesn't count)
* Must change atleast 3 lines within the README.md (added empty lines don't count)
* Must edit atleast one other file

So, if someone edits README.md simply adding their name and opens a PR, that PR will get closed within seconds.

While the code is AI-generated, it has been manually reviewed and tested, and works as expected:
<img width="457" height="172" alt="{C333A0AC-B438-4286-8C6E-204E18036917}" src="https://github.com/user-attachments/assets/2c2c9e6c-535f-45fd-afd5-f379c452be72" />

###### Note: This should (as far as I'm aware), run automatically without maintainer approval, which is a good thing since its job is automating getting rid of spam PRs. If it doesn't run automatically without maintainer approval, please tell me how to fix it.