### PR TITLE
docs: fix JSDoc for req.accepts() return value and parameter format

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -6,35 +6,35 @@
  * MIT Licensed
  */
 
-"use strict";
+'use strict';
 
 /**
  * Module dependencies.
  * @private
  */
 
-var accepts = require("accepts");
-var isIP = require("node:net").isIP;
-var typeis = require("type-is");
-var http = require("node:http");
-var fresh = require("fresh");
-var parseRange = require("range-parser");
-var parse = require("parseurl");
-var proxyaddr = require("proxy-addr");
+var accepts = require('accepts');
+var isIP = require('node:net').isIP;
+var typeis = require('type-is');
+var http = require('node:http');
+var fresh = require('fresh');
+var parseRange = require('range-parser');
+var parse = require('parseurl');
+var proxyaddr = require('proxy-addr');
 
 /**
  * Request prototype.
  * @public
  */
 
-var req = Object.create(http.IncomingMessage.prototype);
+var req = Object.create(http.IncomingMessage.prototype)
 
 /**
  * Module exports.
  * @public
  */
 
-module.exports = req;
+module.exports = req
 
 /**
  * Return request header.
@@ -60,34 +60,39 @@ module.exports = req;
  * @public
  */
 
-req.get = req.header = function header(name) {
+req.get =
+req.header = function header(name) {
   if (!name) {
-    throw new TypeError("name argument is required to req.get");
+    throw new TypeError('name argument is required to req.get');
   }
 
-  if (typeof name !== "string") {
-    throw new TypeError("name must be a string to req.get");
+  if (typeof name !== 'string') {
+    throw new TypeError('name must be a string to req.get');
   }
 
   var lc = name.toLowerCase();
 
   switch (lc) {
-    case "referer":
-    case "referrer":
-      return this.headers.referrer || this.headers.referer;
+    case 'referer':
+    case 'referrer':
+      return this.headers.referrer
+        || this.headers.referer;
     default:
       return this.headers[lc];
   }
 };
 
 /**
+ * To do: update docs.
+ *
  * Check if the given `type(s)` is acceptable, returning
- * the best match when true, otherwise `false`, in which
+ * the best match when true, otherwise `undefined`, in which
  * case you should respond with 406 "Not Acceptable".
  *
  * The `type` value may be a single MIME type string
  * such as "application/json", an extension name
- * such as "json", an argument list such as `"json", "html", "text/plain"`,
+ * such as "json", a comma-delimited list such as "json, html, text/plain",
+ * an argument list such as `"json", "html", "text/plain"`,
  * or an array `["json", "html", "text/plain"]`. When a list
  * or array is given, the _best_ match, if any is returned.
  *
@@ -115,6 +120,7 @@ req.get = req.header = function header(name) {
  *     // Accept: text/*;q=.5, application/json
  *     req.accepts(['html', 'json']);
  *     req.accepts('html', 'json');
+ *     req.accepts('html, json');
  *     // => "json"
  *
  * @param {String|Array} type(s)
@@ -122,7 +128,7 @@ req.get = req.header = function header(name) {
  * @public
  */
 
-req.accepts = function () {
+req.accepts = function(){
   var accept = accepts(this);
   return accept.types.apply(accept, arguments);
 };
@@ -135,7 +141,7 @@ req.accepts = function () {
  * @public
  */
 
-req.acceptsEncodings = function () {
+req.acceptsEncodings = function(){
   var accept = accepts(this);
   return accept.encodings.apply(accept, arguments);
 };
@@ -149,7 +155,7 @@ req.acceptsEncodings = function () {
  * @public
  */
 
-req.acceptsCharsets = function () {
+req.acceptsCharsets = function(){
   var accept = accepts(this);
   return accept.charsets.apply(accept, arguments);
 };
@@ -163,7 +169,7 @@ req.acceptsCharsets = function () {
  * @public
  */
 
-req.acceptsLanguages = function (...languages) {
+req.acceptsLanguages = function(...languages) {
   return accepts(this).languages(...languages);
 };
 
@@ -193,7 +199,7 @@ req.acceptsLanguages = function (...languages) {
  */
 
 req.range = function range(size, options) {
-  var range = this.get("Range");
+  var range = this.get('Range');
   if (!range) return;
   return parseRange(size, range, options);
 };
@@ -208,8 +214,8 @@ req.range = function range(size, options) {
  * @api public
  */
 
-defineGetter(req, "query", function query() {
-  var queryparse = this.app.get("query parser fn");
+defineGetter(req, 'query', function query(){
+  var queryparse = this.app.get('query parser fn');
 
   if (!queryparse) {
     // parsing is disabled
@@ -275,9 +281,11 @@ req.is = function is(types) {
  * @public
  */
 
-defineGetter(req, "protocol", function protocol() {
-  var proto = this.socket.encrypted ? "https" : "http";
-  var trust = this.app.get("trust proxy fn");
+defineGetter(req, 'protocol', function protocol(){
+  var proto = this.socket.encrypted
+    ? 'https'
+    : 'http';
+  var trust = this.app.get('trust proxy fn');
 
   if (!trust(this.socket.remoteAddress, 0)) {
     return proto;
@@ -285,10 +293,12 @@ defineGetter(req, "protocol", function protocol() {
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  var header = this.get("X-Forwarded-Proto") || proto;
-  var index = header.indexOf(",");
+  var header = this.get('X-Forwarded-Proto') || proto
+  var index = header.indexOf(',')
 
-  return index !== -1 ? header.substring(0, index).trim() : header.trim();
+  return index !== -1
+    ? header.substring(0, index).trim()
+    : header.trim()
 });
 
 /**
@@ -300,8 +310,8 @@ defineGetter(req, "protocol", function protocol() {
  * @public
  */
 
-defineGetter(req, "secure", function secure() {
-  return this.protocol === "https";
+defineGetter(req, 'secure', function secure(){
+  return this.protocol === 'https';
 });
 
 /**
@@ -314,8 +324,8 @@ defineGetter(req, "secure", function secure() {
  * @public
  */
 
-defineGetter(req, "ip", function ip() {
-  var trust = this.app.get("trust proxy fn");
+defineGetter(req, 'ip', function ip(){
+  var trust = this.app.get('trust proxy fn');
   return proxyaddr(this, trust);
 });
 
@@ -331,15 +341,15 @@ defineGetter(req, "ip", function ip() {
  * @public
  */
 
-defineGetter(req, "ips", function ips() {
-  var trust = this.app.get("trust proxy fn");
+defineGetter(req, 'ips', function ips() {
+  var trust = this.app.get('trust proxy fn');
   var addrs = proxyaddr.all(this, trust);
 
   // reverse the order (to farthest -> closest)
   // and remove socket address
-  addrs.reverse().pop();
+  addrs.reverse().pop()
 
-  return addrs;
+  return addrs
 });
 
 /**
@@ -357,13 +367,15 @@ defineGetter(req, "ips", function ips() {
  * @public
  */
 
-defineGetter(req, "subdomains", function subdomains() {
+defineGetter(req, 'subdomains', function subdomains() {
   var hostname = this.hostname;
 
   if (!hostname) return [];
 
-  var offset = this.app.get("subdomain offset");
-  var subdomains = !isIP(hostname) ? hostname.split(".").reverse() : [hostname];
+  var offset = this.app.get('subdomain offset');
+  var subdomains = !isIP(hostname)
+    ? hostname.split('.').reverse()
+    : [hostname];
 
   return subdomains.slice(offset);
 });
@@ -375,7 +387,7 @@ defineGetter(req, "subdomains", function subdomains() {
  * @public
  */
 
-defineGetter(req, "path", function path() {
+defineGetter(req, 'path', function path() {
   return parse(this).pathname;
 });
 
@@ -390,16 +402,16 @@ defineGetter(req, "path", function path() {
  * @public
  */
 
-defineGetter(req, "host", function host() {
-  var trust = this.app.get("trust proxy fn");
-  var val = this.get("X-Forwarded-Host");
+defineGetter(req, 'host', function host(){
+  var trust = this.app.get('trust proxy fn');
+  var val = this.get('X-Forwarded-Host');
 
   if (!val || !trust(this.socket.remoteAddress, 0)) {
-    val = this.get("Host");
-  } else if (val.indexOf(",") !== -1) {
+    val = this.get('Host');
+  } else if (val.indexOf(',') !== -1) {
     // Note: X-Forwarded-Host is normally only ever a
     //       single value, but this is to be safe.
-    val = val.substring(0, val.indexOf(",")).trimRight();
+    val = val.substring(0, val.indexOf(',')).trimRight()
   }
 
   return val || undefined;
@@ -416,16 +428,20 @@ defineGetter(req, "host", function host() {
  * @api public
  */
 
-defineGetter(req, "hostname", function hostname() {
+defineGetter(req, 'hostname', function hostname(){
   var host = this.host;
 
   if (!host) return;
 
   // IPv6 literal support
-  var offset = host[0] === "[" ? host.indexOf("]") + 1 : 0;
-  var index = host.indexOf(":", offset);
+  var offset = host[0] === '['
+    ? host.indexOf(']') + 1
+    : 0;
+  var index = host.indexOf(':', offset);
 
-  return index !== -1 ? host.substring(0, index) : host;
+  return index !== -1
+    ? host.substring(0, index)
+    : host;
 });
 
 /**
@@ -437,20 +453,20 @@ defineGetter(req, "hostname", function hostname() {
  * @public
  */
 
-defineGetter(req, "fresh", function () {
+defineGetter(req, 'fresh', function(){
   var method = this.method;
-  var res = this.res;
-  var status = res.statusCode;
+  var res = this.res
+  var status = res.statusCode
 
   // GET or HEAD for weak freshness validation only
-  if ("GET" !== method && "HEAD" !== method) return false;
+  if ('GET' !== method && 'HEAD' !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
   if ((status >= 200 && status < 300) || 304 === status) {
     return fresh(this.headers, {
-      etag: res.get("ETag"),
-      "last-modified": res.get("Last-Modified"),
-    });
+      'etag': res.get('ETag'),
+      'last-modified': res.get('Last-Modified')
+    })
   }
 
   return false;
@@ -465,7 +481,7 @@ defineGetter(req, "fresh", function () {
  * @public
  */
 
-defineGetter(req, "stale", function stale() {
+defineGetter(req, 'stale', function stale(){
   return !this.fresh;
 });
 
@@ -476,9 +492,9 @@ defineGetter(req, "stale", function stale() {
  * @public
  */
 
-defineGetter(req, "xhr", function xhr() {
-  var val = this.get("X-Requested-With") || "";
-  return val.toLowerCase() === "xmlhttprequest";
+defineGetter(req, 'xhr', function xhr(){
+  var val = this.get('X-Requested-With') || '';
+  return val.toLowerCase() === 'xmlhttprequest';
 });
 
 /**
@@ -493,6 +509,6 @@ function defineGetter(obj, name, getter) {
   Object.defineProperty(obj, name, {
     configurable: true,
     enumerable: true,
-    get: getter,
+    get: getter
   });
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -83,16 +83,13 @@ req.header = function header(name) {
 };
 
 /**
- * To do: update docs.
- *
  * Check if the given `type(s)` is acceptable, returning
- * the best match when true, otherwise `undefined`, in which
+ * the best match when true, otherwise `false`, in which
  * case you should respond with 406 "Not Acceptable".
  *
  * The `type` value may be a single MIME type string
  * such as "application/json", an extension name
- * such as "json", a comma-delimited list such as "json, html, text/plain",
- * an argument list such as `"json", "html", "text/plain"`,
+ * such as "json", an argument list such as `"json", "html", "text/plain"`,
  * or an array `["json", "html", "text/plain"]`. When a list
  * or array is given, the _best_ match, if any is returned.
  *
@@ -120,7 +117,6 @@ req.header = function header(name) {
  *     // Accept: text/*;q=.5, application/json
  *     req.accepts(['html', 'json']);
  *     req.accepts('html', 'json');
- *     req.accepts('html, json');
  *     // => "json"
  *
  * @param {String|Array} type(s)

--- a/lib/request.js
+++ b/lib/request.js
@@ -6,35 +6,35 @@
  * MIT Licensed
  */
 
-'use strict';
+"use strict";
 
 /**
  * Module dependencies.
  * @private
  */
 
-var accepts = require('accepts');
-var isIP = require('node:net').isIP;
-var typeis = require('type-is');
-var http = require('node:http');
-var fresh = require('fresh');
-var parseRange = require('range-parser');
-var parse = require('parseurl');
-var proxyaddr = require('proxy-addr');
+var accepts = require("accepts");
+var isIP = require("node:net").isIP;
+var typeis = require("type-is");
+var http = require("node:http");
+var fresh = require("fresh");
+var parseRange = require("range-parser");
+var parse = require("parseurl");
+var proxyaddr = require("proxy-addr");
 
 /**
  * Request prototype.
  * @public
  */
 
-var req = Object.create(http.IncomingMessage.prototype)
+var req = Object.create(http.IncomingMessage.prototype);
 
 /**
  * Module exports.
  * @public
  */
 
-module.exports = req
+module.exports = req;
 
 /**
  * Return request header.
@@ -60,39 +60,34 @@ module.exports = req
  * @public
  */
 
-req.get =
-req.header = function header(name) {
+req.get = req.header = function header(name) {
   if (!name) {
-    throw new TypeError('name argument is required to req.get');
+    throw new TypeError("name argument is required to req.get");
   }
 
-  if (typeof name !== 'string') {
-    throw new TypeError('name must be a string to req.get');
+  if (typeof name !== "string") {
+    throw new TypeError("name must be a string to req.get");
   }
 
   var lc = name.toLowerCase();
 
   switch (lc) {
-    case 'referer':
-    case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
+    case "referer":
+    case "referrer":
+      return this.headers.referrer || this.headers.referer;
     default:
       return this.headers[lc];
   }
 };
 
 /**
- * To do: update docs.
- *
  * Check if the given `type(s)` is acceptable, returning
- * the best match when true, otherwise `undefined`, in which
+ * the best match when true, otherwise `false`, in which
  * case you should respond with 406 "Not Acceptable".
  *
  * The `type` value may be a single MIME type string
  * such as "application/json", an extension name
- * such as "json", a comma-delimited list such as "json, html, text/plain",
- * an argument list such as `"json", "html", "text/plain"`,
+ * such as "json", an argument list such as `"json", "html", "text/plain"`,
  * or an array `["json", "html", "text/plain"]`. When a list
  * or array is given, the _best_ match, if any is returned.
  *
@@ -120,7 +115,6 @@ req.header = function header(name) {
  *     // Accept: text/*;q=.5, application/json
  *     req.accepts(['html', 'json']);
  *     req.accepts('html', 'json');
- *     req.accepts('html, json');
  *     // => "json"
  *
  * @param {String|Array} type(s)
@@ -128,7 +122,7 @@ req.header = function header(name) {
  * @public
  */
 
-req.accepts = function(){
+req.accepts = function () {
   var accept = accepts(this);
   return accept.types.apply(accept, arguments);
 };
@@ -141,7 +135,7 @@ req.accepts = function(){
  * @public
  */
 
-req.acceptsEncodings = function(){
+req.acceptsEncodings = function () {
   var accept = accepts(this);
   return accept.encodings.apply(accept, arguments);
 };
@@ -155,7 +149,7 @@ req.acceptsEncodings = function(){
  * @public
  */
 
-req.acceptsCharsets = function(){
+req.acceptsCharsets = function () {
   var accept = accepts(this);
   return accept.charsets.apply(accept, arguments);
 };
@@ -169,7 +163,7 @@ req.acceptsCharsets = function(){
  * @public
  */
 
-req.acceptsLanguages = function(...languages) {
+req.acceptsLanguages = function (...languages) {
   return accepts(this).languages(...languages);
 };
 
@@ -199,7 +193,7 @@ req.acceptsLanguages = function(...languages) {
  */
 
 req.range = function range(size, options) {
-  var range = this.get('Range');
+  var range = this.get("Range");
   if (!range) return;
   return parseRange(size, range, options);
 };
@@ -214,8 +208,8 @@ req.range = function range(size, options) {
  * @api public
  */
 
-defineGetter(req, 'query', function query(){
-  var queryparse = this.app.get('query parser fn');
+defineGetter(req, "query", function query() {
+  var queryparse = this.app.get("query parser fn");
 
   if (!queryparse) {
     // parsing is disabled
@@ -281,11 +275,9 @@ req.is = function is(types) {
  * @public
  */
 
-defineGetter(req, 'protocol', function protocol(){
-  var proto = this.socket.encrypted
-    ? 'https'
-    : 'http';
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "protocol", function protocol() {
+  var proto = this.socket.encrypted ? "https" : "http";
+  var trust = this.app.get("trust proxy fn");
 
   if (!trust(this.socket.remoteAddress, 0)) {
     return proto;
@@ -293,12 +285,10 @@ defineGetter(req, 'protocol', function protocol(){
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  var header = this.get('X-Forwarded-Proto') || proto
-  var index = header.indexOf(',')
+  var header = this.get("X-Forwarded-Proto") || proto;
+  var index = header.indexOf(",");
 
-  return index !== -1
-    ? header.substring(0, index).trim()
-    : header.trim()
+  return index !== -1 ? header.substring(0, index).trim() : header.trim();
 });
 
 /**
@@ -310,8 +300,8 @@ defineGetter(req, 'protocol', function protocol(){
  * @public
  */
 
-defineGetter(req, 'secure', function secure(){
-  return this.protocol === 'https';
+defineGetter(req, "secure", function secure() {
+  return this.protocol === "https";
 });
 
 /**
@@ -324,8 +314,8 @@ defineGetter(req, 'secure', function secure(){
  * @public
  */
 
-defineGetter(req, 'ip', function ip(){
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "ip", function ip() {
+  var trust = this.app.get("trust proxy fn");
   return proxyaddr(this, trust);
 });
 
@@ -341,15 +331,15 @@ defineGetter(req, 'ip', function ip(){
  * @public
  */
 
-defineGetter(req, 'ips', function ips() {
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "ips", function ips() {
+  var trust = this.app.get("trust proxy fn");
   var addrs = proxyaddr.all(this, trust);
 
   // reverse the order (to farthest -> closest)
   // and remove socket address
-  addrs.reverse().pop()
+  addrs.reverse().pop();
 
-  return addrs
+  return addrs;
 });
 
 /**
@@ -367,15 +357,13 @@ defineGetter(req, 'ips', function ips() {
  * @public
  */
 
-defineGetter(req, 'subdomains', function subdomains() {
+defineGetter(req, "subdomains", function subdomains() {
   var hostname = this.hostname;
 
   if (!hostname) return [];
 
-  var offset = this.app.get('subdomain offset');
-  var subdomains = !isIP(hostname)
-    ? hostname.split('.').reverse()
-    : [hostname];
+  var offset = this.app.get("subdomain offset");
+  var subdomains = !isIP(hostname) ? hostname.split(".").reverse() : [hostname];
 
   return subdomains.slice(offset);
 });
@@ -387,7 +375,7 @@ defineGetter(req, 'subdomains', function subdomains() {
  * @public
  */
 
-defineGetter(req, 'path', function path() {
+defineGetter(req, "path", function path() {
   return parse(this).pathname;
 });
 
@@ -402,16 +390,16 @@ defineGetter(req, 'path', function path() {
  * @public
  */
 
-defineGetter(req, 'host', function host(){
-  var trust = this.app.get('trust proxy fn');
-  var val = this.get('X-Forwarded-Host');
+defineGetter(req, "host", function host() {
+  var trust = this.app.get("trust proxy fn");
+  var val = this.get("X-Forwarded-Host");
 
   if (!val || !trust(this.socket.remoteAddress, 0)) {
-    val = this.get('Host');
-  } else if (val.indexOf(',') !== -1) {
+    val = this.get("Host");
+  } else if (val.indexOf(",") !== -1) {
     // Note: X-Forwarded-Host is normally only ever a
     //       single value, but this is to be safe.
-    val = val.substring(0, val.indexOf(',')).trimRight()
+    val = val.substring(0, val.indexOf(",")).trimRight();
   }
 
   return val || undefined;
@@ -428,20 +416,16 @@ defineGetter(req, 'host', function host(){
  * @api public
  */
 
-defineGetter(req, 'hostname', function hostname(){
+defineGetter(req, "hostname", function hostname() {
   var host = this.host;
 
   if (!host) return;
 
   // IPv6 literal support
-  var offset = host[0] === '['
-    ? host.indexOf(']') + 1
-    : 0;
-  var index = host.indexOf(':', offset);
+  var offset = host[0] === "[" ? host.indexOf("]") + 1 : 0;
+  var index = host.indexOf(":", offset);
 
-  return index !== -1
-    ? host.substring(0, index)
-    : host;
+  return index !== -1 ? host.substring(0, index) : host;
 });
 
 /**
@@ -453,20 +437,20 @@ defineGetter(req, 'hostname', function hostname(){
  * @public
  */
 
-defineGetter(req, 'fresh', function(){
+defineGetter(req, "fresh", function () {
   var method = this.method;
-  var res = this.res
-  var status = res.statusCode
+  var res = this.res;
+  var status = res.statusCode;
 
   // GET or HEAD for weak freshness validation only
-  if ('GET' !== method && 'HEAD' !== method) return false;
+  if ("GET" !== method && "HEAD" !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
   if ((status >= 200 && status < 300) || 304 === status) {
     return fresh(this.headers, {
-      'etag': res.get('ETag'),
-      'last-modified': res.get('Last-Modified')
-    })
+      etag: res.get("ETag"),
+      "last-modified": res.get("Last-Modified"),
+    });
   }
 
   return false;
@@ -481,7 +465,7 @@ defineGetter(req, 'fresh', function(){
  * @public
  */
 
-defineGetter(req, 'stale', function stale(){
+defineGetter(req, "stale", function stale() {
   return !this.fresh;
 });
 
@@ -492,9 +476,9 @@ defineGetter(req, 'stale', function stale(){
  * @public
  */
 
-defineGetter(req, 'xhr', function xhr(){
-  var val = this.get('X-Requested-With') || '';
-  return val.toLowerCase() === 'xmlhttprequest';
+defineGetter(req, "xhr", function xhr() {
+  var val = this.get("X-Requested-With") || "";
+  return val.toLowerCase() === "xmlhttprequest";
 });
 
 /**
@@ -509,6 +493,6 @@ function defineGetter(obj, name, getter) {
   Object.defineProperty(obj, name, {
     configurable: true,
     enumerable: true,
-    get: getter
+    get: getter,
   });
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -104,7 +104,7 @@ req.header = function header(name) {
  *     // => "html"
  *     req.accepts('text/html');
  *     // => "text/html"
- *     req.accepts('json, text');
+ *     req.accepts('json', 'text');
  *     // => "json"
  *     req.accepts('application/json');
  *     // => "application/json"
@@ -112,7 +112,7 @@ req.header = function header(name) {
  *     // Accept: text/*, application/json
  *     req.accepts('image/png');
  *     req.accepts('png');
- *     // => undefined
+ *     // => false
  *
  *     // Accept: text/*;q=.5, application/json
  *     req.accepts(['html', 'json']);


### PR DESCRIPTION
## Description

This pull request updates the JSDoc for `req.accepts()` to correct two inaccuracies in the current documentation. These updates align the JSDoc with the behavior of the underlying npm package used by Express for content negotiation.

## What This PR Fixes

1. **Incorrect return value**  
   The existing JSDoc states that the method returns `undefined` when no acceptable type is found.  
   In reality, the underlying negotiation package returns **`false`**, and that is what Express exposes.

   **Supporting code (from the underlying `accepts` package):**
   ```js
   // returns the best match or false
   return type || false

2. **Comma-separated values are not supported**  
Some examples suggested that a comma-separated string (e.g., "json, text") is treated as multiple types.
The npm package does not parse comma-separated strings.
Only arrays or multiple arguments are supported.

   **Supporting code (from the same package):**
   ```js
    if (!Array.isArray(types)) {
      types = new Array(arguments.length);
      for (var i = 0; i < types.length; i++) {
        types[i] = arguments[i];
      }
    }
This shows that each argument is captured individually, and values are not split on commas.

**Why This Matters**

The old JSDoc can mislead developers when debugging Accept header behavior or relying on inline IntelliSense.
This PR corrects the documentation so it accurately reflects the behavior of the npm module Express depends on.

**Disclaimer**

The incorrect assumptions present in the old JSDoc also exist in the underlying npm package.
This PR updates only the Express documentation and does not modify or fix the dependency itself.