### PR TITLE
docs: replace dummy with placeholder in example comments

### DIFF
--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -38,7 +38,7 @@ app.use(function(req, res, next){
   next();
 });
 
-// dummy database
+// placeholder database
 
 var users = {
   tj: { name: 'tj' }

--- a/examples/ejs/index.js
+++ b/examples/ejs/index.js
@@ -35,7 +35,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 // ex: res.render('users.html').
 app.set('view engine', 'html');
 
-// Dummy users
+// Placeholder users
 var users = [
   { name: 'tobi', email: 'tobi@learnboost.com' },
   { name: 'loki', email: 'loki@learnboost.com' },

--- a/examples/route-middleware/index.js
+++ b/examples/route-middleware/index.js
@@ -15,7 +15,7 @@ var app = express();
 //     curl http://localhost:3000/user/1/edit (unauthorized since this is not you)
 //     curl -X DELETE http://localhost:3000/user/0 (unauthorized since you are not an admin)
 
-// Dummy users
+// Placeholder users
 var users = [
   { id: 0, name: 'tj', email: 'tj@vision-media.ca', role: 'member' }
   , { id: 1, name: 'ciaran', email: 'ciaranj@gmail.com', role: 'member' }


### PR DESCRIPTION
## Summary

- Replaces the term dummy with placeholder in three example file comments
- No functional changes - these are comment-only updates
- Aligns with inclusive language best practices

### Files changed

- examples/ejs/index.js: Dummy users to Placeholder users
- examples/route-middleware/index.js: Dummy users to Placeholder users
- examples/auth/index.js: dummy database to placeholder database

## Context

The Inclusive Naming Initiative lists dummy as a Tier 3 term to replace when possible. Placeholder is a more precise and neutral alternative that better describes the purpose of the test data in these examples.

## Test plan

- No tests affected - changes are limited to code comments in example files
- Verified no other occurrences of dummy exist in the examples directory