### PR TITLE
feat: add 'strict status codes' app setting

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -70,6 +70,10 @@ res.status = function status(code) {
   if (code < 100 || code > 999) {
     throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than 1000.`);
   }
+  // Check if strict status codes is enabled and code is outside RFC 9110 range
+  if (this.app && this.app.enabled('strict status codes') && (code < 100 || code > 599)) {
+    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than 600.`);
+  }
 
   this.statusCode = code;
   return this;

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -201,6 +201,59 @@ describe('res', function () {
           .expect(500, /Invalid status code/, done);
       });
     });
+
+    describe('with "strict status codes" setting', function () {
+      it('should allow standard status codes (100-599)', function (done) {
+        var app = express();
+        app.enable('strict status codes');
+
+        app.use(function (req, res) {
+          res.status(200).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(200, done);
+      });
+
+      it('should reject status codes above 599', function (done) {
+        var app = express();
+        app.enable('strict status codes');
+
+        app.use(function (req, res) {
+          res.status(700).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done);
+      });
+
+      it('should reject status code 999', function (done) {
+        var app = express();
+        app.enable('strict status codes');
+
+        app.use(function (req, res) {
+          res.status(999).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done);
+      });
+
+      it('should allow 600+ when setting is disabled', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(700).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(700, done);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `strict status codes` app setting that restricts valid status codes to the RFC 9110 range (100-599)
- When enabled, `res.status()` throws a `RangeError` for codes outside 100-599
- Default behavior is unchanged — Express continues to accept 100-999 matching Node.js

```js
app.enable('strict status codes');
app.get('/', (req, res) => {
  res.status(700).end(); // RangeError: Invalid status code: 700
});
```

Ref #5623

## Test plan

- [x] Standard status codes (100-599) work when setting is enabled
- [x] Status codes 600+ are rejected when setting is enabled
- [x] Status codes 600+ continue to work when setting is disabled (default)
- [x] All 1248 existing tests continue to pass