### PR TITLE
fix(res.set): keep unknown Content-Type values instead of 'false'

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,20 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should keep unknown Content-Type values', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type')
+        res.end()
+      })
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, done)
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
## Summary
Fixes `res.set('Content-Type', value)` behavior when `mime.contentType(value)` cannot resolve a known type.

Currently, unresolved values can become the literal header `Content-Type: false`.
This change preserves the original input value instead.

## Changes
- In `res.set` content-type normalization branch:
  - from: `value = mime.contentType(value)`
  - to: `value = mime.contentType(value) || value`
- Added regression test:
  - `should keep unknown Content-Type values`

## Why
`res.type()` already uses this fallback strategy. This aligns `res.set('Content-Type', ...)` with that behavior and avoids invalid-looking header output.

## Validation
- Ran focused test file:
  - `npx mocha --require test/support/env test/res.set.js`
- New test passes.
