### PR TITLE
fix: logError shows Error.cause and nested errors

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Bug (expressjs/express#6462)
logError uses console.error(err.stack || err.toString()) which misses Error.cause and nested errors.

## Fix
Use console.error(err) which properly displays Error.cause, parent errors, and other properties.

Resolves: #6462