### PR TITLE
feat: add native .env file loading support

### DIFF
--- a/examples/env-variables/.env
+++ b/examples/env-variables/.env
@@ -1,0 +1,12 @@
+# Application Configuration
+APP_NAME=Express Env Example
+APP_ENV=development
+
+# Server Configuration
+PORT=5000
+DEBUG=true
+
+# API Configuration
+API_URL=https://api.example.com
+MAX_ITEMS=100
+

--- a/examples/env-variables/index.js
+++ b/examples/env-variables/index.js
@@ -1,0 +1,105 @@
+'use strict'
+
+/**
+ * Module dependencies.
+ */
+
+var express = require('../../');
+
+// Automatically loads .env, .env.[NODE_ENV], and .env.local
+
+// Option 1: Simple load
+express.loadEnv();
+
+// Option 2: Load with file watching
+// Uncomment below to enable automatic reloading when .env files change
+/*
+ const unwatch = express.loadEnv({
+  watch: true,
+  onChange: (changed, loaded) => {
+    console.log('Environment variables changed:', changed);
+  },
+  onError: (err) => {
+    console.error('Error reloading .env:', err.message);
+  }
+});
+
+// Cleanup on shutdown
+process.on('SIGINT', () => {
+  unwatch();
+  process.exit();
+});
+
+*/
+
+var app = module.exports = express();
+var logger = require('morgan');
+
+// custom log format
+if (process.env.NODE_ENV !== 'test') app.use(logger(':method :url'))
+
+app.get('/', function(req, res){
+  var nodeEnv = process.env.NODE_ENV || 'development';
+  res.send('<h1>Environment Variables Example</h1>'
+    + '<p>This example demonstrates how to use Express built-in .env file loading.</p>'
+    + '<p><strong>Current Environment:</strong> ' + nodeEnv + '</p>'
+    + '<ul>'
+    + '<li><a href="/env">View loaded environment variables</a></li>'
+    + '<li><a href="/config">View application configuration</a></li>'
+    + '</ul>'
+    + '<hr>'
+    + '<p><strong>Features:</strong></p>'
+    + '<ul>'
+    + '<li>Automatically loads .env, .env.[NODE_ENV], and .env.local files</li>'
+    + '<li>Optional file watching for automatic reloads (see source code)</li>'
+    + '<li>Environment-specific configuration</li>'
+    + '<li>Cascading values with .env.local overrides</li>'
+    + '</ul>'
+    + '<hr>'
+    + '<p><strong>Try running with different environments:</strong></p>'
+    + '<pre>NODE_ENV=development node index.js\nNODE_ENV=production node index.js</pre>'
+    + '<p><strong>Enable watch mode:</strong> Uncomment the watch example in index.js and modify your .env file to see live updates!</p>');
+});
+
+app.get('/env', function(req, res){
+  // Display some environment variables
+  var safeEnvVars = {
+    APP_NAME: process.env.APP_NAME,
+    APP_ENV: process.env.APP_ENV,
+    PORT: process.env.PORT,
+    DEBUG: process.env.DEBUG,
+    API_URL: process.env.API_URL,
+    MAX_ITEMS: process.env.MAX_ITEMS
+  };
+
+  res.send('<h1>Environment Variables</h1>'
+    + '<p>The following variables were loaded from .env file:</p>'
+    + '<pre>' + JSON.stringify(safeEnvVars, null, 2) + '</pre>'
+    + '<p><a href="/">Back to home</a></p>');
+});
+
+app.get('/config', function(req, res){
+  // Use environment variables for configuration
+  var config = {
+    appName: process.env.APP_NAME,
+    environment: process.env.APP_ENV,
+    port: process.env.PORT || 3000,
+    debug: process.env.DEBUG === 'true',
+    apiUrl: process.env.API_URL,
+    maxItems: parseInt(process.env.MAX_ITEMS) || 10
+  };
+
+  res.send('<h1>Application Configuration</h1>'
+    + '<p>Configuration built from environment variables:</p>'
+    + '<pre>' + JSON.stringify(config, null, 2) + '</pre>'
+    + '<p><a href="/">Back to home</a></p>');
+});
+
+/* istanbul ignore next */
+if (!module.parent) {
+  var port = process.env.PORT || 3000;
+  app.listen(port);
+  console.log('Express started on port ' + port);
+  console.log('App Name: ' + (process.env.APP_NAME || 'Not set'));
+  console.log('Environment: ' + (process.env.APP_ENV || 'Not set'));
+}

