### PR TITLE
Fix logerror to preserve error details like Error.cause

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
The previous implementation logged only err.stack or err.toString(), which loses important error details such as Error.cause and other custom properties. Logging the full error object preserves all error information for better debugging.

Fixes #6462