### PR TITLE
docs: fix README security policy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,7 +154,7 @@ See the [Contributing Guide] for more technical details on contributing.
 
 ### Security Issues
 
-If you discover a security vulnerability in Express, please see [Security Policies and Procedures](https://github.com/expressjs/express?tab=security-ov-file).
+If you discover a security vulnerability in Express, please see [Security Policies and Procedures](https://github.com/expressjs/express/security/policy).
 
 ### Running Tests
 


### PR DESCRIPTION
## Description
This PR fixes ~two~ one README issue:

~Clarifies the Quick Start note about express-generator versioning: the generator’s major version indicates which Express major it targets (implication, not equality). Also~ 
updates the “Security Issues” link to the stable security policy URL: https://github.com/expressjs/express/security/policy

## Certificate of Origin
Signed-off-by: Pavan Shinde <pavann97@gmail.com>