### PR TITLE
fix: prefer Referer header over Referrer

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -75,8 +75,7 @@ req.header = function header(name) {
   switch (lc) {
     case 'referer':
     case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
+      return this.headers.referer || this.headers.referrer;
     default:
       return this.headers[lc];
   }

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -33,6 +33,20 @@ describe('req', function(){
       .expect('http://foobar.com', done);
     })
 
+    it('should prefer Referer over Referrer', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.end(req.get('Referer'));
+      });
+
+      request(app)
+      .post('/')
+      .set('Referrer', 'http://foobar.com')
+      .set('Referer', 'http://example.com')
+      .expect('http://example.com', done);
+    })
+
     it('should throw missing header name', function (done) {
       var app = express()
 


### PR DESCRIPTION
Unlike #4106, which deprecates the use of `referrer`, this PR does the opposite, it prefers `referer` over `referrer`. According to RFC 9110, section 10.1.3, the specification technically already takes into account the use of `referrer` as well, so I think it’s fine to keep that validation. That said, we should still prefer reading the value from `referer` first.

> The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the [target URI](https://datatracker.ietf.org/doc/html/rfc9110#target.resource) was obtained (i.e., the "referrer", though the field name is misspelled). A user agent MUST NOT include the fragment and userinfo components of the URI reference [[URI](https://datatracker.ietf.org/doc/html/rfc3986)], if any, when generating the Referer field value

closes #4106 closes https://github.com/expressjs/express/issues/3951