### PR TITLE
fix: throw TypeError when url is undefined in res.redirect()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -820,6 +820,10 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
+  if (address === undefined) {
+    throw new TypeError('url argument is required for res.redirect()');
+  }
+
   if (!address) {
     deprecate('Provide a url argument');
   }

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -211,4 +211,23 @@ describe('res', function(){
         .end(done)
     })
   })
+
+  describe('.redirect(undefined)', function(){
+    it('should throw TypeError', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(undefined);
+      });
+
+      request(app)
+        .get('/')
+        .end(function(err, res){
+          if (res.statusCode !== 500) {
+            return done(new Error('Expected 500 status'));
+          }
+          done();
+        });
+    })
+  })
 })


### PR DESCRIPTION
Previously, res.redirect(undefined) would send an invalid 'Location: undefined' header which is malformed. This fix adds validation to throw a clear TypeError when the url argument is undefined, rather than sending an invalid header.

Fixes expressjs/express#6941