--- a/lib/express.js
+++ b/lib/express.js
@@ -79,3 +79,9 @@ exports.raw = bodyParser.raw
 exports.static = require('serve-static');
 exports.text = bodyParser.text
 exports.urlencoded = bodyParser.urlencoded
+
+/**
+ * Expose utilities.
+ */
+
+exports.loadEnv = require('./utils').loadEnv;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,8 @@ var proxyaddr = require('proxy-addr');
 var qs = require('qs');
 var querystring = require('node:querystring');
 const { Buffer } = require('node:buffer');
+const fs = require('node:fs');
+const path = require('node:path');
 
 
 /**
@@ -268,4 +270,277 @@ function parseExtendedQueryString(str) {
   return qs.parse(str, {
     allowPrototypes: true
   });
+}
+
+/**
+ * Load environment variables from .env file
+ *
+ * @param {String|Object} [envPath]
+ * @param {Object} [options]
+ * @param {Boolean} [options.override]
+ * @param {String} [options.env]
+ * @param {Boolean} [options.cascade]
+ * @param {Boolean} [options.watch]
+ * @param {Function} [options.onChange]
+ * @param {Function} [options.onError]
+ * @return {Object|Function}
+ * @api private
+ */
+
+exports.loadEnv = function loadEnv(envPath, options) {
+
+  if (typeof envPath === 'object' && envPath !== null && !Array.isArray(envPath)) {
+    options = envPath;
+    envPath = undefined;
+  }
+
+  options = options || {};
+  const override = options.override === true;
+  const cascade = options.cascade !== false; // Default to true
+  const nodeEnv = options.env || process.env.NODE_ENV;
+
+  var filesToLoad = [];
+  var baseDir = process.cwd();
+
+  // If specific path provided, use it
+  if (envPath) {
+    filesToLoad.push(path.resolve(envPath));
+  } else {
+    // Default behavior: load .env and optionally .env.[NODE_ENV]
+    var baseEnvPath = path.resolve(baseDir, '.env');
+
+    if (cascade) {
+      // Load .env first, then .env.[environment]
+      filesToLoad.push(baseEnvPath);
+
+      if (nodeEnv) {
+        filesToLoad.push(path.resolve(baseDir, '.env.' + nodeEnv));
+      }
+    } else if (nodeEnv) {
+      // Only load .env.[environment]
+      filesToLoad.push(path.resolve(baseDir, '.env.' + nodeEnv));
+    } else {
+      // Only load .env
+      filesToLoad.push(baseEnvPath);
+    }
+
+    // Always try to load .env.local (for local overrides)
+    var localEnvPath = path.resolve(baseDir, '.env.local');
+    if (filesToLoad.indexOf(localEnvPath) === -1) {
+      filesToLoad.push(localEnvPath);
+    }
+  }
+
+  var allParsed = {};
+  var loadedFiles = [];
+
+  // Load files in order
+  for (var i = 0; i < filesToLoad.length; i++) {
+    var filePath = filesToLoad[i];
+
+    if (!fs.existsSync(filePath)) {
+      continue;
+    }
+
+    try {
+      var content = fs.readFileSync(filePath, 'utf8');
+      var parsed = parseEnvFile(content);
+
+      // Merge parsed values
+      Object.keys(parsed).forEach(function(key) {
+        // Later files can override earlier ones in cascade mode
+        if (!allParsed.hasOwnProperty(key) || cascade) {
+          allParsed[key] = parsed[key];
+        }
+      });
+
+      loadedFiles.push(filePath);
+    } catch (err) {
+      throw new Error('Failed to load .env file (' + filePath + '): ' + err.message);
+    }
+  }
+
+  // Set environment variables
+  Object.keys(allParsed).forEach(function(key) {
+    if (override || !process.env.hasOwnProperty(key)) {
+      process.env[key] = allParsed[key];
+    }
+  });
+
+  // Add metadata about loaded files
+  allParsed._loaded = loadedFiles;
+
+  // If watch option is enabled, set up file watchers
+  if (options.watch === true) {
+    var previousValues = {};
+    var watchers = [];
+    var isReloading = false;
+
+    // Store current values (exclude metadata)
+    Object.keys(allParsed).forEach(function(key) {
+      if (key !== '_loaded') {
+        previousValues[key] = allParsed[key];
+      }
+    });
+
+    // Watch each loaded file
+    loadedFiles.forEach(function(filePath) {
+      try {
+        var watcher = fs.watch(filePath, function(eventType) {
+          if (eventType === 'change' && !isReloading) {
+            isReloading = true;
+
+            // Small delay to ensure file is fully written
+            setTimeout(function() {
+              try {
+                // Reload with override to update existing values
+                var reloaded = exports.loadEnv(envPath, Object.assign({}, options, {
+                  override: true,
+                  watch: false // Prevent recursive watching
+                }));
+
+                // Detect what changed
+                var changed = {};
+                var currentValues = {};
+
+                Object.keys(reloaded).forEach(function(key) {
+                  if (key !== '_loaded') {
+                    currentValues[key] = reloaded[key];
+
+                    // Check if value changed
+                    if (!previousValues.hasOwnProperty(key)) {
+                      changed[key] = { type: 'added', value: reloaded[key] };
+                    } else if (previousValues[key] !== reloaded[key]) {
+                      changed[key] = {
+                        type: 'modified',
+                        oldValue: previousValues[key],
+                        newValue: reloaded[key]
+                      };
+                    }
+                  }
+                });
+
+                // Check for removed keys
+                Object.keys(previousValues).forEach(function(key) {
+                  if (!currentValues.hasOwnProperty(key)) {
+                    changed[key] = { type: 'removed', oldValue: previousValues[key] };
+                    // Remove from process.env if it was set by us
+                    if (process.env[key] === previousValues[key]) {
+                      delete process.env[key];
+                    }
+                  }
+                });
+
+                // Update previous values
+                previousValues = currentValues;
+
+                // Call onChange callback if there were changes
+                if (Object.keys(changed).length > 0 && typeof options.onChange === 'function') {
+                  options.onChange(changed, reloaded);
+                }
+
+              } catch (err) {
+                if (typeof options.onError === 'function') {
+                  options.onError(err);
+                }
+              } finally {
+                isReloading = false;
+              }
+            }, 100);
+          }
+        });
+
+        watchers.push(watcher);
+      } catch (err) {
+        // Silently ignore watch errors for individual files
+        if (typeof options.onError === 'function') {
+          options.onError(new Error('Failed to watch file: ' + filePath));
+        }
+      }
+    });
+
+    // Return unwatch function when watch is enabled
+    return function unwatch() {
+      watchers.forEach(function(watcher) {
+        try {
+          watcher.close();
+        } catch (err) {
+          // Ignore errors when closing watchers
+        }
+      });
+      watchers = [];
+    };
+  }
+
+  return allParsed;
+};
+
+
+
+/**
+ * Parse .env file content
+ *
+ * @param {String} content - Content of .env file
+ * @return {Object} Parsed key-value pairs
+ * @api private
+ */
+
+function parseEnvFile(content) {
+  const result = {};
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
+
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    if (line.startsWith('export ')) {
+      line = line.slice(7).trim();
+    }
+
+    // Handle multi-line values
+    while (line.endsWith('\\') && i < lines.length - 1) {
+      line = line.slice(0, -1) + lines[++i].trim();
+    }
+
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, equalsIndex).trim();
+    let value = line.slice(equalsIndex + 1).trim();
+
+    // Handle inline comments for unquoted values
+    if (!value.startsWith('"') && !value.startsWith("'")) {
+      const commentIndex = value.indexOf('#');
+      if (commentIndex !== -1) {
+        value = value.slice(0, commentIndex).trim();
+      }
+    }
+
+    // Remove quotes if present
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+      // Handle escaped characters in a single pass
+      value = value.replace(/\\(.)/g, function(match, char) {
+        switch (char) {
+          case 'n': return '\n';
+          case 'r': return '\r';
+          case 't': return '\t';
+          case '\\': return '\\';
+          case '"': return '"';
+          case "'": return "'";
+          default: return match;
+        }
+      });
+    }
+
+    result[key] = value;
+  }
+
+  return result;
 }

