### PR TITLE
feat: add app.renderAsync() for promise-based view rendering

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -575,6 +575,31 @@ app.render = function render(name, options, callback) {
 };
 
 /**
+ * Render the given view `name` with `options`, returning a Promise.
+ *
+ * Example:
+ *
+ *    const html = await app.renderAsync('email', { name: 'Tobi' });
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @return {Promise<String>}
+ * @public
+ */
+
+app.renderAsync = function renderAsync(name, options) {
+  var self = this;
+  var opts = options || {};
+
+  return new Promise(function(resolve, reject) {
+    self.render(name, opts, function(err, str) {
+      if (err) reject(err);
+      else resolve(str);
+    });
+  });
+};
+
+/**
  * Listen for connections.
  *
  * A node `http.Server` is returned, with this


### PR DESCRIPTION
## Summary
- Add `app.renderAsync(name, options)` method that returns a Promise instead of using callbacks
- Enables async/await usage for view rendering

## Usage
```javascript
// Before (callback)
app.render('email', { name: 'Tobi' }, (err, html) => {
  if (err) return next(err);
  res.send(html);
});

// After (async/await)
const html = await app.renderAsync('email', { name: 'Tobi' });
res.send(html);