### PR TITLE
fix: handle BigInt status codes in res.status() and res.sendStatus()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -62,6 +62,11 @@ module.exports = res
  */
 
 res.status = function status(code) {
+  // Coerce BigInt to Number for compatibility
+  if (typeof code === 'bigint') {
+    code = Number(code);
+  }
+
   // Check if the status code is not an integer
   if (!Number.isInteger(code)) {
     throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);

--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -40,5 +40,17 @@ describe('res', function () {
         .get('/')
         .expect(500, /TypeError: Invalid status code/, done)
     })
+
+    it('should work with BigInt status code', function (done) {
+      var app = express();
+
+      app.use(function(req, res){
+        res.sendStatus(200n);
+      });
+
+      request(app)
+        .get('/')
+        .expect(200, 'OK', done);
+    })
   })
 })

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -189,6 +189,18 @@ describe('res', function () {
           .expect(500, /Invalid status code/, done);
       });
 
+      it('should accept BigInt status code', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(200n).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(200, done);
+      });
+
       it('should raise error for NaN status code', function (done) {
         var app = express();
 


### PR DESCRIPTION
## Description

This PR fixes a bug where passing a BigInt value (e.g., `200n`) to `res.status()` or `res.sendStatus()` would throw a `TypeError: Do not know how to serialize a BigInt`.

### Root Cause

The `res.status()` function uses `JSON.stringify(code)` in its error message. When a BigInt is passed, `JSON.stringify()` throws because BigInt values cannot be serialized to JSON.

### Fix

Coerce BigInt values to Number before validation. HTTP status codes (100-999) are well within the safe range for JavaScript numbers.

### Changes

- **lib/response.js**: Add BigInt to Number coercion at the start of `res.status()`
- **test/res.status.js**: Add test for BigInt status code acceptance
- **test/res.sendStatus.js**: Add test for BigInt status code with `sendStatus`

### Test Results

All 1251 existing tests pass, plus 2 new BigInt-specific tests.

Fixes #6756