### PR TITLE
fix: make view engine extension matching case-insensitive

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -301,8 +301,9 @@ app.engine = function engine(ext, fn) {
     ? '.' + ext
     : ext;
 
-  // store engine
-  this.engines[extension] = fn;
+  // store engine, normalizing extension to lowercase for
+  // case-insensitive matching with file extensions
+  this.engines[extension.toLowerCase()] = fn;
 
   return this;
 };

--- a/lib/view.js
+++ b/lib/view.js
@@ -53,7 +53,7 @@ function View(name, options) {
   var opts = options || {};
 
   this.defaultEngine = opts.defaultEngine;
-  this.ext = extname(name);
+  this.ext = extname(name).toLowerCase();
   this.name = name;
   this.root = opts.root;
 
@@ -65,9 +65,9 @@ function View(name, options) {
 
   if (!this.ext) {
     // get extension from default engine name
-    this.ext = this.defaultEngine[0] !== '.'
+    this.ext = (this.defaultEngine[0] !== '.'
       ? '.' + this.defaultEngine
-      : this.defaultEngine;
+      : this.defaultEngine).toLowerCase();
 
     fileName += this.ext;
   }

--- a/test/app.engine.js
+++ b/test/app.engine.js
@@ -79,5 +79,34 @@ describe('app', function(){
         done();
       })
     })
+
+    it('should match engine registered with uppercase ext to lowercase file', function(done){
+      var app = express();
+
+      app.set('views', path.join(__dirname, 'fixtures'))
+      app.engine('HTML', render);
+      app.locals.user = { name: 'tobi' };
+
+      app.render('user.html', function(err, str){
+        if (err) return done(err);
+        assert.strictEqual(str, '<p>tobi</p>')
+        done();
+      })
+    })
+
+    it('should match engine registered with mixed case ext', function(done){
+      var app = express();
+
+      app.set('views', path.join(__dirname, 'fixtures'))
+      app.engine('Html', render);
+      app.set('view engine', 'Html');
+      app.locals.user = { name: 'tobi' };
+
+      app.render('user', function(err, str){
+        if (err) return done(err);
+        assert.strictEqual(str, '<p>tobi</p>')
+        done();
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary

- `app.engine('Eta', fn)` stored the engine under `.Eta`, but `path.extname('search.eta')` returns `.eta`, causing a lookup miss and triggering an unnecessary `require()` fallback.
- This normalizes extensions to lowercase in `app.engine()` and the `View` constructor so that engine registration and file extension matching are case-insensitive.

### Before
```js
app.engine('Eta', Eta.renderFile);
console.log(app.engines); // { '.Eta': [Function: renderFile] }

// When rendering 'search.eta':
// path.extname('search.eta') => '.eta'
// app.engines['.eta'] => undefined (BUG: stored as '.Eta')
// Falls through to require('eta').__express
```

### After
```js
app.engine('Eta', Eta.renderFile);
console.log(app.engines); // { '.eta': [Function: renderFile] }

// When rendering 'search.eta':
// path.extname('search.eta') => '.eta'
// app.engines['.eta'] => [Function: renderFile] (MATCH)
```

## Changes

- `lib/application.js`: normalize extension to lowercase in `app.engine()`
- `lib/view.js`: normalize `this.ext` to lowercase in `View` constructor (both from filename and from `defaultEngine`)
- `test/app.engine.js`: 2 new tests for uppercase and mixed-case engine extensions

## Test plan

- [x] Added test: engine registered with uppercase ext matches lowercase file
- [x] Added test: engine registered with mixed case ext works with `view engine` setting
- [x] All 1246 tests pass (1244 existing + 2 new)

Fixes #4594