### PR TITLE
feat: add diagnostics_channel support for app initialization

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -24,7 +24,6 @@ var compileTrust = require('./utils').compileTrust;
 var resolve = require('node:path').resolve;
 var once = require('once')
 var Router = require('router');
-const channels = require('./diagnostics');
 
 /**
  * Module variables.

--- a/lib/application.js
+++ b/lib/application.js
@@ -24,6 +24,7 @@ var compileTrust = require('./utils').compileTrust;
 var resolve = require('node:path').resolve;
 var once = require('once')
 var Router = require('router');
+const channels = require('./diagnostics');
 
 /**
  * Module variables.

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const dc = require('node:diagnostics_channel');
+
+const initialization = dc.channel('express.initialization');
+
+module.exports = { initialization };

--- a/lib/express.js
+++ b/lib/express.js
@@ -19,6 +19,7 @@ var proto = require('./application');
 var Router = require('router');
 var req = require('./request');
 var res = require('./response');
+const channels = require('./diagnostics');
 
 /**
  * Expose `createApplication()`.
@@ -52,6 +53,11 @@ function createApplication() {
   })
 
   app.init();
+
+  if (channels.initialization.hasSubscribers) {
+    channels.initialization.publish({ express: app });
+  }
+
   return app;
 }
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -55,7 +55,7 @@ function createApplication() {
   app.init();
 
   if (channels.initialization.hasSubscribers) {
-    channels.initialization.publish({ express: app });
+    channels.initialization.publish({ app });
   }
 
   return app;

--- a/test/diagnostics-channel.js
+++ b/test/diagnostics-channel.js
@@ -16,7 +16,7 @@ describe('diagnostics channels', function () {
 
       const app = express()
       assert.ok(msg, 'express.initialization was not published')
-      assert.strictEqual(msg.express, app)
+      assert.strictEqual(msg.app, app)
     })
 
     it('should not throw when there are no subscribers', function () {

--- a/test/diagnostics-channel.js
+++ b/test/diagnostics-channel.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const dc = require('node:diagnostics_channel')
+const express = require('../')
+const assert = require('node:assert')
+
+describe('diagnostics channels', function () {
+  describe('express.initialization', function () {
+    it('should publish when app is created', function () {
+      let msg
+
+      dc.subscribe('express.initialization', function handler (data) {
+        msg = data
+        dc.unsubscribe('express.initialization', handler)
+      })
+
+      const app = express()
+      assert.ok(msg, 'express.initialization was not published')
+      assert.strictEqual(msg.express, app)
+    })
+
+    it('should not throw when there are no subscribers', function () {
+      assert.ok(express())
+    })
+  })
+})


### PR DESCRIPTION
 Publishes `express.initialization` channel when an Express app is created,                                             
  allowing instrumentation libraries to attach middleware and hooks before
  any request arrives.                                                                     
                  
  Route-level tracing (start/end/error per request with matched route pattern)
  will be implemented in the `router` module using `TracingChannel` API.
  
  Refs:  https://github.com/expressjs/express/issues/6353 https://github.com/pillarjs/router/pull/96/changes
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
