### PR TITLE
res: throw TypeError for invalid redirect url

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -820,8 +820,9 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
+
+  if (typeof address !== 'string' || address.trim().length === 0) {
+    throw new TypeError('res.redirect() requires a non-empty URL string');
   }
 
   if (typeof address !== 'string') {

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -43,7 +43,26 @@ describe('res', function(){
       .get('/')
       .expect('Location', 'https://google.com?q=%A710')
       .expect(302, done)
-    })
+    });
+
+    [
+      { value: undefined, name: 'undefined' },
+      { value: null, name: 'null' },
+      { value: 123, name: 'number' },
+      { value: '', name: 'empty stṛing' },
+    ].forEach(function (testCase) {
+      it('should respond with 500 when url is ' + testCase.name, function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.redirect(testCase.value);
+        });
+
+        request(app)
+            .get('/')
+            .expect(500, done);
+      });
+    });
   })
 
   describe('.redirect(status, url)', function(){


### PR DESCRIPTION
Currently, res.redirect() only emits a deprecation warning when called with an invalid or empty URL value, but continues execution.

This PR changes the behavior to throw a TypeError when:
- url is undefined
- url is null
- url is not a string
- url is an empty or whitespace-only string

This ensures invalid redirects fail fast and prevents unintended behavior.

Tests have been added to cover these cases.