### PR TITLE
fix(application): preserve error details in logError

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Problem

The current `logError` implementation uses `err.stack || err.toString()`, which loses important error details:

- `Error.cause` chain (introduced in ES2022)
- Asynchronous stack traces (from async/await)
- Custom error properties
- Error metadata added by libraries

## Solution

Change `console.error(err.stack || err.toString())` to `console.error(err)` to preserve the full error object, allowing Node.js to format it completely.

## Changes

- Modified `lib/application.js` to pass the error object directly to `console.error`

## Testing

- Verified that passing the error object directly preserves all error details
- The change is backward compatible as console.error handles Error objects correctly

Fixes potential issues where error context is lost during logging.