### PR TITLE
Release: 4.22.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
-UNRELEASED
+4.22.0 / 2025-12-01
 ==========
-
+  * Security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
   * deps: use tilde notation for dependencies
   * deps: qs@6.14.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express",
   "description": "Fast, unopinionated, minimalist web framework",
-  "version": "4.21.2",
+  "version": "4.22.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",


### PR DESCRIPTION
## Context

- Closes https://github.com/expressjs/express/pull/6907 (patch content is included in this minor)
- It will include a security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
- Related #6920

## What's included in the `HISTORY.md`

```
4.22.0 / 2025-12-01
==========

  * Security fix for [CVE-2024-51999](https://www.cve.org/CVERecord?id=CVE-2024-51999) ([GHSA-pj86-cfqh-vqx6](https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6))
  * deps: use tilde notation for dependencies
  * deps: qs@6.14.0
```

## What's Changed
* Refactor: improve readability by @sazk07 in https://github.com/expressjs/express/pull/6190
* ci: add support for Node.js@23.0 by @UlisesGascon in https://github.com/expressjs/express/pull/6080
* Method functions with no path should error by @wesleytodd in https://github.com/expressjs/express/pull/5957
* ci: updated github actions ci workflow by @Phillip9587 in https://github.com/expressjs/express/pull/6323
* ci: reorder `npm i` steps to fix ci for older node versions by @Phillip9587 in https://github.com/expressjs/express/pull/6336
* Backport: ci: add node.js 24 to test matrix by @Phillip9587 in https://github.com/expressjs/express/pull/6506
* chore(4.x): wider range for query test skip by @jonchurch in https://github.com/expressjs/express/pull/6513
* use tilde notation for certain dependencies by @UlisesGascon in https://github.com/expressjs/express/pull/6905
* deps: qs@6.14.0 by @UlisesGascon in https://github.com/expressjs/express/pull/6909


**Full Changelog**: https://github.com/expressjs/express/compare/4.21.2...4.x
