### PR TITLE
Fix #6462: Log full error object instead of just stack in logerror

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Summary

Changes `logerror` in `lib/application.js` to use `console.error(err)` instead of `console.error(err.stack || err.toString())`, so that error details like `Error.cause` and custom properties (e.g. Sequelize `parent`/`original`) are preserved in the console output.

Fixes #6462

## Changes

- **lib/application.js**: Changed line 617 from `console.error(err.stack || err.toString())` to `console.error(err)` in the `logerror` function

## Why

`console.error(err)` delegates to Node's built-in error inspection, which handles `Error.cause`, custom enumerable properties, and other details that `err.stack` alone discards.

The `test` environment guard (`this.get('env') !== 'test'`) is unchanged.

---

**Link to Devin Session:** https://app.devin.ai/sessions/68fe83d5d3064681931d4a9d7cdd7238
**Requested by:** nithik (nithik@berkeley.edu) / @NithikYekollu