### PR TITLE
fix: logerror now preserves Error.cause and custom properties

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
Fixes #6462

## Problem
`logError` uses `console.error(err.stack || err.toString())` which loses:
- Error.cause chains (ES2022)
- Custom error properties (e.g. Sequelize parent/original)
- Async stack traces

## Solution
Change to `console.error(err)` — Node.js console handles full error inspection natively, including nested causes and custom properties.

## Before
```js
if (this.get("env") !== "test") console.error(err.stack || err.toString());
```

## After
```js
if (this.get("env") !== "test") console.error(err);
```

## Testing
Verified that `console.error(err)` now shows Error.cause chains and custom properties that were previously lost.