### PR TITLE
fix(res): throw error when res.redirect(undefined) is called

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -839,6 +839,10 @@ res.redirect = function redirect(url) {
     deprecate('Status must be a number');
   }
 
+  if (!address || typeof address !== 'string') {
+    throw new TypeError('path argument is required to res.redirect');
+  }
+
   // Set location header
   address = this.location(address).get('Location');
 

--- a/test/res.redirect.undefined.js
+++ b/test/res.redirect.undefined.js
@@ -1,0 +1,64 @@
+'use strict'
+
+var express = require('..')
+var request = require('supertest')
+
+describe('res.redirect - Issue #6942', function () {
+  describe('when redirect argument is undefined', function () {
+    it('should throw a TypeError with correct message', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(undefined)
+      })
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name,
+          stack: err.stack
+        })
+      })
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type)
+          }
+          if (res.body.error !== 'path argument is required to res.redirect') {
+            throw new Error(
+              'Unexpected error message: ' + res.body.error
+            )
+          }
+          if (!res.body.stack) {
+            throw new Error('Expected error stack to be present')
+          }
+        })
+        .end(done)
+    })
+
+    it('should not send a Location header when redirect throws', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(undefined)
+      })
+
+      app.use(function (err, req, res, next) {
+        res.status(500).send('error')
+      })
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if ('location' in res.headers) {
+            throw new Error('Location header should not exist when redirect throws')
+          }
+        })
+        .end(done)
+    })
+  })
+})

--- a/test/res.redirect.undefined.js
+++ b/test/res.redirect.undefined.js
@@ -3,22 +3,24 @@
 var express = require('..')
 var request = require('supertest')
 
-describe('res.redirect - Issue #6942', function () {
-  describe('when redirect argument is undefined', function () {
-    it('should throw a TypeError with correct message', function (done) {
+describe('res.redirect - Issue #6941 / #6942', function () {
+  function jsonError(err, req, res, next) {
+    res.status(500).json({
+      error: err.message,
+      type: err.name,
+      stack: Boolean(err.stack)
+    })
+  }
+
+  describe('when url is undefined', function () {
+    it('should throw a TypeError', function (done) {
       var app = express()
 
       app.use(function (req, res) {
         res.redirect(undefined)
       })
 
-      app.use(function (err, req, res, next) {
-        res.status(500).json({
-          error: err.message,
-          type: err.name,
-          stack: err.stack
-        })
-      })
+      app.use(jsonError)
 
       request(app)
         .get('/')
@@ -28,9 +30,7 @@ describe('res.redirect - Issue #6942', function () {
             throw new Error('Expected TypeError, got ' + res.body.type)
           }
           if (res.body.error !== 'path argument is required to res.redirect') {
-            throw new Error(
-              'Unexpected error message: ' + res.body.error
-            )
+            throw new Error('Unexpected error message: ' + res.body.error)
           }
           if (!res.body.stack) {
             throw new Error('Expected error stack to be present')
@@ -39,7 +39,7 @@ describe('res.redirect - Issue #6942', function () {
         .end(done)
     })
 
-    it('should not send a Location header when redirect throws', function (done) {
+    it('should not send a Location header', function (done) {
       var app = express()
 
       app.use(function (req, res) {
@@ -54,6 +54,7 @@ describe('res.redirect - Issue #6942', function () {
         .get('/')
         .expect(500)
         .expect(function (res) {
+          // stronger than checking "undefined"
           if ('location' in res.headers) {
             throw new Error('Location header should not exist when redirect throws')
           }
@@ -61,4 +62,120 @@ describe('res.redirect - Issue #6942', function () {
         .end(done)
     })
   })
+
+  describe('when url is not a string', function () {
+    it('should throw a TypeError for null', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(null)
+      })
+
+      app.use(jsonError)
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError')
+          }
+        })
+        .end(done)
+    })
+
+    it('should throw a TypeError for number (when single argument)', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(123)
+      })
+
+      app.use(jsonError)
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError')
+          }
+        })
+        .end(done)
+    })
+
+    it('should throw a TypeError for object', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect({ url: '/home' })
+      })
+
+      app.use(jsonError)
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError')
+          }
+        })
+        .end(done)
+    })
+  })
+
+  describe('when status and url are provided', function () {
+    it('should throw a TypeError if url is undefined', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(301, undefined)
+      })
+
+      app.use(jsonError)
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError')
+          }
+          if (res.body.error !== 'path argument is required to res.redirect') {
+            throw new Error('Unexpected error message: ' + res.body.error)
+          }
+        })
+        .end(done)
+    })
+
+    it('should work correctly with valid status and url', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(301, '/new-location')
+      })
+
+      request(app)
+        .get('/')
+        .expect('Location', '/new-location')
+        .expect(301, done)
+    })
+  })
+
+  describe('valid redirects should still work', function () {
+    it('should redirect with a string url', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect('/home')
+      })
+
+      request(app)
+        .get('/')
+        .expect('Location', '/home')
+        .expect(302, done)
+    })
+  })
 })
+


### PR DESCRIPTION
Calling res.redirect(undefined) currently sends a 302 response with `Location: undefined`,
resulting in an invalid redirect header.

This PR throws a TypeError when the URL argument is missing, consistent with the deprecation
warning ("Provide a url argument") and prevents malformed headers.

Improved the redirect tests to match Express behavior more accurately:
- correct expected error message
- unified jsonError handler
- stronger Location header assertion
- stack presence check

The updated test suite does not change redirect behavior, but validates it more accurately and prevents future regressions.
Fixes #6941
