### PR TITLE
refactor: use cached slice in app.listen

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -597,7 +597,7 @@ app.render = function render(name, options, callback) {
 
 app.listen = function listen() {
   var server = http.createServer(this)
-  var args = Array.prototype.slice.call(arguments)
+  var args = slice.call(arguments)
   if (typeof args[args.length - 1] === 'function') {
     var done = args[args.length - 1] = once(args[args.length - 1])
     server.once('error', done)


### PR DESCRIPTION
Use the existing `slice` variable instead of `Array.prototype.slice` for consistency and to avoid repeated property lookups.

No behavior change. All tests pass. Linting clean.

Closes #6896
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
