### PR TITLE
fix: throw TypeError when redirect URL is not provided

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -821,7 +821,7 @@ res.redirect = function redirect(url) {
   }
 
   if (!address) {
-    deprecate('Provide a url argument');
+    throw new TypeError('path argument is required to res.redirect');
   }
 
   if (typeof address !== 'string') {


### PR DESCRIPTION
## Summary

This PR changes `res.redirect()` behavior when called without a URL argument from issuing a deprecation warning to throwing an explicit `TypeError`. This provides clearer error messaging and prevents silent failures in production.

## The Problem

Previously, calling `res.redirect()` without arguments would only trigger a deprecation notice:
```javascript
deprecate('Provide a url argument');
```

This allowed code with missing redirect URLs to continue running (albeit with warnings), which could lead to confusing runtime behavior and make debugging harder.

## The Fix

Changed the validation in `lib/response.js` line 824 from:
```javascript
deprecate('Provide a url argument');
```

To:
```javascript
throw new TypeError('path argument is required to res.redirect');
```

**Why this matters:**
- **Fail-fast behavior**: Developers immediately know something is wrong instead of continuing with invalid state
- **Clearer error messages**: `TypeError` is more descriptive than a generic deprecation warning
- **Better DX**: Easier to catch bugs during development rather than in production

## Verification

Tested by:
1. Calling `res.redirect()` without arguments → now throws `TypeError` as expected
2. Calling `res.redirect('/path')` with valid string → works normally
3. Existing redirect functionality remains unchanged for valid inputs

## Notes

- This is a **breaking change** for code that relied on the deprecation warning behavior
- Aligns with Express's pattern of throwing errors for required argument violations
- Related to broader dependency updates (see debug module issue #443 referenced in original issue)

## Limitations

This only addresses the missing URL case. Other edge cases around redirect validation remain unchanged from previous versions.