### PR TITLE
fix: throw TypeError for invalid url in res.redirect

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -827,12 +827,13 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
+  // Validate URL argument
+  if (address === undefined) {
+    throw new TypeError('url argument is required to res.redirect');
   }
 
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
+    throw new TypeError('url argument must be a string to res.redirect');
   }
 
   if (typeof status !== 'number') {

--- a/test/res.redirect.issue-6941.js
+++ b/test/res.redirect.issue-6941.js
@@ -1,0 +1,206 @@
+'use strict'
+
+var express = require('..');
+var request = require('supertest');
+
+describe('res.redirect - Issue #6941', function () {
+  describe('when url is undefined', function () {
+    it('should throw a TypeError', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(undefined);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+          if (res.body.error !== 'url argument is required to res.redirect') {
+            throw new Error('Unexpected error message: ' + res.body.error);
+          }
+        })
+        .end(done);
+    });
+
+    it('should not send Location: undefined header', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(undefined);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).send('error');
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.headers.location === 'undefined') {
+            throw new Error('Location header should not be "undefined"');
+          }
+        })
+        .end(done);
+    });
+  });
+
+  describe('when url is not a string', function () {
+    it('should throw a TypeError for null', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(null);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw a TypeError for number (when single argument)', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(123);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw a TypeError for object', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect({ url: '/home' });
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+  });
+
+  describe('when status and url are provided', function () {
+    it('should throw a TypeError if url is undefined', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(301, undefined);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+          if (res.body.error !== 'url argument is required to res.redirect') {
+            throw new Error('Unexpected error message: ' + res.body.error);
+          }
+        })
+        .end(done);
+    });
+
+    it('should work correctly with valid status and url', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect(301, '/new-location');
+      });
+
+      request(app)
+        .get('/')
+        .expect('Location', '/new-location')
+        .expect(301, done);
+    });
+  });
+
+  describe('valid redirects should still work', function () {
+    it('should redirect with a string url', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect('/home');
+      });
+
+      request(app)
+        .get('/')
+        .expect('Location', '/home')
+        .expect(302, done);
+    });
+
+    it('should redirect with empty string', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.redirect('');
+      });
+
+      request(app)
+        .get('/')
+        .expect('Location', '')
+        .expect(302, done);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6941

Previously, res.redirect(undefined) would send an invalid Location: undefined header. This change throws a TypeError when the url argument is undefined or not a string, aligning with the behavior of other Express methods like res.sendFile.

Changes:
- Throw TypeError when url is undefined
- Throw TypeError when url is not a string
- Add comprehensive tests for invalid url handling

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->