### PR TITLE
fix: preserve case in setCharset

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -233,6 +233,10 @@ exports.setCharset = function setCharset(type, charset) {
   // set charset
   parsed.parameters.charset = charset;
 
+
+  var originalType = type.split(';')[0];
+  parsed.type = originalType;
+
   // format type
   return contentType.format(parsed);
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -58,6 +58,12 @@ describe('utils.setCharset(type, charset)', function () {
   it('should override charset', function () {
     assert.strictEqual(utils.setCharset('text/html; charset=iso-8859-1', 'utf-8'), 'text/html; charset=utf-8');
   });
+  it('should preserve original case of type', function(){
+    assert.strictEqual(
+      utils.setCharset('TEXT/PLAIN', 'UTF-8'),
+      'TEXT/PLAIN; charset=UTF-8'
+    )
+  });
 });
 
 describe('utils.wetag(body, encoding)', function(){


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
This change fixes an issue where `utils.setCharset` would incorrectly convert the content type to lowercase when adding a charset.

This PR preserves the original case of the content type, as discussed in the issue. It also includes a new test case to verify this behaviour.

Fixes #6613

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
