### PR TITLE
test: add failing test case for res.redirect(undefined) ref #6941

### DIFF
--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -211,4 +211,20 @@ describe('res', function(){
         .end(done)
     })
   })
+
+  // Wisp-xd: Added this test case to reproduce Issue #6941
+  describe('when redirecting to undefined', function () {
+    it('should error when redirecting to undefined', function (done) {
+      var app = express();
+  
+      app.use(function (req, res) {
+        res.redirect(undefined);
+      });
+  
+      request(app)
+        .get('/')
+        .expect(500, done); 
+    });
+  });
+
 })


### PR DESCRIPTION
This PR adds a test case to reproduce the issue described in #6941.

When passing `undefined` to `res.redirect()`:
1. It prints a `express deprecated` warning to the console.
2. But it **still sends a 302 response** with an invalid `Location: undefined` header, instead of throwing an error.

This test expects a `500` error, so it currently **FAILS**, confirming the unexpected behavior.

Ref: #6941