### PR TITLE
test: add test for req.host with comma-separated X-Forwarded-Host

### DIFF
--- a/test/req.host.js
+++ b/test/req.host.js
@@ -135,6 +135,22 @@ describe('req', function(){
           .expect('example.com', done);
         })
       })
+
+      it('should use first value when X-Forwarded-Host has comma', function (done) {
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function (req, res) {
+          res.end(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'localhost')
+        .set('X-Forwarded-Host', 'example.com, foobar.com')
+        .expect('example.com', done);
+      })
     })
 
     describe('when "trust proxy" is disabled', function(){


### PR DESCRIPTION
Add test to verify that req.host correctly handles comma-separated
values in X-Forwarded-Host header by using only the first value.
This ensures the behavior matches req.hostname and properly handles
edge cases when proxies send multiple host values