### PR TITLE
clarify express-generator is still 4.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,11 +88,16 @@ for more information.
 
   The quickest way to get started with express is to utilize the executable [`express(1)`](https://github.com/expressjs/generator) to generate an application as shown below:
 
-  Install the executable. The executable's major version will match Express's:
+  Install the executable:
 
 ```bash
-npm install -g express-generator@5
+npm install -g express-generator@4
 ```
+
+  > Note: the generator is currently 4.x and scaffolds an Express 4-style
+  > application. If you want a starter that follows the Express 5 APIs, create
+  > a new project manually (for example `npm init -y && npm install express`) or
+  > update the generated app to Express 5 after scaffolding.
 
   Create the app:
 

--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,7 @@ for more information.
   Install the executable. The executable's major version will match Express's:
 
 ```bash
-npm install -g express-generator@4
+npm install -g express-generator@5
 ```
 
   Create the app:


### PR DESCRIPTION
In Quick Start section, keep express-generator@4 and add a note that the generator is 4.x and scaffolds an Express 4-style app; suggest manual setup/upgrade paths for Express 5.

Why: Express is 5.2.x but the only published generator remains 4.16.1, so the prior wording implying matching major versions was misleading. This prevents users from unknowingly starting on the wrong major.
Scope: Docs only; no code changes.