### PR TITLE
fix(redirect): throw TypeError for missing/invalid url or status

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,7 +14,6 @@
 
 var contentDisposition = require('content-disposition');
 var createError = require('http-errors')
-var deprecate = require('depd')('express');
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
 var http = require('node:http');
@@ -821,15 +820,15 @@ res.redirect = function redirect(url) {
   }
 
   if (!address) {
-    deprecate('Provide a url argument');
+    throw new TypeError('Provide a url argument to res.redirect()');
   }
 
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
+    throw new TypeError('The "url" argument must be a string');
   }
 
   if (typeof status !== 'number') {
-    deprecate('Status must be a number');
+    throw new TypeError('The "status" argument must be a number');
   }
 
   // Set location header

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -19,6 +19,58 @@ describe('res', function(){
       .expect(302, done)
     })
 
+    it('should throw TypeError when url is undefined', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(undefined);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500)
+      .expect(/Provide a url argument to res\.redirect\(\)/, done)
+    })
+
+    it('should throw TypeError when url is null', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(null);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500)
+      .expect(/Provide a url argument to res\.redirect\(\)/, done)
+    })
+
+    it('should throw TypeError when url is an empty string', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect('');
+      });
+
+      request(app)
+      .get('/')
+      .expect(500)
+      .expect(/Provide a url argument to res\.redirect\(\)/, done)
+    })
+
+    it('should throw TypeError when url is not a string', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(123);
+      });
+
+      request(app)
+      .get('/')
+      .expect(500)
+      .expect(/The .*url.* argument must be a string/, done)
+    })
+
     it('should encode "url"', function (done) {
       var app = express()
 
@@ -58,6 +110,19 @@ describe('res', function(){
       .get('/')
       .expect('Location', 'http://google.com')
       .expect(303, done)
+    })
+
+    it('should throw TypeError when status is not a number', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect('303', 'http://google.com');
+      });
+
+      request(app)
+      .get('/')
+      .expect(500)
+      .expect(/The .*status.* argument must be a number/, done)
     })
   })
 


### PR DESCRIPTION
## Problem

Calling `res.redirect(undefined)` currently sends a 302 response with the header `Location: undefined`. While there is a deprecation warning printed to the console ("Provide a url argument"), the actual HTTP response is malformed because undefined is not a valid URL.

## Solution

Replace deprecation warnings with TypeErrors in `res.redirect()` when:
- url argument is missing (undefined, null, or empty string)
- url argument is not a string  
- status argument is not a number

This prevents malformed Location headers from being sent to clients and makes the error immediately visible to developers.

## Changes

- Modified `lib/response.js` to throw TypeError instead of calling deprecate()
- Added tests for all new error cases
- Removed unused `deprecate` import

## Testing

All tests pass including new tests for:
- redirect with undefined url
- redirect with null url
- redirect with empty string url
- redirect with non-string url
- redirect with non-number status

Fixes #6941