### PR TITLE
refactor: use cached slice reference in app.listen

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -597,7 +597,7 @@ app.render = function render(name, options, callback) {
 
 app.listen = function listen() {
   var server = http.createServer(this)
-  var args = Array.prototype.slice.call(arguments)
+  var args = slice.call(arguments)
   if (typeof args[args.length - 1] === 'function') {
     var done = args[args.length - 1] = once(args[args.length - 1])
     server.once('error', done)


### PR DESCRIPTION
## Description

This PR uses the already-defined `slice` reference instead of `Array.prototype.slice` in the `app.listen` implementation for consistency and micro-optimization.

## Changes

- Changed `Array.prototype.slice.call(arguments)` to `slice.call(arguments)` in `lib/application.js`

## Rationale

- Improves consistency within the file (uses the cached reference defined at line 33)
- Avoids repeated long-form prototype access
- Slight micro-optimization (cached function reference)
- No behavioral changes
- All tests continue to pass

## Testing

All existing tests pass (1236 passing, 2 pending), including all `app.listen()` tests.

Closes #6896