### PR TITLE
Release: 5.2.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 
 * Security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
 * deps: `body-parser@^2.2.1`
+* A deprecation warning was added when using `res.redirect` with undefined arguments, Express now emits a warning to help detect calls that pass undefined as the status or URL and make them easier to fix.
 
 5.1.0 / 2025-03-31
 ========================

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+5.2.0 / 2025-12-01
+========================
+  * Security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
+
 5.1.0 / 2025-03-31
 ========================
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express",
   "description": "Fast, unopinionated, minimalist web framework",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",


### PR DESCRIPTION
## Context

- Related to #6921
- It will include a security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))


## What's included in the `HISTORY.md`

```
5.2.0 / 2025-12-01
========================

* Security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
* deps: `body-parser@^2.2.1`
* A deprecation warning was added when using `res.redirect` with undefined arguments, Express now emits a warning to help detect calls that pass undefined as the status or URL and make them easier to fix.
```

## What's Changed
* build(deps): bump github/codeql-action from 3.28.11 to 3.28.13 by @dependabot[bot] in https://github.com/expressjs/express/pull/6429
* Refactor: simplify `acceptsLanguages` implementation using spread operator by @Ayoub-Mabrouk in https://github.com/expressjs/express/pull/6137
* increased code coverage of utils.js file by @ashish3011 in https://github.com/expressjs/express/pull/6386
* chore: remove duplicate word by @dufucun in https://github.com/expressjs/express/pull/6456
* build(deps): bump github/codeql-action from 3.28.13 to 3.28.16 by @dependabot[bot] in https://github.com/expressjs/express/pull/6498
* build(deps): bump actions/setup-node from 4.3.0 to 4.4.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6497
* build(deps): bump actions/download-artifact from 4.2.1 to 4.3.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6496
* ci: add node.js 24 to test matrix by @Phillip9587 in https://github.com/expressjs/express/pull/6504
* ci: update codeql config by @Phillip9587 in https://github.com/expressjs/express/pull/6488
* chore: wider range for query test skip by @jonchurch in https://github.com/expressjs/express/pull/6512
* chore: fix typos in test by @noritaka1166 in https://github.com/expressjs/express/pull/6535
* ci: disable credential persistence for checkout actions by @mertssmnoglu in https://github.com/expressjs/express/pull/6522
* ci: allow manual triggering of workflow by @shivarm in https://github.com/expressjs/express/pull/6515
* test: add coverage for app.listen() variants by @kgarg1 in https://github.com/expressjs/express/pull/6476
* docs: move documentation and charters to the discussions and .github … by @bjohansebas in https://github.com/expressjs/express/pull/6427
* build(deps): bump github/codeql-action from 3.28.16 to 3.28.18 by @dependabot[bot] in https://github.com/expressjs/express/pull/6549
* build(deps): bump ossf/scorecard-action from 2.4.1 to 2.4.2 by @dependabot[bot] in https://github.com/expressjs/express/pull/6548
* chore: enforce explicit `Buffer` import and add lint rule by @shivarm in https://github.com/expressjs/express/pull/6525
* chore: use node protocol for querystring by @shivarm in https://github.com/expressjs/express/pull/6520
* chore: fix typo by @mountdisk in https://github.com/expressjs/express/pull/6609
* build(deps): bump github/codeql-action from 3.28.18 to 3.29.2 by @dependabot[bot] in https://github.com/expressjs/express/pull/6618
* add deprecation warnings for redirect arguments undefined by @bjohansebas in https://github.com/expressjs/express/pull/6405
* ci: run CI when the markdown changes by @bjohansebas in https://github.com/expressjs/express/pull/6632
* doc: fix CONTRIBUTING link by @jonchurch in https://github.com/expressjs/express/pull/6653
* doc: update contributing guidelines and code of conduct links by @ShubhamOulkar in https://github.com/expressjs/express/pull/6601
* build(deps-dev): bump morgan from 1.10.0 to 1.10.1 by @dependabot[bot] in https://github.com/expressjs/express/pull/6679
* build(deps-dev): bump cookie-session from 2.1.0 to 2.1.1 by @dependabot[bot] in https://github.com/expressjs/express/pull/6678
* lint: add --fix flag to automatic fix linting issue by @shivarm in https://github.com/expressjs/express/pull/6644
* chore: ignore yarn.lock file and update example by @shivarm in https://github.com/expressjs/express/pull/6588
* lib: use req.socket over deprecated req.connection by @bjohansebas in https://github.com/expressjs/express/pull/6705
* doc: update express app example by @shivarm in https://github.com/expressjs/express/pull/6718
* build(deps): bump github/codeql-action from 3.29.2 to 3.29.5 by @dependabot[bot] in https://github.com/expressjs/express/pull/6675
* Remove history.md from being packaged on publish by @sheplu in https://github.com/expressjs/express/pull/6780
* build(deps): bump actions/checkout from 4.2.2 to 5.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6797
* build(deps): bump github/codeql-action from 3.29.7 to 3.30.5 by @dependabot[bot] in https://github.com/expressjs/express/pull/6796
* build(deps): bump ossf/scorecard-action from 2.4.2 to 2.4.3 by @dependabot[bot] in https://github.com/expressjs/express/pull/6795
* build(deps): bump actions/setup-node from 4.4.0 to 5.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6794
* build(deps): bump actions/download-artifact from 4.3.0 to 5.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6793
* ci: add node.js 25 to test matrix by @Phillip9587 in https://github.com/expressjs/express/pull/6843
* build(deps): bump actions/download-artifact from 5.0.0 to 6.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6871
* build(deps): bump actions/setup-node from 5.0.0 to 6.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6870
* build(deps): bump github/codeql-action from 3.30.5 to 4.31.2 by @dependabot[bot] in https://github.com/expressjs/express/pull/6869
* build(deps): bump actions/upload-artifact from 4.6.2 to 5.0.0 by @dependabot[bot] in https://github.com/expressjs/express/pull/6868
* chore: switch badges from badgen.net to shields.io by @Phillip9587 in https://github.com/expressjs/express/pull/6900
* refactor: use cached slice in app.listen by @Tacit1 in https://github.com/expressjs/express/pull/6897
* Nominate to @efekrskl for triage team by @bjohansebas in https://github.com/expressjs/express/pull/6888
* docs: update emeritus triagers by @bjohansebas in https://github.com/expressjs/express/pull/6890
* fix: upgrade body-parser to 2.2.1 to address CVE-2025-13466 by @shivarm in https://github.com/expressjs/express/pull/6922

## New Contributors
* @ashish3011 made their first contribution in https://github.com/expressjs/express/pull/6386
* @dufucun made their first contribution in https://github.com/expressjs/express/pull/6456
* @noritaka1166 made their first contribution in https://github.com/expressjs/express/pull/6535
* @mertssmnoglu made their first contribution in https://github.com/expressjs/express/pull/6522
* @shivarm made their first contribution in https://github.com/expressjs/express/pull/6515
* @kgarg1 made their first contribution in https://github.com/expressjs/express/pull/6476
* @mountdisk made their first contribution in https://github.com/expressjs/express/pull/6609
* @ShubhamOulkar made their first contribution in https://github.com/expressjs/express/pull/6601
* @sheplu made their first contribution in https://github.com/expressjs/express/pull/6780
* @Tacit1 made their first contribution in https://github.com/expressjs/express/pull/6897

**Full Changelog**: https://github.com/expressjs/express/compare/v5.1.0...master
