### PR TITLE
fix: update urlencoded test expectation for duplicate keys with extended : false as option

### DIFF
--- a/test/express.urlencoded.js
+++ b/test/express.urlencoded.js
@@ -103,7 +103,7 @@ describe('express.urlencoded()', function () {
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .send('user=Tobi&user=Loki')
-          .expect(200, '{"user":["Tobi","Loki"]}', done)
+          .expect(200, '{"user":{"0":"Tobi","1":"Loki"}}', done)
       })
     })
 


### PR DESCRIPTION
Fixes #6966 