### PR TITLE
Fix fallback for unknown Content-Type values (#7034)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,8 +227,13 @@ exports.setCharset = function setCharset(type, charset) {
     return type;
   }
 
-  // parse type
-  var parsed = contentType.parse(type);
+  // preserve unparseable values instead of throwing when callers set
+  // a non-standard Content-Type manually.
+  try {
+    var parsed = contentType.parse(type);
+  } catch {
+    return type;
+  }
 
   // set charset
   parsed.parameters.charset = charset;

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -31,6 +31,34 @@ describe('res', function(){
       .expect('X-Number', '123')
       .expect(200, 'string', done);
     })
+
+    it('should preserve unknown Content-Type values', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type');
+        res.end('hello');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, 'hello', done);
+    })
+
+    it('should preserve unknown Content-Type values when sending strings', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'some-custom-type');
+        res.send('hello');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'some-custom-type')
+      .expect(200, 'hello', done);
+    })
   })
 
   describe('.set(field, values)', function(){

--- a/test/utils.js
+++ b/test/utils.js
@@ -65,6 +65,10 @@ describe('utils.setCharset(type, charset)', function () {
   it('should override charset', function () {
     assert.strictEqual(utils.setCharset('text/html; charset=iso-8859-1', 'utf-8'), 'text/html; charset=utf-8');
   });
+
+  it('should preserve unparseable types', function () {
+    assert.strictEqual(utils.setCharset('some-custom-type', 'utf-8'), 'some-custom-type');
+  });
 });
 
 describe('utils.wetag(body, encoding)', function(){


### PR DESCRIPTION
This updates the response/content-type fallback path for `#7034` and adds coverage in both `res.set` and utils tests, plus the runtime `/send` and `/end` checks that reproduced the issue.

Validation:
- `npx mocha --require test/support/env --reporter spec --check-leaks test/res.set.js test/utils.js`
- `npx eslint lib/response.js lib/utils.js test/res.set.js test/utils.js`
- runtime inline `node` + `supertest` check for `/send` and `/end`