### PR TITLE
perf: skip ETag generation for no-store responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -158,8 +158,11 @@ res.send = function send(body) {
   }
 
   // determine if ETag should be generated
+  // Skip ETag for no-store responses as the client will ignore it anyway
   var etagFn = app.get('etag fn')
-  var generateETag = !this.get('ETag') && typeof etagFn === 'function'
+  var cacheControl = this.get('Cache-Control')
+  var isNoStore = cacheControl && /(?:^|,)\s*no-store\s*(?:,|$)/i.test(cacheControl)
+  var generateETag = !isNoStore && !this.get('ETag') && typeof etagFn === 'function'
 
   // populate Content-Length
   var len

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -456,6 +456,42 @@ describe('res', function(){
         .expect(utils.shouldNotHaveHeader('ETag'))
         .expect(200, done);
       })
+
+      it('should not send ETag when Cache-Control: no-store is set', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'no-store');
+          var str = Array(1000).join('-');
+          res.send(str);
+        });
+
+        app.enable('etag');
+
+        request(app)
+        .get('/')
+        .expect('Cache-Control', 'no-store')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect(200, done);
+      })
+
+      it('should not send ETag when Cache-Control contains no-store', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'private, no-store, max-age=0');
+          var str = Array(1000).join('-');
+          res.send(str);
+        });
+
+        app.enable('etag');
+
+        request(app)
+        .get('/')
+        .expect('Cache-Control', 'private, no-store, max-age=0')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect(200, done);
+      })
     });
 
     describe('when disabled', function () {


### PR DESCRIPTION
## Summary
When `Cache-Control: no-store` is set, the client is required to ignore any ETag header. Generating ETags for these responses wastes CPU cycles on CRC/hash computation that the client will never use.

## Solution
Check the `Cache-Control` header for `no-store` directive before generating ETags. If present, skip the ETag generation entirely.

## Changes
- Modified `lib/response.js` to check for `no-store` in Cache-Control
- Uses a regex that correctly matches `no-store` as a standalone directive
- Added tests for both `Cache-Control: no-store` and combined directives like `private, no-store, max-age=0`

## Performance
Eliminates unnecessary hash computation for responses that explicitly don't want caching.

Fixes #2472