### PR TITLE
Add clarifying comment to res.send

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -121,7 +121,7 @@ res.links = function(links) {
  * @param {string|number|boolean|object|Buffer} body
  * @public
  */
-
+// Sends the response body to the client
 res.send = function send(body) {
   var chunk = body;
   var encoding;


### PR DESCRIPTION
Added a small comment to clarify the purpose of res.send
for better readability.
