### PR TITLE
fix(res.redirect): throw on undefined url to avoid invalid Location header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -820,6 +820,10 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
+  if (address == null) {
+    throw new TypeError('Provide a url argument');
+  }
+
   if (!address) {
     deprecate('Provide a url argument');
   }

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -44,6 +44,18 @@ describe('res', function(){
       .expect('Location', 'https://google.com?q=%A710')
       .expect(302, done)
     })
+
+    it('should throw on undefined "url"', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(undefined)
+      })
+
+      request(app)
+      .get('/')
+      .expect(500, done)
+    })
   })
 
   describe('.redirect(status, url)', function(){


### PR DESCRIPTION
## Summary
Fixes the `res.redirect(undefined)` case that currently leads to an invalid `Location: undefined` header.

## Changes
- Throw a `TypeError` when redirect url is `null`/`undefined`.
- Added regression test in `test/res.redirect.js`.

## Motivation
Issue reports indicate `res.redirect(undefined)` can produce an invalid location value instead of failing fast.

## Validation
- Ran redirect-focused tests:
  - `npm test -- --grep "redirect"`
- New test passes and no regressions in redirect-related suites.
