### PR TITLE
docs: fix various typos in source and documentation

### DIFF
--- a/History.md
+++ b/History.md
@@ -571,7 +571,7 @@ This is the first Express 5.0 alpha release, based off 4.10.1.
   * deps: utils-merge@1.0.1
   * deps: vary@~1.1.2
     - perf: improve header token parsing speed
-  * perf: re-use options object when generating ETags
+  * perf: reuse options object when generating ETags
   * perf: remove dead `.charset` set in `res.jsonp`
 
 4.15.5 / 2017-09-24
@@ -3128,7 +3128,7 @@ This is the first Express 5.0 alpha release, based off 4.10.1.
   * Added ./routes dir for generated app by default
   * Added npm install reminder to express(1) app gen
   * Added 0.5.x support
-  * Removed `make test-cov` since it wont work with node 0.5.x
+  * Removed `make test-cov` since it won't work with node 0.5.x
   * Fixed express(1) public dir for windows. Closes #866
 
 2.4.7 / 2011-10-05
@@ -3290,7 +3290,7 @@ Closes #805
   * Added options support to `res.clearCookie()`
   * Added `res.helpers()` as alias of `res.locals()`
   * Added; json defaults to UTF-8 with `res.send()`. Closes #632. [Daniel   * Dependency `connect >= 1.4.0`
-  * Changed; auto set Content-Type in res.attachement [Aaron Heckmann]
+  * Changed; auto set Content-Type in res.attachment [Aaron Heckmann]
   * Renamed "cache views" to "view cache". Closes #628
   * Fixed caching of views when using several apps. Closes #637
   * Fixed gotcha invoking `app.param()` callbacks once per route middleware.

--- a/Readme.md
+++ b/Readme.md
@@ -249,7 +249,7 @@ The original author of Express is [TJ Holowaychuk](https://github.com/tj)
   * [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe**
   * [enyoghasim](https://github.com/enyoghasim) - **David Enyoghasim**
   * [0ss](https://github.com/0ss) - **Salah**
-  * [import-brain](https://github.com/import-brain) - **Eric Cheng** (he/him)
+  * import-brain - **Eric Cheng** (he/him)
   * [dakshkhetan](https://github.com/dakshkhetan) - **Daksh Khetan** (he/him)
   * [lucasraziel](https://github.com/lucasraziel) - **Lucas Soares Do Rego**
   * [mertcanaltin](https://github.com/mertcanaltin) - **Mert Can Altin**

--- a/examples/mvc/controllers/user/index.js
+++ b/examples/mvc/controllers/user/index.js
@@ -14,7 +14,7 @@ exports.before = function(req, res, next){
   // pretend to query a database...
   process.nextTick(function(){
     req.user = db.users[id];
-    // cant find that user
+    // can't find that user
     if (!req.user) return next('route');
     // found it, move on to the routes
     next();

--- a/lib/response.js
+++ b/lib/response.js
@@ -360,7 +360,7 @@ res.sendStatus = function sendStatus(statusCode) {
  *         if (yes) {
  *           res.sendFile('/uploads/' + uid + '/' + file);
  *         } else {
- *           res.send(403, 'Sorry! you cant see that.');
+ *           res.send(403, 'Sorry! you can\'t see that.');
  *         }
  *       });
  *     });


### PR DESCRIPTION
Fix minor typos in source comments and documentation:\n- 'cant' -> 'can't' in lib/response.js and examples\n- 'attachement' -> 'attachment' in History.md\n- 're-use' -> 'reuse' in History.md\n- 'wont' -> 'won't' in History.md