### PR TITLE
Fix: Allow unlimited query parameters in extended parser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -266,6 +266,7 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    parameterLimit: Infinity
   });
 }


### PR DESCRIPTION
The qs library has a default parameterLimit of 1000, which silently truncates query parameters beyond that limit. This can cause data loss when handling requests with many query parameters.

Fix by setting parameterLimit: Infinity in the parseExtendedQueryString function, allowing all query parameters to be parsed.

Fixes: #5878