### PR TITLE
fix: avoid setting Content-Type header to "false" when mime lookup fails

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);


### PR DESCRIPTION
Fixes issue where res.set('Content-Type', ...) sets header to string 'false' if mime-types lookup fails. Updated response.js to fallback to original value.