### PR TITLE
include edge case tests for `res.type()`

### DIFF
--- a/test/res.type.js
+++ b/test/res.type.js
@@ -42,5 +42,73 @@ describe('res', function(){
       .get('/')
       .expect('Content-Type', 'application/vnd.amazon.ebook', done);
     })
+    describe('edge cases', function(){
+      it('should handle empty string gracefully', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.type('').end('test');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .end(done);
+      })
+
+      it('should handle file extension with dots', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.type('.json').end('{"test": true}');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .end(done);
+      })
+
+      it('should handle multiple file extensions', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.type('file.tar.gz').end('compressed');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/gzip')
+        .end(done);
+      })
+
+      it('should handle uppercase extensions', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.type('FILE.JSON').end('{"test": true}');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .end(done);
+      })
+
+      it('should handle extension with special characters', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.type('file@test.json').end('{"test": true}');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .end(done);
+      })
+    })
   })
 })
+
+

--- a/test/res.type.js
+++ b/test/res.type.js
@@ -42,6 +42,7 @@ describe('res', function(){
       .get('/')
       .expect('Content-Type', 'application/vnd.amazon.ebook', done);
     })
+
     describe('edge cases', function(){
       it('should handle empty string gracefully', function(done){
         var app = express();


### PR DESCRIPTION
Description:-
This PR adds edge case tests for `res.type()` to improve test coverage for the response type-setting functionality.

Motivation:-
While reviewing the test coverage for `res.type()`, I noticed that several edge cases weren't being tested. These edge cases could lead to unexpected behaviour or bugs in production.

Changes:-
Added 5 new test cases under a new `describe('edge cases')` block:

1. **Empty string handling** - Ensures the function defaults gracefully to `application/octet-stream`
2. **Extensions with leading dot** - Tests `.json` vs `json` handling
3. **Multiple file extensions** - Tests compound extensions like `.tar.gz`
4. **Case-insensitive extensions** - Ensures `FILE.JSON` works like `file.json`
5. **Special characters in filenames** - Tests filenames like `file@test.json`

Testing:-
```bash
npm test
```

All tests passing: **1249 passing (1s)** 

Impact:-
- Improves test coverage for `res.type()`
- Documents expected behaviour for edge cases
- Helps prevent future bugs with unusual input
- No breaking changes to existing functionality