### PR TITLE
fix(res): handle null maxAge gracefully in res.cookie() and updated the dependency "cookie" to the 1.0.2 latest version

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -727,7 +727,7 @@ res.clearCookie = function clearCookie(name, options) {
  *
  * Options:
  *
- *    - `maxAge`   max-age in milliseconds, converted to `expires`
+ *    - `maxAge`   max-age in milliseconds (number), converted to `expires`
  *    - `signed`   sign the cookie
  *    - `path`     defaults to "/"
  *
@@ -763,12 +763,17 @@ res.cookie = function (name, value, options) {
     val = 's:' + sign(val, secret);
   }
 
-  if (opts.maxAge != null) {
-    var maxAge = opts.maxAge - 0
+  if (opts.maxAge === null) {
+    // Treat null as "unset" (session cookie)
+    opts.maxAge = undefined;
+  }
 
-    if (!isNaN(maxAge)) {
-      opts.expires = new Date(Date.now() + maxAge)
-      opts.maxAge = Math.floor(maxAge / 1000)
+  if (typeof opts.maxAge !== 'undefined') {
+    var maxAge = Number(opts.maxAge);
+
+    if (Number.isFinite(maxAge)) {
+      opts.expires = new Date(Date.now() + maxAge);
+      opts.maxAge = Math.floor(maxAge / 1000);
     }
   }
 
@@ -777,9 +782,10 @@ res.cookie = function (name, value, options) {
   }
 
   this.append('Set-Cookie', cookie.serialize(name, String(val), opts));
-
   return this;
 };
+
+
 
 /**
  * Set the location header to `url`.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "body-parser": "^2.2.0",
     "content-disposition": "^1.0.0",
     "content-type": "^1.0.5",
-    "cookie": "^0.7.1",
+    "cookie": "^1.0.2",
     "cookie-signature": "^1.2.1",
     "debug": "^4.4.0",
     "depd": "^2.0.0",


### PR DESCRIPTION
This pull request fixes an edge case in res.cookie() where specifying maxAge: null caused the function to produce incorrect cookie headers or throw an internal error when updated to 1.0.2

Previously, maxAge: null was not normalized and led to unintended conversion to 0, causing an undesired Expires header (Max-Age=0). This behavior conflicted with Express’s intended semantics, where null should mean “no expiration — session cookie”.

### Updated Behavior

When maxAge is explicitly null, it is now normalized to undefined.
The cookie is serialized without Expires or Max-Age fields (consistent with session cookies).
Existing logic for finite and numeric maxAge values remains unchanged.
All test cases, including res.cookie(name, string, options) maxAge should not throw on null, now pass successfully.

### Implementation Summary

In lib/response.js, the logic under res.cookie() was updated:
```
if (opts.maxAge === null) {
  opts.maxAge = undefined;
}
```

This ensures that null values are excluded from expiration logic.

###  Test Results

1) In cookie 1.0.2
Test:
```
  1238 passing (11s)
  0 failing
```
Version : 
```
npm list cookie
express@5.1.0 C:\Coding Project\Git\express
├─┬ cookie-parser@1.4.7
│ └── cookie@0.7.2
├── cookie@1.0.2
└─┬ express-session@1.18.2
  └── cookie@0.7.2
```

2) In cookie 0.7.2
Test: 
```
  1238 passing (11s)
```

Version: 
```
npm list cookie
express@5.1.0 C:\Coding Project\Git\express
├─┬ cookie-parser@1.4.7
│ └── cookie@0.7.2 deduped
├── cookie@0.7.2
└─┬ express-session@1.18.2
  └── cookie@0.7.2 deduped
```


### Motivation

This change improves compatibility with earlier Express 4.x behavior, aligns with the HTTP cookie specification for session cookies, and maintains backward compatibility with existing user code.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
