### PR TITLE
fix: prevent Content-Type header from being set to 'false'

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -31,6 +31,20 @@ describe('res', function(){
       .expect('X-Number', '123')
       .expect(200, 'string', done);
     })
+
+    it('should preserve Content-Type value when mime lookup fails', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'custom-type');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'custom-type')
+      .expect(200, done);
+    })
   })
 
   describe('.set(field, values)', function(){


### PR DESCRIPTION
Fixes #7034

When `res.set('Content-Type', value)` is called with a value that `mime.contentType()` can't resolve (returns `false`), the header ends up being set to the literal string `"false"`.

This happens because `mime.contentType()` returns `false` for unrecognized types, and that `false` gets passed straight to `setHeader()`, which coerces it to a string.

```js
// before this fix:
res.set('Content-Type', 'custom-type');
// => Content-Type: false
```

The fix is a one-liner — fall back to the original value when `mime.contentType()` returns `false`. This is consistent with how `res.type()` already handles the same case (it falls back to `'application/octet-stream'`).

```js
// after:
res.set('Content-Type', 'custom-type');
// => Content-Type: custom-type
```

Added a test to cover this edge case. Full test suite passes (1247 tests).