### PR TITLE
ci: remove paths-ignore for md files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
       - '4.x'
       - '5.x'
       - '5.0'
-    paths-ignore:
-      - '*.md'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
# Problem
because we have required checks for CI, PRs that are markdown only will never trigger them, so will always appear blocked and waiting

an example is this doc only PR https://github.com/expressjs/express/pull/6570:

<img width="1848" height="506" alt="image" src="https://github.com/user-attachments/assets/0f813616-76d3-4190-95dd-12dd43f8007a" />



# Solution
make ci.yml run for all changes, even md

its not worth complicating the CI to solve for this by making each step aware of files changed and thus able to noop out of a real check. best to remove the "smart" addition I had made to ignore md only changes in CI in https://github.com/expressjs/express/pull/5564

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
