### PR TITLE
fix(res): preserve original value when mime.contentType() returns false

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,20 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should preserve original value when mime.contentType() returns false', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type')
+        res.end()
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, done)
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
fix: prevent `res.set('Content-Type')` from setting header to literal string `'false'`

When calling `res.set('Content-Type', value)` with a value that `mime.contentType()` cannot resolve (e.g., `'some-custom-type'`, it returns false. This false was passed directly to `setHeader()`, which coerced it to the string `"false"` — resulting in `Content-Type: false` in the response headers.

This change falls back to the original value when `mime.contentType()` returns `false`, consistent with how `res.type()` already handles this case.

Changes:

- `response.js` : `mime.contentType(value)` → `mime.contentType(value) || value`
- `res.set.js` : Added test to verify the original value is preserved for unrecognized types

Fixes #7034