### PR TITLE
fix(res.set): prevent Content-Type from being set to 'false' for unknown types

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,10 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      var ct = mime.contentType(value);
+      if (ct !== false) {
+        value = ct;
+      }
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,20 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should not set Content-Type to "false" when mime type is unknown', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, done);
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
## Problem

When calling `res.set('Content-Type', value)` where the value doesn't contain a `/` (like a bare extension or shorthand), `mime.contentType(value)` is used to resolve the full MIME type. However, if `mime.contentType()` returns `false` (for unrecognized types), the Content-Type header is set to the literal string `"false"` instead of keeping the original value.

## Reproduction

```js
const express = require('express');
const app = express();

app.get('/', (req, res) => {
  res.set('Content-Type', 'some-custom-type');
  res.send('hello');
});

app.listen(3000);
```

Requesting `/` returns `Content-Type: false` in the response headers.

## Root Cause

In `res.set()` (response.js), the Content-Type branch does:

```js
if (field.toLowerCase() === 'content-type') {
  if (Array.isArray(value)) {
    throw new TypeError('Content-Type cannot be set to an Array');
  }
  value = mime.contentType(value)  // can return false!
}
this.setHeader(field, value);
```

When `mime.contentType(value)` returns `false`, the value `false` is passed to `setHeader`, which coerces it to the string `"false"`.

## Solution

This fix checks if `mime.contentType()` returns `false` and falls back to the original value instead:

```js
var ct = mime.contentType(value);
if (ct !== false) {
  value = ct;
}
```

This is consistent with how `res.type()` handles unknown types.

## Changes

- Modified `lib/response.js` to handle the case when `mime.contentType()` returns `false`
- Added test case in `test/res.set.js` to verify the fix

Fixes #7034