### PR TITLE
fix: handle BigInt in status code error message

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -64,7 +64,9 @@ module.exports = res
 res.status = function status(code) {
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
-    throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
+    // Use String() instead of JSON.stringify() to handle BigInt and other types safely
+    var stringifiedCode = typeof code === 'bigint' ? code.toString() : JSON.stringify(code)
+    throw new TypeError(`Invalid status code: ${stringifiedCode}. Status code must be an integer.`);
   }
   // Check if the status code is outside of Node's valid range
   if (code < 100 || code > 999) {

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -200,6 +200,18 @@ describe('res', function () {
           .get('/')
           .expect(500, /Invalid status code/, done);
       });
+
+      it('should raise error for BigInt status code with readable message', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(200n).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code: 200\. Status code must be an integer/, done);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
When a BigInt is passed to `res.status()` or `res.sendStatus()`, the current error handling using `JSON.stringify()` throws `TypeError: Do not know how to serialize a BigInt` instead of the intended helpful error message about invalid status codes.

## Solution
Use `String()` for BigInt types and `JSON.stringify()` for other types to ensure readable error messages for all input types.

**Before:**
```
TypeError: Do not know how to serialize a BigInt
```

**After:**
```
TypeError: Invalid status code: 200. Status code must be an integer.
```

## Changes
- Modified `lib/response.js` to handle BigInt serialization in error messages
- Added test for BigInt status code error handling

Fixes #6756