### PR TITLE
docs: update emeritus triagers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,7 +204,9 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
 
 ### Triagers
 
+* [aravindvnair99](https://github.com/aravindvnair99) - **Aravind Nair**
 * [bjohansebas](https://github.com/bjohansebas) - **Sebastian Beltran**
+* [carpasse](https://github.com/carpasse) - **Carlos Serrano**
 * [CBID2](https://github.com/CBID2) - **Christine Belzie**
 * [UlisesGascon](https://github.com/UlisesGascon) - **Ulises Gascón** (he/him)
 * [IamLizu](https://github.com/IamLizu) - **S M Mahmudul Hasan** (he/him)
@@ -248,9 +250,7 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
   * [dakshkhetan](https://github.com/dakshkhetan) - **Daksh Khetan** (he/him)
   * [lucasraziel](https://github.com/lucasraziel) - **Lucas Soares Do Rego**
   * [mertcanaltin](https://github.com/mertcanaltin) - **Mert Can Altin**
-  * [carpasse](https://github.com/carpasse) - **Carlos Serrano**
   * [dpopp07](https://github.com/dpopp07) - **Dustin Popp**
-  * [aravindvnair99](https://github.com/aravindvnair99) - **Aravind Nair**
   * [Sushmeet](https://github.com/Sushmeet) - **Sushmeet Sunger**
   * [3imed-jaberi](https://github.com/3imed-jaberi) - **Imed Jaberi**
 

--- a/Readme.md
+++ b/Readme.md
@@ -204,16 +204,11 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
 
 ### Triagers
 
-* [aravindvnair99](https://github.com/aravindvnair99) - **Aravind Nair**
 * [bjohansebas](https://github.com/bjohansebas) - **Sebastian Beltran**
-* [carpasse](https://github.com/carpasse) - **Carlos Serrano**
 * [CBID2](https://github.com/CBID2) - **Christine Belzie**
-* [dpopp07](https://github.com/dpopp07) - **Dustin Popp**
 * [UlisesGascon](https://github.com/UlisesGascon) - **Ulises Gascón** (he/him)
-* [3imed-jaberi](https://github.com/3imed-jaberi) - **Imed Jaberi**
 * [IamLizu](https://github.com/IamLizu) - **S M Mahmudul Hasan** (he/him)
 * [Phillip9587](https://github.com/Phillip9587) - **Phillip Barta**
-* [Sushmeet](https://github.com/Sushmeet) - **Sushmeet Sunger**
 * [rxmarbles](https://github.com/rxmarbles) **Rick Markins** (He/him)
 
 <details>
@@ -253,6 +248,11 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
   * [dakshkhetan](https://github.com/dakshkhetan) - **Daksh Khetan** (he/him)
   * [lucasraziel](https://github.com/lucasraziel) - **Lucas Soares Do Rego**
   * [mertcanaltin](https://github.com/mertcanaltin) - **Mert Can Altin**
+  * [carpasse](https://github.com/carpasse) - **Carlos Serrano**
+  * [dpopp07](https://github.com/dpopp07) - **Dustin Popp**
+  * [aravindvnair99](https://github.com/aravindvnair99) - **Aravind Nair**
+  * [Sushmeet](https://github.com/Sushmeet) - **Sushmeet Sunger**
+  * [3imed-jaberi](https://github.com/3imed-jaberi) - **Imed Jaberi**
 
 </details>
 


### PR DESCRIPTION
This validation was done manually, so please let me know if there is any error.

I don’t know when it will be released, but let’s keep this open for at least a week, and then a TC member will make the change since I can’t do it due to permission issues.

cc: @expressjs/triagers @expressjs/express-tc 

ref: https://github.com/expressjs/discussions/blob/master/docs/GOVERNANCE.md#inactivity-and-emeritus-policy-for-any-role, https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md#removal-of-triage-role