### PR TITLE
fix: throw TypeError for invalid arguments in res.redirect()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -820,16 +820,12 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
-  }
-
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
+    throw new TypeError('res.redirect() requires a URL string, got ' + typeof address);
   }
 
   if (typeof status !== 'number') {
-    deprecate('Status must be a number');
+    throw new TypeError('res.redirect() requires a numeric status code, got ' + typeof status);
   }
 
   // Set location header

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -6,6 +6,42 @@ var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.redirect(url)', function(){
+    it('should throw on undefined url', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(undefined);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
+
+    it('should throw on null url', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(null);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
+
+    it('should throw on numeric url', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(123);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
+
     it('should default to a 302 redirect', function(done){
       var app = express();
 
@@ -47,6 +83,30 @@ describe('res', function(){
   })
 
   describe('.redirect(status, url)', function(){
+    it('should throw on non-string url', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(301, undefined);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
+
+    it('should throw on non-numeric status', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect('301', '/foo');
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
+
     it('should set the response status', function(done){
       var app = express();
 


### PR DESCRIPTION
## Summary

- `res.redirect(undefined)` previously sent a malformed HTTP response with `Location: undefined` header. While a deprecation warning was emitted, the invalid response was still sent to the client.
- This converts the deprecated behavior into thrown `TypeError`s, consistent with how `res.status()` already validates its input (see [response.js#L64-L72](https://github.com/expressjs/express/blob/master/lib/response.js#L64-L72)).
- Validates both the `url` (must be a string) and `status` (must be a number) arguments.

### Before
```js
res.redirect(undefined)
// => 302 with "Location: undefined" header (malformed HTTP response)

res.redirect(null)
// => 302 with "Location: null" header (malformed HTTP response)
```

### After
```js
res.redirect(undefined)
// => TypeError: res.redirect() requires a URL string, got undefined

res.redirect(null)
// => TypeError: res.redirect() requires a URL string, got object
```

## Test plan

- [x] Added test: `res.redirect(undefined)` throws (500)
- [x] Added test: `res.redirect(null)` throws (500)
- [x] Added test: `res.redirect(123)` throws (500)
- [x] Added test: `res.redirect(301, undefined)` throws (500)
- [x] Added test: `res.redirect('301', '/foo')` throws (500)
- [x] All 1249 existing tests pass
- [x] 5 new tests pass (18 total in res.redirect suite)

Fixes #6941