### PR TITLE
deps: body-parser@~1.20.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "accepts": "~1.3.8",
     "array-flatten": "1.1.1",
-    "body-parser": "~1.20.3",
+    "body-parser": "~1.20.4",
     "content-disposition": "~0.5.4",
     "content-type": "~1.0.4",
     "cookie": "~0.7.1",


### PR DESCRIPTION
# TL;DR

Updates `body-parser` from `~1.20.3` to `~1.20.4` to pull in patched `qs@6.14.1` and clear the GHSA-6rw7-vpxm-498p advisory. Single-line change, full test pass, `npm audit --production` reports 0 vulnerabilities.

---

# Context

## Issue

- Issue: expressjs/express #7016
- Title: "Update body-parser dependency in 4.x/ to `1.20.4`"

## Problem

Express 4.x depends on `body-parser`, which transitively depends on `qs`. `qs < 6.14.1` is flagged by **GHSA-6rw7-vpxm-498p** (HIGH severity: arrayLimit bypass → potential DoS via memory exhaustion).  
This is reported as **vulnerable** (not malicious).

### Dependency chain (before)

```
express@4.22.1
└── body-parser@1.20.3
    └── qs@6.13.0 (vulnerable)
```

## Additional context (#6972)

With `~1.20.3` in `package.json`:
- Fresh installs may resolve to newer patch releases, but
- Existing installations running `npm install express@4` can remain on `1.20.3` since it still satisfies `~1.20.3`.

Bumping the minimum to `~1.20.4` makes the safe patch-level update explicit.

---

# Changes

- `package.json`: bump `body-parser` from `~1.20.3` → `~1.20.4` (single-line change)
- No lockfile changes (repo policy)

```diff
- "body-parser": "~1.20.3",
+ "body-parser": "~1.20.4",
```

---

# Evidence

## Dependency tree (after)

```bash
npm ls body-parser qs
express@4.22.1
├─┬ body-parser@1.20.4
│ └── qs@6.14.1 deduped
└── qs@6.14.1
```

## Vulnerabilities (after)

```bash
npm audit --production
found 0 vulnerabilities
```

## Tests

```bash
npm test
1322 passing (1s)
1 pending
```

---

# Notes

- No functional changes besides the dependency bump.
- Patch-level update only; no breaking changes expected.

---

## Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.