### PR TITLE
Fix #5878: Query Param Silently Remove param query value if it is over 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -266,6 +266,7 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    parameterLimit: Infinity
   });
 }

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -31,6 +31,20 @@ describe('req', function(){
         .expect(200, '{"foo":[{"bar":"baz","fizz":"buzz"},"done!"]}', done);
       });
 
+      it('should not truncate query params over 1000', function (done) {
+        var app = createApp('extended');
+        var params = Array.from({ length: 1001 }, function (_, i) { return 'p' + i + '=1'; }).join('&');
+
+        request(app)
+        .get('/?' + params)
+        .expect(200, function (err, res) {
+          if (err) return done(err);
+          var query = JSON.parse(res.text);
+          assert.strictEqual(Object.keys(query).length, 1001);
+          done();
+        });
+      });
+
       it('should parse parameters with dots', function (done) {
         var app = createApp('extended');
 


### PR DESCRIPTION
Fixes #5878

## Summary
This PR addresses: Query Param Silently Remove param query value if it is over 1000

## Changes
```
lib/utils.js      |  3 ++-
 test/req.query.js | 14 ++++++++++++++
 2 files changed, 16 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).