### PR TITLE
Fix: Prevent Content-Type from being set to literal 'false' string

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,10 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      var ct = mime.contentType(value)
+      if (ct !== false) {
+        value = ct
+      }
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,20 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should preserve the original value when mime.contentType returns false', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type')
+        res.end()
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, done)
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
When mime.contentType() returns false for unrecognized types, res.set() now preserves the original value instead of setting the header to the literal string 'false'.

## Bug Description
Previously, when calling res.set('Content-Type', 'some-custom-type') with an unrecognized type, mime.contentType() would return false, and the header would be set to the literal string "false" instead of preserving the original value.

## Root Cause
In lib/response.js, the res.set() function was directly assigning the result of mime.contentType(value) to the value variable without checking if it returned false.

## Fix
Modified the Content-Type handling in res.set() to only update the value if mime.contentType() returns a non-false value, preserving the original value otherwise.

## Test Added
Added a test case in test/res.set.js to verify that unrecognized Content-Type values are preserved correctly.

Fixes: Express issue #7034