### PR TITLE
 Add Type Check for `acceptParams` Input

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,7 +87,9 @@ exports.normalizeTypes = function(types) {
  */
 
 function acceptParams (str) {
-  
+  if (typeof str !== 'string') {
+    throw new TypeError('Parameter must be a string');
+  }
   var length = str.length;
   var colonIndex = str.indexOf(';');
   var index = colonIndex === -1 ? length : colonIndex;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,6 +87,7 @@ exports.normalizeTypes = function(types) {
  */
 
 function acceptParams (str) {
+  
   var length = str.length;
   var colonIndex = str.indexOf(';');
   var index = colonIndex === -1 ? length : colonIndex;


### PR DESCRIPTION
## 📌 Pull Request: Add Type Check for `acceptParams` Input

### Summary
This PR adds a type check to the `acceptParams` function to ensure that the input is always a string. If a value of any other type is passed, the function will now immediately throw a `TypeError`. This prevents unexpected behavior downstream and provides a clearer, more immediate error message for developers.

### Changes
```js
// Validate input type at the start of the function
if (typeof str !== 'string') {
  throw new TypeError('Parameter must be a string');
}

// Existing logic of acceptParams continues here...
