### PR TITLE
fix: fall back to JSON when JSONP callback sanitizes to empty

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -277,13 +277,15 @@ res.jsonp = function jsonp(obj) {
     callback = callback[0];
   }
 
+  // restrict callback charset
+  if (typeof callback === 'string') {
+    callback = callback.replace(/[^\[\]\w$.]/g, '');
+  }
+
   // jsonp
   if (typeof callback === 'string' && callback.length !== 0) {
     this.set('X-Content-Type-Options', 'nosniff');
     this.set('Content-Type', 'text/javascript');
-
-    // restrict callback charset
-    callback = callback.replace(/[^\[\]\w$.]/g, '');
 
     if (body === undefined) {
       // empty argument

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -87,6 +87,22 @@ describe('res', function(){
       .expect(200, /foobar\(\{\}\);/, done);
     })
 
+    it('should not use JSONP when callback sanitizes to empty', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonp({ count: 1 });
+      });
+
+      // A callback of all disallowed characters sanitizes to an empty string.
+      // This should fall back to plain JSON, not produce invalid JavaScript
+      // like: /**/ typeof  === 'function' &&  ({"count":1});
+      request(app)
+      .get('/?callback=!!!')
+      .expect('Content-Type', 'application/json; charset=utf-8')
+      .expect(200, '{"count":1}', done);
+    })
+
     it('should escape utf whitespace', function(done){
       var app = express();
 


### PR DESCRIPTION
## Summary

`res.jsonp()` sanitizes the callback parameter by stripping disallowed characters (`/[^\[\]\w$.]/g`), but the JSONP branch is entered *before* sanitization. A callback consisting entirely of disallowed characters (e.g. `!!!`) passes the `callback.length !== 0` check, sets `Content-Type: text/javascript`, then sanitizes to an empty string, producing malformed JavaScript:

```
/**/ typeof  === 'function' &&  ({"count":1});
```

This patch moves the sanitization step before the JSONP branch check so an all-invalid callback is reduced to empty first and falls through to the plain JSON path, returning valid `application/json`.

## Changes

- **`lib/response.js`** — Move `callback.replace(…)` before the `callback.length !== 0` guard.
- **`test/res.jsonp.js`** — Add regression test: `?callback=!!!` expects `application/json` with valid JSON body.

## Test plan

- [x] New test fails before the fix (`text/javascript` with malformed JS)
- [x] New test passes after the fix (`application/json` with `{"count":1}`)
- [x] All 24 `res.jsonp` tests pass
- [x] Full Express test suite passes (1250 tests)
