### PR TITLE
fix: logError now logs full error object including cause

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #6462 - `logError` swallows error details (such as `cause`)

## Problem

Before: `console.error(err.stack || err.toString())`
After: `console.error(err)`

The previous code using `err.stack` loses important error information:
- Error.cause property (nested errors)
- Async stack traces
- Nested errors in Sequelize and other libraries (parent/original properties)

## Solution

Change from `err.stack || err.toString()` to just `err`, which allows the console to properly format and display the full error object including all nested properties.

## Testing

This fix preserves:
- Error.cause
- Nested errors (parent, original properties)
- Async stack traces

See the original issue for concrete examples.