### PR TITLE
fix content-type fallback to original value

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);


### PR DESCRIPTION
hey, noticed that when you set a custom content-type that mime.types doesnt recognize, it sets the header to "false" instead of keeping the original value.

changed it to fall back to the original value if mime.contentType() returns false. this way custom types still work.

let me know if anything needs changing!

fixes #7034