### PR TITLE
test: add test for ignoring comma-separated X-Forwarded-Host when trust proxy disabled

### DIFF
--- a/test/req.host.js
+++ b/test/req.host.js
@@ -151,6 +151,20 @@ describe('req', function(){
         .set('X-Forwarded-Host', 'evil')
         .expect('localhost', done);
       })
+
+      it('should ignore comma-separated X-Forwarded-Host', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'localhost')
+        .set('X-Forwarded-Host', 'example.com, foobar.com')
+        .expect('localhost', done);
+      })
     })
   })
 })


### PR DESCRIPTION
Verify that req.host ignores comma-separated X-Forwarded-Host values
when trust proxy is disabled, ensuring security by using Host header
instead of potentially malicious forwarded headers