### PR TITLE
test: add test for normalizeType fallback when mime lookup fails

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -35,8 +35,15 @@ describe('utils.normalizeType acceptParams method', () => {
       params: {} // No parameters are added since "invalid" has no "="
     });
   });
-});
 
+  it('should default to application/octet-stream when mime lookup fails', () => {
+    const result = utils.normalizeType('unknown-extension-xyz');
+    assert.deepEqual(result, {
+      value: 'application/octet-stream',
+      params: {}
+    });
+  });
+});
 
 describe('utils.setCharset(type, charset)', function () {
   it('should do anything without type', function () {


### PR DESCRIPTION
Add test to verify that utils.normalizeType correctly defaults to 'application/octet-stream' when mime.lookup() returns null/undefined for unknown file extensions. This covers the fallback behavior on line 64 of lib/utils.js and ensures proper handling of unrecognized MIME types