### PR TITLE
fix: logError now logs full error object including cause

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #6462 - `logError` swallows error details (such as `cause`)

## Problem

When an error with a `cause` property is logged, only `err.stack` or `err.toString()` is logged, which loses:
- The `cause` property chain
- Nested error details
- Async stack traces

## Solution

Change from:
```js
console.error(err.stack || err.toString())
```

To:
```js
console.error(err)
```

This preserves the full error object including `cause`, nested errors, and async stack traces.

## Testing

Verified that `console.error(err)` outputs the full error object with all properties intact.