### PR TITLE
fix: keep repeated extended query params as arrays beyond 20 values

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -266,6 +266,7 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    arrayLimit: 1000
   });
 }

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -38,6 +38,17 @@ describe('req', function(){
         .get('/?user.name=tj')
         .expect(200, '{"user.name":"tj"}', done);
       });
+
+      it('should parse repeated keys over 20 values as an array', function (done) {
+        var app = createApp('extended');
+        var query = Array.from({ length: 21 }, function (_, i) {
+          return 'tenancyIds=' + (i + 1)
+        }).join('&')
+
+        request(app)
+        .get('/?' + query)
+        .expect(200, '{"tenancyIds":["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]}', done);
+      });
     });
 
     describe('when "query parser" is simple', function () {


### PR DESCRIPTION
## Summary
- fix `extended` query parser behavior for repeated keys with >20 values
- set `arrayLimit: 1000` in `parseExtendedQueryString` so repeated key form (`a=1&a=2...`) keeps returning arrays
- add regression test for 21 repeated `tenancyIds` values

## Why
Issue #7147 reports that in 4.22.x repeated query keys switch from array to object once count exceeds 20, which is a behavior break for existing apps.

## Testing
- ran test suite in Docker (`node:22`)
- validated `req.query` extended parser test including new regression case
