### PR TITLE
fix: res.set('Content-Type') silently sets header to literal string

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);


### PR DESCRIPTION
Fixes #7034

When `res.set('Content-Type', value)` was called with an unrecognized MIME type, `mime.contentType()` returned `false`, and that `false` value was passed directly to `this.setHeader()`, resulting in the literal string `'false'` being set as the Content-Type header. The fix in `lib/response.js` changes the assignment in `res.header` to `mime.contentType(value) || value`, falling back to the original value when `mime.contentType()` returns a falsy result. This preserves the existing behavior for recognized types while allowing unrecognized but valid Content-Type strings (e.g. custom or vendor types) to pass through unchanged. Verified against the reported reproduction case where `res.set('Content-Type', 'application/vnd.custom')` previously set the header to `'false'`.