### PR TITLE
Prevent ETag generation when Cache-Control: no-store is set

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -166,7 +166,9 @@ res.send = function send(body) {
 
   // determine if ETag should be generated
   var etagFn = app.get('etag fn')
-  var generateETag = !this.get('ETag') && typeof etagFn === 'function'
+  var cacheControl = this.get('Cache-Control')
+  var hasNoStore = cacheControl && /no-store/i.test(cacheControl)
+  var generateETag = !this.get('ETag') && typeof etagFn === 'function' && !hasNoStore
 
   // populate Content-Length
   var len

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -564,6 +564,78 @@ describe('res', function(){
         .expect(utils.shouldNotHaveHeader('ETag'))
         .expect(200, done);
       })
+
+      it('should not generate ETag when Cache-Control: no-store is set', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'no-store');
+          res.send('hello, world!');
+        });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect('Cache-Control', 'no-store')
+        .expect(200, done);
+      })
+
+      it('should not generate ETag when Cache-Control: no-store with other directives is set', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'no-store, no-cache');
+          res.send('large body content for etag generation');
+        });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect('Cache-Control', 'no-store, no-cache')
+        .expect(200, done);
+      })
+
+      it('should not generate ETag when Cache-Control contains no-store (case insensitive)', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'NO-STORE');
+          res.send('test data');
+        });
+
+        request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect(200, done);
+      })
+
+      it('should still generate ETag when Cache-Control has other directives but not no-store', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'no-cache, must-revalidate');
+          res.send('hello, world!');
+        });
+
+        request(app)
+        .get('/')
+        .expect('ETag', /^(W\/)?"/)
+        .expect('Cache-Control', 'no-cache, must-revalidate')
+        .expect(200, done);
+      })
+
+      it('should generate ETag when Cache-Control is not set', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.send('hello, world!');
+        });
+
+        request(app)
+        .get('/')
+        .expect('ETag', /^(W\/)?"/)
+        .expect(200, done);
+      })
     })
   })
 })


### PR DESCRIPTION
Respect the Cache-Control: no-store directive by skipping ETag generation when this header is present.

Changes:
- Modified res.send() to check for Cache-Control header containing no-store directive (case-insensitive)
- ETag is no longer generated if no-store is present in Cache-Control
- Added 5 comprehensive test cases covering:
  - Basic no-store directive
  - no-store with other cache directives
  - Case-insensitive matching
  - Other directives without no-store (still generates ETag)
  - Absence of Cache-Control header (still generates ETag)

This ensures compliance with HTTP caching specifications where no-store prohibits storing the response.

Issue: https://github.com/expressjs/express/issues/2472
Review wanted to @bjohansebas 