### PR TITLE
refactor: use rest parameters in request.js

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -6,35 +6,35 @@
  * MIT Licensed
  */
 
-'use strict';
+"use strict";
 
 /**
  * Module dependencies.
  * @private
  */
 
-var accepts = require('accepts');
-var isIP = require('node:net').isIP;
-var typeis = require('type-is');
-var http = require('node:http');
-var fresh = require('fresh');
-var parseRange = require('range-parser');
-var parse = require('parseurl');
-var proxyaddr = require('proxy-addr');
+var accepts = require("accepts");
+var isIP = require("node:net").isIP;
+var typeis = require("type-is");
+var http = require("node:http");
+var fresh = require("fresh");
+var parseRange = require("range-parser");
+var parse = require("parseurl");
+var proxyaddr = require("proxy-addr");
 
 /**
  * Request prototype.
  * @public
  */
 
-var req = Object.create(http.IncomingMessage.prototype)
+var req = Object.create(http.IncomingMessage.prototype);
 
 /**
  * Module exports.
  * @public
  */
 
-module.exports = req
+module.exports = req;
 
 /**
  * Return request header.
@@ -44,14 +44,14 @@ module.exports = req
  *
  * Examples:
  *
- *     req.get('Content-Type');
- *     // => "text/plain"
+ * req.get('Content-Type');
+ * // => "text/plain"
  *
- *     req.get('content-type');
- *     // => "text/plain"
+ * req.get('content-type');
+ * // => "text/plain"
  *
- *     req.get('Something');
- *     // => undefined
+ * req.get('Something');
+ * // => undefined
  *
  * Aliased as `req.header()`.
  *
@@ -60,23 +60,21 @@ module.exports = req
  * @public
  */
 
