### PR TITLE
Update path-to-regexp to 0.1.13 to fix CVE-2026-4867

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "methods": "~1.1.2",
     "on-finished": "~2.4.1",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "~0.1.12",
+    "path-to-regexp": "~0.1.13",
     "proxy-addr": "~2.0.7",
     "qs": "~6.15.1",
     "range-parser": "~1.2.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
### Description
---
To keep projects on version 4.x, you need to update the path-to-regexp package to version 0.1.13 to fix the CVE-2026-4867 vulnerability.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
