### PR TITLE
fix(application): preserve error details in logError

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
Change console.error(err.stack || err.toString()) to console.error(err) to preserve error details like Error.cause, async stack traces, and custom error properties (e.g., Sequelize's parent/original) that are lost when only logging err.stack.

Fixes #6462