### PR TITLE
Remove duplicate tests in res.location and res.jsonp

### DIFF
--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -327,18 +327,4 @@ describe('res', function(){
       })
     })
   })
-
-  it('should not override previous Content-Types', function(done){
-    var app = express();
-
-    app.get('/', function(req, res){
-      res.type('application/vnd.example+json');
-      res.jsonp({ hello: 'world' });
-    });
-
-    request(app)
-    .get('/')
-    .expect('content-type', 'application/vnd.example+json; charset=utf-8')
-    .expect(200, '{"hello":"world"}', done)
-  })
 })

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -46,7 +46,7 @@ describe('res', function(){
       .expect(200, done)
     })
 
-    it('should encode data uri1', function (done) {
+    it('should encode data uri', function (done) {
       var app = express()
       app.use(function (req, res) {
         res.location('data:text/javascript,export default () => { }').end();

--- a/test/res.location.js
+++ b/test/res.location.js
@@ -58,18 +58,6 @@ describe('res', function(){
         .expect(200, done)
     })
 
-    it('should encode data uri2', function (done) {
-      var app = express()
-      app.use(function (req, res) {
-        res.location('data:text/javascript,export default () => { }').end();
-      });
-
-      request(app)
-        .get('/')
-        .expect('Location', 'data:text/javascript,export%20default%20()%20=%3E%20%7B%20%7D')
-        .expect(200, done)
-    })
-
     it('should consistently handle non-string input: boolean', function (done) {
       var app = express()
       app.use(function (req, res) {


### PR DESCRIPTION
Remove duplicate test cases:
- Remove duplicate "should encode data uri2" test from res.location.js (original at line 49: "should encode data uri1")
- Remove duplicate "should not override previous Content-Types" test from res.jsonp.js (original at line 130: "should not override previous Content-Types with no callback")

Review wanted to @bjohansebas 
