### PR TITLE
fix(res.set): remove implicit mime lookup and charset injection for Content-Type   

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -239,7 +239,7 @@ res.json = function json(obj) {
 
   // content-type
   if (!this.get('Content-Type')) {
-    this.set('Content-Type', 'application/json');
+    this.set('Content-Type', 'application/json; charset=utf-8');
   }
 
   return this.send(body);
@@ -667,14 +667,6 @@ res.header = function header(field, val) {
     var value = Array.isArray(val)
       ? val.map(String)
       : String(val);
-
-    // add charset to content-type
-    if (field.toLowerCase() === 'content-type') {
-      if (Array.isArray(value)) {
-        throw new TypeError('Content-Type cannot be set to an Array');
-      }
-      value = mime.contentType(value)
-    }
 
     this.setHeader(field, value);
   } else {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -174,7 +174,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect('Content-Type', 'text/plain')
       .expect(200, 'hey', done);
     })
 
@@ -187,7 +187,7 @@ describe('res', function(){
 
       request(app)
         .get("/")
-        .expect("Content-Type", "text/plain; charset=utf-8")
+        .expect("Content-Type", "text/plain")
         .expect(200, "hey", done);
     })
 

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -61,31 +61,32 @@ describe('res', function(){
       .expect(200, '["123","456"]', done);
     })
 
-    it('should not set a charset of one is already set', function (done) {
+    it('should set Content-Type without mime lookup', function (done) {
       var app = express();
 
       app.use(function (req, res) {
-        res.set('Content-Type', 'text/html; charset=lol');
+        res.set('Content-Type', 'text/html');
         res.end();
       });
 
       request(app)
       .get('/')
-      .expect('Content-Type', 'text/html; charset=lol')
+      .expect('Content-Type', 'text/html')
       .expect(200, done);
     })
 
-    it('should throw when Content-Type is an array', function (done) {
-      var app = express()
+    it('should not perform mime lookup for extension-like values', function (done) {
+      var app = express();
 
       app.use(function (req, res) {
-        res.set('Content-Type', ['text/html'])
-        res.end()
+        res.set('Content-Type', 'html');
+        res.end();
       });
 
       request(app)
       .get('/')
-      .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
+      .expect('Content-Type', 'html')
+      .expect(200, done);
     })
   })
 


### PR DESCRIPTION
  Closes #7034    
              
  `res.set('Content-Type', value)` was silently calling `mime.contentType()` on the value, which would:
  - Perform a mime-type lookup if the value had no `/` (e.g. `'html'` → `'text/html; charset=utf-8'`)                
  - Append a charset if none was present (e.g. `'text/plain'` → `'text/plain; charset=utf-8'`)       
                                                                                                                     
  This hidden mutation is unexpected — `res.set` is a generic header setter and should not transform user input.
                                                                                                                     
  ## Solution     
                                                                                                                     
  Remove the Content-Type special-casing from `res.set`/`res.header`. Users who want mime lookup + charset behaviour
  should use `res.type()`, which already exists for exactly this purpose.                                            
                                                                         
  ## Changes                                                                                                         
                  
  - Remove the `mime.contentType()` block from `res.set`
  - `res.json` now explicitly sets `'application/json; charset=utf-8'` so its behaviour is unchanged
  - Update tests to reflect the new pass-through semantics of `res.set`                             
                                                                                                                     
  ## Breaking Change
                                                                                                                     
  `res.set('Content-Type', 'text/plain')` will no longer silently become `text/plain; charset=utf-8`. Use
  `res.type('text/plain')` if charset injection is desired.      