### PR TITLE
fix: prevent crash when BigInt passed to res.status()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -64,11 +64,11 @@ module.exports = res
 res.status = function status(code) {
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
-    throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
+    throw new TypeError(`Invalid status code: ${code} (type: ${typeof code}). Status code must be an integer.`);
   }
   // Check if the status code is outside of Node's valid range
   if (code < 100 || code > 999) {
-    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than 1000.`);
+    throw new RangeError(`Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.`);
   }
 
   this.statusCode = code;

--- a/lib/response.js
+++ b/lib/response.js
@@ -64,11 +64,17 @@ module.exports = res
 res.status = function status(code) {
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
-    throw new TypeError(`Invalid status code: ${code} (type: ${typeof code}). Status code must be an integer.`);
+    // Use Object.prototype.toString to safely convert any value to string
+    // This handles edge cases like Object.create(null) which has no toString method
+    var codeStr = typeof code === 'object' && code !== null
+      ? Object.prototype.toString.call(code)
+      : String(code);
+    var codeType = typeof code;
+    throw new TypeError('Invalid status code: ' + codeStr + ' (type: ' + codeType + '). Status code must be an integer.');
   }
   // Check if the status code is outside of Node's valid range
   if (code < 100 || code > 999) {
-    throw new RangeError(`Invalid status code: ${code}. Status code must be greater than 99 and less than 1000.`);
+    throw new RangeError('Invalid status code: ' + code + '. Status code must be greater than 99 and less than 1000.');
   }
 
   this.statusCode = code;

--- a/test/issue-6756.js
+++ b/test/issue-6756.js
@@ -1,0 +1,68 @@
+var express = require("..");
+var request = require("supertest");
+var assert = require("assert");
+
+describe("Issue #6756: BigInt status code", function () {
+  it("should throw a helpful TypeError when passing a BigInt to res.sendStatus", function (done) {
+    var app = express();
+
+    app.use(function (req, res) {
+      try {
+        res.sendStatus(200n);
+      } catch (err) {
+        res.send(err.message);
+      }
+    });
+
+    request(app)
+      .get("/")
+      .expect(200)
+      .expect(function (res) {
+        assert.match(res.text, /Invalid status code/);
+        assert.match(res.text, /bigint/);
+      })
+      .end(done);
+  });
+
+  it("should throw a helpful TypeError when passing a BigInt to res.status", function (done) {
+    var app = express();
+
+    app.use(function (req, res) {
+      try {
+        res.status(200n).send("ok");
+      } catch (err) {
+        res.send(err.message);
+      }
+    });
+
+    request(app)
+      .get("/")
+      .expect(200)
+      .expect(function (res) {
+        assert.match(res.text, /Invalid status code/);
+        assert.match(res.text, /bigint/);
+      })
+      .end(done);
+  });
+
+  it("should throw a helpful TypeError when passing Object.create(null) to res.status", function (done) {
+    var app = express();
+
+    app.use(function (req, res) {
+      try {
+        res.status(Object.create(null)).send("ok");
+      } catch (err) {
+        res.send(err.message);
+      }
+    });
+
+    request(app)
+      .get("/")
+      .expect(200)
+      .expect(function (res) {
+        assert.match(res.text, /Invalid status code/);
+        assert.match(res.text, /object/);
+      })
+      .end(done);
+  });
+});

--- a/test/res.status.issue-6756.js
+++ b/test/res.status.issue-6756.js
@@ -1,0 +1,241 @@
+'use strict'
+
+var express = require('..');
+var request = require('supertest');
+
+describe('res.status - Issue #6756', function () {
+  describe('when status code is a BigInt', function () {
+    it('should throw a TypeError with a meaningful message', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(200n);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+          if (!res.body.error.includes('200')) {
+            throw new Error('Error message should include the value: ' + res.body.error);
+          }
+          if (!res.body.error.includes('bigint')) {
+            throw new Error('Error message should include the type: ' + res.body.error);
+          }
+        })
+        .end(done);
+    });
+
+    it('should not crash with uncaught exception', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.sendStatus(200n);
+      });
+
+      app.use(function (err, req, res, next) {
+        // Error was caught properly, not an uncaught exception
+        res.status(500).send('caught');
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect('caught')
+        .end(done);
+    });
+  });
+
+  describe('when status code is invalid type', function () {
+    it('should throw TypeError for string', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status('200');
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw TypeError for null', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(null);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw TypeError for undefined', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(undefined);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw TypeError for float', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(200.5);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'TypeError') {
+            throw new Error('Expected TypeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+  });
+
+  describe('when status code is out of range', function () {
+    it('should throw RangeError for code < 100', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(99);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'RangeError') {
+            throw new Error('Expected RangeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+
+    it('should throw RangeError for code > 999', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(1000);
+      });
+
+      app.use(function (err, req, res, next) {
+        res.status(500).json({
+          error: err.message,
+          type: err.name
+        });
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .expect(function (res) {
+          if (res.body.type !== 'RangeError') {
+            throw new Error('Expected RangeError, got ' + res.body.type);
+          }
+        })
+        .end(done);
+    });
+  });
+
+  describe('valid status codes should still work', function () {
+    it('should accept valid integer status code', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.status(201).send('created');
+      });
+
+      request(app)
+        .get('/')
+        .expect(201)
+        .expect('created')
+        .end(done);
+    });
+
+    it('should work with sendStatus', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.sendStatus(204);
+      });
+
+      request(app)
+        .get('/')
+        .expect(204)
+        .end(done);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6756

Previously, passing a BigInt to res.status() would cause an uncaught TypeError because JSON.stringify() cannot serialize BigInt values. The error occurred when trying to create the error message.

Changes:
- Replace JSON.stringify(code) with template literal and typeof
- Error message now shows both the value and its type
- Add comprehensive tests for BigInt and other invalid types

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
