### PR TITLE
fix: preserve error details like cause in logerror

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -608,13 +608,17 @@ app.listen = function listen() {
 /**
  * Log error using console.error.
  *
+ * Logs the full error object to preserve details like `cause` property
+ * and other custom error properties that would be lost when only
+ * logging the stack trace.
+ *
  * @param {Error} err
  * @private
  */
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Summary
The `logerror` function currently logs `err.stack || err.toString()`, which loses important error details like the `Error.cause` property (introduced in ES2022) and custom error properties from ORMs like Sequelize.

## Solution
Log the full error object directly with `console.error(err)` instead of just the stack trace. Modern Node.js/console implementations properly format error objects and preserve all their properties.

**Before:**
```
Error: outer
    at ...stack trace...
```

**After:**
```
Error: outer
    at ...stack trace...
    [cause]: Error: inner
        at ...nested stack trace...
```

## Changes
- Modified `lib/application.js` to log the full error object
- Updated JSDoc to document the rationale

Fixes #6462