--- a/test/utils.loadEnv.js
+++ b/test/utils.loadEnv.js
@@ -1,0 +1,513 @@
+'use strict'
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+describe('utils.loadEnv()', function () {
+  var testDir;
+  var originalEnv;
+
+  beforeEach(function () {
+    // Create a temporary directory for test files
+    testDir = path.join(os.tmpdir(), 'express-env-test-' + Date.now());
+    fs.mkdirSync(testDir, { recursive: true });
+
+    // Backup original environment variables
+    originalEnv = Object.assign({}, process.env);
+  });
+
+  afterEach(function () {
+    // Restore original environment variables
+    Object.keys(process.env).forEach(function (key) {
+      if (!originalEnv.hasOwnProperty(key)) {
+        delete process.env[key];
+      }
+    });
+    Object.assign(process.env, originalEnv);
+
+    // Clean up test directory
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should load basic key-value pairs', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'KEY1=value1\nKEY2=value2');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.KEY1, 'value1');
+    assert.strictEqual(result.KEY2, 'value2');
+    assert.strictEqual(process.env.KEY1, 'value1');
+    assert.strictEqual(process.env.KEY2, 'value2');
+  });
+
+  it('should handle quoted values', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'QUOTED="double quotes"\nSINGLE=\'single quotes\'');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.QUOTED, 'double quotes');
+    assert.strictEqual(result.SINGLE, 'single quotes');
+  });
+
+  it('should handle escaped characters', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'ESCAPED="line1\\nline2\\ttab"');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.ESCAPED, 'line1\nline2\ttab');
+  });
+
+  it('should skip comments and empty lines', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, '# Comment\n\nKEY=value\n\n# Another comment');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.KEY, 'value');
+    assert.strictEqual(Object.keys(result).filter(k => k !== '_loaded').length, 1);
+  });
+
+  it('should handle multi-line values with backslash', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'MULTILINE=line1\\\nline2\\\nline3');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.MULTILINE, 'line1line2line3');
+  });
+
+  it('should handle values with equals signs', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'CONNECTION_STRING=server=localhost;user=admin');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.CONNECTION_STRING, 'server=localhost;user=admin');
+  });
+
+  it('should handle empty values', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'EMPTY=\nEMPTY_QUOTED=""');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.EMPTY, '');
+    assert.strictEqual(result.EMPTY_QUOTED, '');
+  });
+
+  it('should not override existing env vars by default', function () {
+    process.env.EXISTING = 'original';
+
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'EXISTING=new value');
+
+    var utils = require('../lib/utils');
+    utils.loadEnv(envPath);
+
+    assert.strictEqual(process.env.EXISTING, 'original');
+  });
+
+  it('should override existing env vars when override is true', function () {
+    process.env.EXISTING = 'original';
+
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'EXISTING=new value');
+
+    var utils = require('../lib/utils');
+    utils.loadEnv(envPath, { override: true });
+
+    assert.strictEqual(process.env.EXISTING, 'new value');
+  });
+
+  it('should return empty object if file does not exist', function () {
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(path.join(testDir, 'nonexistent.env'));
+
+    assert.strictEqual(Object.keys(result).filter(k => k !== '_loaded').length, 0);
+  });
+
+  it('should throw error on invalid file read', function () {
+    var utils = require('../lib/utils');
+
+    // Create a directory instead of a file to cause read error
+    var dirPath = path.join(testDir, 'invalid');
+    fs.mkdirSync(dirPath);
+
+    assert.throws(function () {
+      utils.loadEnv(dirPath);
+    }, /Failed to load \.env file/);
+  });
+
+  it('should handle whitespace around keys and values', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, '  KEY1  =  value1  \n\tKEY2\t=\tvalue2\t');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.KEY1, 'value1');
+    assert.strictEqual(result.KEY2, 'value2');
+  });
+
+  it('should handle special characters in values', function () {
+    var envPath = path.join(testDir, '.env');
+    fs.writeFileSync(envPath, 'SPECIAL="!@#$%^&*(){}[]|:;<>,.?/~`"');
+
+    var utils = require('../lib/utils');
+    var result = utils.loadEnv(envPath);
+
+    assert.strictEqual(result.SPECIAL, '!@#$%^&*(){}[]|:;<>,.?/~`');
+  });
+
+  it('should use .env in cwd when no path provided', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'DEFAULT_KEY=default_value');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv();
+
+      assert.strictEqual(result.DEFAULT_KEY, 'default_value');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should load environment-specific file (.env.production)', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env.production', 'ENV_TYPE=production\nDB_HOST=prod.db.com');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'production', cascade: false });
+
+      assert.strictEqual(result.ENV_TYPE, 'production');
+      assert.strictEqual(result.DB_HOST, 'prod.db.com');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should load environment-specific file (.env.development)', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env.development', 'ENV_TYPE=development\nDB_HOST=localhost');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'development', cascade: false });
+
+      assert.strictEqual(result.ENV_TYPE, 'development');
+      assert.strictEqual(result.DB_HOST, 'localhost');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should cascade .env then .env.[environment]', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'BASE_KEY=base\nOVERRIDE_KEY=base_value');
+      fs.writeFileSync('.env.production', 'PROD_KEY=prod\nOVERRIDE_KEY=prod_value');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'production' });
+
+      assert.strictEqual(result.BASE_KEY, 'base');
+      assert.strictEqual(result.PROD_KEY, 'prod');
+      assert.strictEqual(result.OVERRIDE_KEY, 'prod_value'); // Should be overridden
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should load .env.local for local overrides', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'KEY1=base');
+      fs.writeFileSync('.env.production', 'KEY2=prod');
+      fs.writeFileSync('.env.local', 'KEY1=local\nKEY3=local_only');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'production' });
+
+      assert.strictEqual(result.KEY1, 'local'); // Local overrides base
+      assert.strictEqual(result.KEY2, 'prod');
+      assert.strictEqual(result.KEY3, 'local_only');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should use NODE_ENV when env option not specified', function () {
+    var originalCwd = process.cwd();
+    var originalNodeEnv = process.env.NODE_ENV;
+
+    try {
+      process.env.NODE_ENV = 'staging';
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'BASE=value');
+      fs.writeFileSync('.env.staging', 'STAGING=value');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv();
+
+      assert.strictEqual(result.BASE, 'value');
+      assert.strictEqual(result.STAGING, 'value');
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should disable cascade when cascade option is false', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'BASE_KEY=base');
+      fs.writeFileSync('.env.test', 'TEST_KEY=test');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'test', cascade: false });
+
+      assert.strictEqual(result.TEST_KEY, 'test');
+      assert.strictEqual(result.BASE_KEY, undefined); // Should not load .env
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should return metadata about loaded files', function () {
+    var originalCwd = process.cwd();
+
+    try {
+      process.chdir(testDir);
+      fs.writeFileSync('.env', 'KEY=value');
+      fs.writeFileSync('.env.production', 'KEY2=value2');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv({ env: 'production' });
+
+      assert(Array.isArray(result._loaded));
+      assert(result._loaded.length >= 2);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  describe('watch functionality', function () {
+    it('should return unwatch function when watch is true', function () {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY1=value1');
+
+      var utils = require('../lib/utils');
+      var unwatch = utils.loadEnv(envPath, { watch: true });
+
+      assert.strictEqual(typeof unwatch, 'function');
+      unwatch();
+    });
+
+    it('should detect file changes and call onChange callback', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'WATCH_KEY=initial');
+
+      var utils = require('../lib/utils');
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onChange: function (changed, loaded) {
+          assert(changed.WATCH_KEY);
+          assert.strictEqual(changed.WATCH_KEY.type, 'modified');
+          assert.strictEqual(changed.WATCH_KEY.oldValue, 'initial');
+          assert.strictEqual(changed.WATCH_KEY.newValue, 'updated');
+          assert.strictEqual(loaded.WATCH_KEY, 'updated');
+          assert.strictEqual(process.env.WATCH_KEY, 'updated');
+
+          unwatch();
+          done();
+        }
+      });
+
+      // Give the watcher time to set up
+      setTimeout(function () {
+        fs.writeFileSync(envPath, 'WATCH_KEY=updated');
+      }, 150);
+    });
+
+    it('should detect added variables', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'EXISTING=value');
+
+      var utils = require('../lib/utils');
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onChange: function (changed) {
+          assert(changed.NEW_KEY);
+          assert.strictEqual(changed.NEW_KEY.type, 'added');
+          assert.strictEqual(changed.NEW_KEY.value, 'new_value');
+          assert.strictEqual(process.env.NEW_KEY, 'new_value');
+
+          unwatch();
+          done();
+        }
+      });
+
+      setTimeout(function () {
+        fs.writeFileSync(envPath, 'EXISTING=value\nNEW_KEY=new_value');
+      }, 150);
+    });
+
+    it('should detect removed variables', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY1=value1\nKEY2=value2');
+
+      var utils = require('../lib/utils');
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onChange: function (changed) {
+          assert(changed.KEY2);
+          assert.strictEqual(changed.KEY2.type, 'removed');
+          assert.strictEqual(changed.KEY2.oldValue, 'value2');
+          assert.strictEqual(process.env.KEY2, undefined);
+
+          unwatch();
+          done();
+        }
+      });
+
+      setTimeout(function () {
+        fs.writeFileSync(envPath, 'KEY1=value1');
+      }, 150);
+    });
+
+    it('should handle errors via onError callback', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY=value');
+
+      var utils = require('../lib/utils');
+      var errorCalled = false;
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onError: function (err) {
+          errorCalled = true;
+          assert(err instanceof Error);
+          unwatch();
+          done();
+        }
+      });
+
+      setTimeout(function () {
+        // Write invalid content that will cause a parsing issue
+        fs.writeFileSync(envPath, 'INVALID');
+
+        // If no error after another delay, pass anyway
+        setTimeout(function () {
+          if (!errorCalled) {
+            unwatch();
+            // This is actually expected - INVALID without = is just skipped
+            done();
+          }
+        }, 200);
+      }, 150);
+    });
+
+    it('should stop watching when unwatch is called', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY=initial');
+
+      var utils = require('../lib/utils');
+      var changeCount = 0;
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onChange: function () {
+          changeCount++;
+        }
+      });
+
+      setTimeout(function () {
+        // Verify no changes happened before unwatching
+        assert.strictEqual(changeCount, 0);
+        unwatch();
+
+        // Try to change file after unwatching
+        setTimeout(function () {
+          fs.writeFileSync(envPath, 'KEY=after_unwatch');
+
+          // Verify onChange was not called after unwatch
+          setTimeout(function () {
+            assert.strictEqual(changeCount, 0);
+            done();
+          }, 200);
+        }, 100);
+      }, 100);
+    });
+
+    it('should not create watchers when watch is false', function () {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY=value');
+
+      var utils = require('../lib/utils');
+      var result = utils.loadEnv(envPath, { watch: false });
+
+      assert.strictEqual(typeof result, 'object');
+      assert.strictEqual(typeof result.KEY, 'string');
+      assert.strictEqual(result.KEY, 'value');
+    });
+
+    it('should prevent recursive watching when reloading', function (done) {
+      var envPath = path.join(testDir, '.env');
+      fs.writeFileSync(envPath, 'KEY=initial');
+
+      var utils = require('../lib/utils');
+      var changeCount = 0;
+
+      var unwatch = utils.loadEnv(envPath, {
+        watch: true,
+        onChange: function (changed) {
+          changeCount++;
+
+          // Should only be called once despite the reload
+          assert.strictEqual(changeCount, 1);
+
+          setTimeout(function () {
+            assert.strictEqual(changeCount, 1);
+            unwatch();
+            done();
+          }, 200);
+        }
+      });
+
+      setTimeout(function () {
+        fs.writeFileSync(envPath, 'KEY=updated');
+      }, 150);
+    });
+  });
+});


### PR DESCRIPTION
Giving a try

This example demonstrates how to use Express's built-in environment variable loading from `.env` files.

## Automatically loads .env, .env.[NODE_ENV], and .env.local
```javascript
import express from "express";

express.loadEnv();
```

## Enable watch mode
```javascript
import express from 'express';

 
const unwatch = express.loadEnv({
  watch: true,
  onChange: (changed, loaded) => {
    console.log('Environment variables changed:', changed);
  },
  onError: (err) => {
    console.error('Error reloading .env:', err.message);
  }
});

// Cleanup on shutdown
process.on('SIGINT', () => {
  unwatch();
  process.exit();
});

```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
