### PR TITLE
docs: fix typo in response.js comment

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -360,7 +360,7 @@ res.sendStatus = function sendStatus(statusCode) {
  *         if (yes) {
  *           res.sendFile('/uploads/' + uid + '/' + file);
  *         } else {
- *           res.send(403, 'Sorry! you cant see that.');
+ *           res.send(403, 'Sorry! you can't see that.');
  *         }
  *       });
  *     });


### PR DESCRIPTION
Fixes a minor typo in a comment in `lib/response.js`: 'cant' -> 'can\'t'.