### PR TITLE
fix: prevent silent truncation of query parameters

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -259,6 +259,11 @@ function createETagGenerator (options) {
 /**
  * Parse an extended query string with qs.
  *
+ * Sets parameterLimit to Infinity to avoid silently truncating
+ * query parameters. The default qs limit of 1000 parameters
+ * would cause data loss without any warning. If users need a
+ * limit for security, they can provide a custom query parser.
+ *
  * @param {String} str
  * @return {Object}
  * @private
@@ -266,6 +271,7 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    parameterLimit: Infinity
   });
 }

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -38,6 +38,28 @@ describe('req', function(){
         .get('/?user.name=tj')
         .expect(200, '{"user.name":"tj"}', done);
       });
+
+      it('should not truncate parameters over 1000', function (done) {
+        var app = createApp('extended');
+
+        // Create a query string with 1500 parameters
+        var params = [];
+        for (var i = 0; i < 1500; i++) {
+          params.push('a' + i + '=' + i);
+        }
+        var query = params.join('&');
+
+        request(app)
+        .get('/?' + query)
+        .expect(200)
+        .expect(function (res) {
+          var keys = Object.keys(res.body);
+          if (keys.length !== 1500) {
+            throw new Error('Expected 1500 parameters, got ' + keys.length);
+          }
+        })
+        .end(done);
+      });
     });
 
     describe('when "query parser" is simple', function () {


### PR DESCRIPTION
## Summary
The `qs` library used by Express has a default `parameterLimit` of 1000, which silently truncates query parameters beyond this limit. This can lead to subtle data loss bugs that are extremely difficult to diagnose, as there's no warning when parameters are dropped.

## Solution
Set `parameterLimit: Infinity` in the extended query string parser. Users who need a limit for security reasons can provide a custom query parser.

This aligns with the principle of least surprise - it's better to process all parameters by default and let users explicitly opt into limits, rather than silently dropping data.

**Before:**
Query string with 1500 parameters silently returns only 1000.

**After:**
All 1500 parameters are parsed correctly.

## Changes
- Modified `lib/utils.js` to set `parameterLimit: Infinity`
- Added JSDoc explaining the rationale
- Added test verifying 1500+ parameters are not truncated

Fixes #5878