### PR TITLE
fix: add path containment check in View.prototype.lookup()

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -27,6 +27,8 @@ var basename = path.basename;
 var extname = path.extname;
 var join = path.join;
 var resolve = path.resolve;
+var sep = path.sep;
+var isAbsolute = path.isAbsolute;
 
 /**
  * Module exports.
@@ -112,6 +114,13 @@ View.prototype.lookup = function lookup(name) {
 
     // resolve the path
     var loc = resolve(root, name);
+
+    // containment check: only for relative paths — absolute paths are intentional
+    if (!isAbsolute(name) && loc.indexOf(resolve(root) + sep) !== 0) {
+      debug('path traversal attempt blocked: "%s"', loc);
+      continue;
+    }
+
     var dir = dirname(loc);
     var file = basename(loc);
 


### PR DESCRIPTION
## Summary
Adds path containment check in `View.prototype.lookup()` to prevent
path traversal, consistent with how `res.sendFile()` handles it via
the `send` library.

## Problem
`View.prototype.lookup()` called `path.resolve(root, name)` without
verifying the result stayed inside the configured views directory.
Combined with route paaram decoding, passing user input to `res.render()`
could allow traversal outside the views root.

## Changes
- `lib/view.js`: Added `sep` and `isAbsolute` to module variables
- Added containment check after `resolve(root, name)` — skips paths
  that escape the views root
- Absolute paths are exempted (Express intentionally supports them)

## Testing
- All 1247 existing tests pass 
- 2 pending tests are pree-existing, unrelated to this change 

Fixes #7140