### PR TITLE
CVE-2024-10491 fix link header injection

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -91,7 +91,7 @@ res.links = function(links){
   var link = this.get('Link') || '';
   if (link) link += ', ';
   return this.set('Link', link + Object.keys(links).map(function(rel){
-    return '<' + links[rel] + '>; rel="' + rel + '"';
+    return '<' + links[rel].replace(/>/g, '%3E') + '>; rel="' + rel + '"';
   }).join(', '));
 };
 


### PR DESCRIPTION
Exploit example code:
https://www.herodevs.com/vulnerability-directory/cve-2024-10491?nes-for-express

Recomendation for uri-reference format:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link#uri-reference

Related Issue: https://github.com/expressjs/express/issues/6222