### PR TITLE
fix(application): preserve error details in logError

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Problem

The current `logError` function in `lib/application.js` uses:

```js
console.error(err.stack || err.toString())
```

This approach loses important error information:
- `Error.cause` chain (introduced in ES2022)
- Async stack traces
- Custom error properties
- Additional metadata attached to error objects

## Solution

Change to simply:

```js
console.error(err)
```

Modern Node.js `console.error()` handles Error objects properly and outputs the stack trace by default, while preserving all additional properties.

## Changes

- `lib/application.js`: Simplified error logging to preserve full error details

Fixes #6462