### PR TITLE
fix: prevent res.set('Content-Type') from setting header to 'false'

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -31,6 +31,34 @@ describe('res', function(){
       .expect('X-Number', '123')
       .expect(200, 'string', done);
     })
+
+    it('should preserve unknown Content-Type shorthand', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'custom-type');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'custom-type')
+      .expect(200, done);
+    })
+
+    it('should set Content-Type with valid full MIME type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'application/x-custom');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'application/x-custom')
+      .expect(200, done);
+    })
   })
 
   describe('.set(field, values)', function(){


### PR DESCRIPTION
## Summary

- When `mime.contentType()` cannot resolve a shorthand value (e.g., `'custom-type'`), it returns `false`, which was silently set as the literal Content-Type header string `"false"`
- Fall back to the original value instead, consistent with how `res.type()` already handles this case
- Added tests for unknown Content-Type shorthands and valid full MIME types

Fixes #7034

## Test plan

- [x] `res.set('Content-Type', 'custom-type')` preserves the original value instead of setting `"false"`
- [x] `res.set('Content-Type', 'application/x-custom')` works correctly with full MIME types
- [x] All existing tests continue to pass