### PR TITLE
fix: throw error when Content-Type is invalid

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,11 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      var contentType = mime.contentType(value);
+      if (contentType === false) {
+        throw new TypeError('invalid content type');
+      }
+      value = contentType;
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -31,6 +31,19 @@ describe('res', function(){
       .expect('X-Number', '123')
       .expect(200, 'string', done);
     })
+
+    it('should throw when Content-Type is invalid', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'not-a-real-content-type')
+        res.end()
+      })
+
+      request(app)
+      .get('/')
+      .expect(500, /TypeError: invalid content type/, done)
+    })
   })
 
   describe('.set(field, values)', function(){


### PR DESCRIPTION
## Summary

Fixes #7034 

When calling `res.set('Content-Type', value)` where `value` is not a valid MIME type (e.g., `'some-custom-type'`), `mime.contentType()` returns `false`. Previously, this `false` value was coerced to the literal string `"false"` and set as the Content-Type header.

## Changes

This PR modifies `res.set()` in `lib/response.js` to throw a `TypeError` when `mime.contentType()` returns `false`, making the error explicit and easier to catch during development.

```js
// Before (silently sets header to "false")
res.set('Content-Type', 'some-custom-type');
// => Content-Type: false

// After (throws TypeError)
res.set('Content-Type', 'some-custom-type');
// => TypeError: invalid content type
```

## Rationale

As noted by @krzysdz in #7034, the Content-Type header must contain a valid media type with a `/` separator (per [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-type)). Silently setting the header to `"false"` creates invalid HTTP responses that are harder to debug.

This change aligns with the existing `TypeError` thrown when Content-Type is set to an Array (line 674).

## Test plan

- ✅ All existing tests pass (`npm test` - 1244 passing)
- ✅ Manually verified that invalid Content-Type now throws `TypeError`
- ✅ Verified that valid Content-Types still work correctly (e.g., `application/json`, `text/html`)