-req.get =
-req.header = function header(name) {
+req.get = req.header = function header(name) {
   if (!name) {
-    throw new TypeError('name argument is required to req.get');
+    throw new TypeError("name argument is required to req.get");
   }
 
-  if (typeof name !== 'string') {
-    throw new TypeError('name must be a string to req.get');
+  if (typeof name !== "string") {
+    throw new TypeError("name must be a string to req.get");
   }
 
   var lc = name.toLowerCase();
 
   switch (lc) {
-    case 'referer':
-    case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
+    case "referer":
+    case "referrer":
+      return this.headers.referrer || this.headers.referer;
     default:
       return this.headers[lc];
   }
@@ -95,38 +93,38 @@ req.header = function header(name) {
  *
  * Examples:
  *
- *     // Accept: text/html
- *     req.accepts('html');
- *     // => "html"
+ * // Accept: text/html
+ * req.accepts('html');
+ * // => "html"
  *
- *     // Accept: text/*, application/json
- *     req.accepts('html');
- *     // => "html"
- *     req.accepts('text/html');
- *     // => "text/html"
- *     req.accepts('json', 'text');
- *     // => "json"
- *     req.accepts('application/json');
- *     // => "application/json"
+ * // Accept: text/*, application/json
+ * req.accepts('html');
+ * // => "html"
+ * req.accepts('text/html');
+ * // => "text/html"
+ * req.accepts('json', 'text');
+ * // => "json"
+ * req.accepts('application/json');
+ * // => "application/json"
  *
- *     // Accept: text/*, application/json
- *     req.accepts('image/png');
- *     req.accepts('png');
- *     // => false
+ * // Accept: text/*, application/json
+ * req.accepts('image/png');
+ * req.accepts('png');
+ * // => false
  *
- *     // Accept: text/*;q=.5, application/json
- *     req.accepts(['html', 'json']);
- *     req.accepts('html', 'json');
- *     // => "json"
+ * // Accept: text/*;q=.5, application/json
+ * req.accepts(['html', 'json']);
+ * req.accepts('html', 'json');
+ * // => "json"
  *
  * @param {String|Array} type(s)
  * @return {String|Array|Boolean}
  * @public
  */
 
-req.accepts = function(){
+req.accepts = function (...types) {
   var accept = accepts(this);
-  return accept.types.apply(accept, arguments);
+  return accept.types(...types);
 };
 
 /**
@@ -137,9 +135,9 @@ req.accepts = function(){
  * @public
  */
 
-req.acceptsEncodings = function(){
+req.acceptsEncodings = function (...encodings) {
   var accept = accepts(this);
-  return accept.encodings.apply(accept, arguments);
+  return accept.encodings(...encodings);
 };
 
 /**
@@ -153,22 +151,22 @@ req.acceptsEncodings = function(){
  *
  * Examples:
  *
- *     // Accept-Charset: utf-8, iso-8859-1
- *     req.acceptsCharsets('utf-8');
- *     // => "utf-8"
+ * // Accept-Charset: utf-8, iso-8859-1
+ * req.acceptsCharsets('utf-8');
+ * // => "utf-8"
  *
- *     req.acceptsCharsets('utf-8', 'iso-8859-1');
- *     // => "utf-8"
+ * req.acceptsCharsets('utf-8', 'iso-8859-1');
+ * // => "utf-8"
  *
- *     req.acceptsCharsets('utf-8, utf-16');
- *     // => "utf-8"
+ * req.acceptsCharsets('utf-8, utf-16');
+ * // => "utf-8"
  *
  * @param {...String} charsets - The charset(s) to check against the `Accept-Charset` header.
  * @return {String|Array} - The best matching charset, or an array of acceptable charsets.
  * @public
  */
 
-req.acceptsCharsets = function(...charsets) {
+req.acceptsCharsets = function (...charsets) {
   const accept = accepts(this);
   return accept.charsets(...charsets);
 };
@@ -182,7 +180,7 @@ req.acceptsCharsets = function(...charsets) {
  * @public
  */
 
-req.acceptsLanguages = function(...languages) {
+req.acceptsLanguages = function (...languages) {
   return accepts(this).languages(...languages);
 };
 
@@ -212,7 +210,7 @@ req.acceptsLanguages = function(...languages) {
  */
 
 req.range = function range(size, options) {
-  var range = this.get('Range');
+  var range = this.get("Range");
   if (!range) return;
   return parseRange(size, range, options);
 };
@@ -227,8 +225,8 @@ req.range = function range(size, options) {
  * @api public
  */
 
-defineGetter(req, 'query', function query(){
-  var queryparse = this.app.get('query parser fn');
+defineGetter(req, "query", function query() {
+  var queryparse = this.app.get("query parser fn");
 
   if (!queryparse) {
     // parsing is disabled
@@ -246,35 +244,32 @@ defineGetter(req, 'query', function query(){
  *
  * Examples:
  *
- *      // With Content-Type: text/html; charset=utf-8
- *      req.is('html');
- *      req.is('text/html');
- *      req.is('text/*');
- *      // => true
+ * // With Content-Type: text/html; charset=utf-8
+ * req.is('html');
+ * req.is('text/html');
+ * req.is('text/*');
+ * // => true
  *
- *      // When Content-Type is application/json
- *      req.is('json');
- *      req.is('application/json');
- *      req.is('application/*');
- *      // => true
+ * // When Content-Type is application/json
+ * req.is('json');
+ * req.is('application/json');
+ * req.is('application/*');
+ * // => true
  *
- *      req.is('html');
- *      // => false
+ * req.is('html');
+ * // => false
  *
  * @param {String|Array} types...
  * @return {String|false|null}
  * @public
  */
 
-req.is = function is(types) {
+req.is = function is(...types) {
   var arr = types;
 
   // support flattened arguments
-  if (!Array.isArray(types)) {
-    arr = new Array(arguments.length);
-    for (var i = 0; i < arr.length; i++) {
-      arr[i] = arguments[i];
-    }
+  if (types.length === 1 && Array.isArray(types[0])) {
+    arr = types[0];
   }
 
   return typeis(this, arr);
@@ -294,11 +289,9 @@ req.is = function is(types) {
  * @public
  */
 
-defineGetter(req, 'protocol', function protocol(){
-  var proto = this.socket.encrypted
-    ? 'https'
-    : 'http';
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "protocol", function protocol() {
+  var proto = this.socket.encrypted ? "https" : "http";
+  var trust = this.app.get("trust proxy fn");
 
   if (!trust(this.socket.remoteAddress, 0)) {
     return proto;
@@ -306,25 +299,23 @@ defineGetter(req, 'protocol', function protocol(){
 
   // Note: X-Forwarded-Proto is normally only ever a
   //       single value, but this is to be safe.
-  var header = this.get('X-Forwarded-Proto') || proto
-  var index = header.indexOf(',')
+  var header = this.get("X-Forwarded-Proto") || proto;
+  var index = header.indexOf(",");
 
-  return index !== -1
-    ? header.substring(0, index).trim()
-    : header.trim()
+  return index !== -1 ? header.substring(0, index).trim() : header.trim();
 });
 
 /**
  * Short-hand for:
  *
- *    req.protocol === 'https'
+ * req.protocol === 'https'
  *
  * @return {Boolean}
  * @public
  */
 
-defineGetter(req, 'secure', function secure(){
-  return this.protocol === 'https';
+defineGetter(req, "secure", function secure() {
+  return this.protocol === "https";
 });
 
 /**
@@ -337,8 +328,8 @@ defineGetter(req, 'secure', function secure(){
  * @public
  */
 
-defineGetter(req, 'ip', function ip(){
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "ip", function ip() {
+  var trust = this.app.get("trust proxy fn");
   return proxyaddr(this, trust);
 });
 
@@ -354,15 +345,15 @@ defineGetter(req, 'ip', function ip(){
  * @public
  */
 
-defineGetter(req, 'ips', function ips() {
-  var trust = this.app.get('trust proxy fn');
+defineGetter(req, "ips", function ips() {
+  var trust = this.app.get("trust proxy fn");
   var addrs = proxyaddr.all(this, trust);
 
   // reverse the order (to farthest -> closest)
   // and remove socket address
-  addrs.reverse().pop()
+  addrs.reverse().pop();
 
-  return addrs
+  return addrs;
 });
 
 /**
@@ -380,15 +371,13 @@ defineGetter(req, 'ips', function ips() {
  * @public
  */
 
-defineGetter(req, 'subdomains', function subdomains() {
+defineGetter(req, "subdomains", function subdomains() {
   var hostname = this.hostname;
 
   if (!hostname) return [];
 
-  var offset = this.app.get('subdomain offset');
-  var subdomains = !isIP(hostname)
-    ? hostname.split('.').reverse()
-    : [hostname];
+  var offset = this.app.get("subdomain offset");
+  var subdomains = !isIP(hostname) ? hostname.split(".").reverse() : [hostname];
 
   return subdomains.slice(offset);
 });
@@ -400,7 +389,7 @@ defineGetter(req, 'subdomains', function subdomains() {
  * @public
  */
 
-defineGetter(req, 'path', function path() {
+defineGetter(req, "path", function path() {
   return parse(this).pathname;
 });
 
@@ -415,16 +404,16 @@ defineGetter(req, 'path', function path() {
  * @public
  */
 
-defineGetter(req, 'host', function host(){
-  var trust = this.app.get('trust proxy fn');
-  var val = this.get('X-Forwarded-Host');
+defineGetter(req, "host", function host() {
+  var trust = this.app.get("trust proxy fn");
+  var val = this.get("X-Forwarded-Host");
 
   if (!val || !trust(this.socket.remoteAddress, 0)) {
-    val = this.get('Host');
-  } else if (val.indexOf(',') !== -1) {
+    val = this.get("Host");
+  } else if (val.indexOf(",") !== -1) {
     // Note: X-Forwarded-Host is normally only ever a
     //       single value, but this is to be safe.
-    val = val.substring(0, val.indexOf(',')).trimRight()
+    val = val.substring(0, val.indexOf(",")).trimRight();
   }
 
   return val || undefined;
@@ -441,20 +430,16 @@ defineGetter(req, 'host', function host(){
  * @api public
  */
 
-defineGetter(req, 'hostname', function hostname(){
+defineGetter(req, "hostname", function hostname() {
   var host = this.host;
 
   if (!host) return;
 
   // IPv6 literal support
-  var offset = host[0] === '['
-    ? host.indexOf(']') + 1
-    : 0;
-  var index = host.indexOf(':', offset);
+  var offset = host[0] === "[" ? host.indexOf("]") + 1 : 0;
+  var index = host.indexOf(":", offset);
 
-  return index !== -1
-    ? host.substring(0, index)
-    : host;
+  return index !== -1 ? host.substring(0, index) : host;
 });
 
 /**
@@ -466,20 +451,20 @@ defineGetter(req, 'hostname', function hostname(){
  * @public
  */
 
-defineGetter(req, 'fresh', function(){
+defineGetter(req, "fresh", function () {
   var method = this.method;
-  var res = this.res
-  var status = res.statusCode
+  var res = this.res;
+  var status = res.statusCode;
 
   // GET or HEAD for weak freshness validation only
-  if ('GET' !== method && 'HEAD' !== method) return false;
+  if ("GET" !== method && "HEAD" !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
   if ((status >= 200 && status < 300) || 304 === status) {
     return fresh(this.headers, {
-      'etag': res.get('ETag'),
-      'last-modified': res.get('Last-Modified')
-    })
+      etag: res.get("ETag"),
+      "last-modified": res.get("Last-Modified"),
+    });
   }
 
   return false;
@@ -494,7 +479,7 @@ defineGetter(req, 'fresh', function(){
  * @public
  */
 
-defineGetter(req, 'stale', function stale(){
+defineGetter(req, "stale", function stale() {
   return !this.fresh;
 });
 
@@ -505,9 +490,9 @@ defineGetter(req, 'stale', function stale(){
  * @public
  */
 
-defineGetter(req, 'xhr', function xhr(){
-  var val = this.get('X-Requested-With') || '';
-  return val.toLowerCase() === 'xmlhttprequest';
+defineGetter(req, "xhr", function xhr() {
+  var val = this.get("X-Requested-With") || "";
+  return val.toLowerCase() === "xmlhttprequest";
 });
 
 /**
@@ -522,6 +507,6 @@ function defineGetter(obj, name, getter) {
   Object.defineProperty(obj, name, {
     configurable: true,
     enumerable: true,
-    get: getter
+    get: getter,
   });
 }


### PR DESCRIPTION
Cleaned up some legacy arguments usage in lib/request.js.

What changed:
-Switched req.accepts, req.acceptsEncodings, and req.is to use rest parameters (...types).
-Removed the manual for loop in req.is that was used to clone the arguments object.
-Replaced .apply() calls with the spread operator.

Testing:
Verified with test/req.accepts.js and test/req.is.js. All tests passed.