### PR TITLE
docs: remove dead link from Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -249,7 +249,7 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
   * [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe**
   * [enyoghasim](https://github.com/enyoghasim) - **David Enyoghasim**
   * [0ss](https://github.com/0ss) - **Salah**
-  * [import-brain](https://github.com/import-brain) - **Eric Cheng** (he/him)
+  * import-brain - **Eric Cheng** (he/him)
   * [dakshkhetan](https://github.com/dakshkhetan) - **Daksh Khetan** (he/him)
   * [lucasraziel](https://github.com/lucasraziel) - **Lucas Soares Do Rego**
   * [mertcanaltin](https://github.com/mertcanaltin) - **Mert Can Altin**

--- a/Readme.md
+++ b/Readme.md
@@ -249,7 +249,7 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
   * [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe**
   * [enyoghasim](https://github.com/enyoghasim) - **David Enyoghasim**
   * [0ss](https://github.com/0ss) - **Salah**
-  * import-brain - **Eric Cheng** (he/him)
+  * [ejcheng](https://github.com/ejcheng)- **Eric Cheng** (he/him)
   * [dakshkhetan](https://github.com/dakshkhetan) - **Daksh Khetan** (he/him)
   * [lucasraziel](https://github.com/lucasraziel) - **Lucas Soares Do Rego**
   * [mertcanaltin](https://github.com/mertcanaltin) - **Mert Can Altin**


### PR DESCRIPTION
The GitHub account for import-brain appears to be deleted/renamed resulting in a 404 in the README. Removed the hyperlink while retaining the name.