### PR TITLE
fix: preserve original value when Content-Type is unrecognized

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,10 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      var ct = mime.contentType(value);
+      if (ct) {
+        value = ct;
+      }
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,81 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should set charset for known Content-Type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'text/html');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200, done);
+    })
+
+    it('should add charset for shorthand Content-Type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'html');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200, done);
+    })
+
+    it('should keep original value when Content-Type is unknown', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, done);
+    })
+
+    it('should not set header to false for unrecognized Content-Type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'unknown-type');
+        var value = res.get('Content-Type');
+        res.end(value);
+      });
+
+      request(app)
+      .get('/')
+      .expect(function (res) {
+        if (res.text === 'false') {
+          throw new Error('Content-Type was set to literal string "false"');
+        }
+      })
+      .expect(200, done);
+    })
+
+    it('should preserve full MIME type with slash in Content-Type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'application/vnd.custom+json');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'application/vnd.custom+json')
+      .expect(200, done);
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
When `res.set('Content-Type', value)` is called with a value that `mime.contentType()` cannot resolve (returns `false`), the Content-Type header is currently set to the literal string `"false"`.

This happens because `mime.contentType(value)` returns `false` for unrecognized types, and that `false` value is passed to `setHeader()`, which coerces it to the string `"false"`.

The fix preserves the original user-supplied value when `mime.contentType()` returns `false`, so `res.set('Content-Type', 'some-custom-type')` will set the header to `"some-custom-type"` instead of `"false"`.

This is consistent with how `res.type()` handles unknown types (it falls back to `"application/octet-stream"` rather than propagating `false`).

**Reproduction:**

```js
const express = require('express');
const app = express();

app.get('/', (req, res) => {
  res.set('Content-Type', 'some-custom-type');
  res.send('hello');
});
// Response has Content-Type: false
```

**Changes:**
- `lib/response.js`: Only assign the result of `mime.contentType()` when it returns a truthy value
- `test/res.set.js`: Add 5 test cases covering known types, shorthand types, unknown types, the false regression, and full MIME types with slashes

Fixes #7034