### PR TITLE
fix: fall back to JSON when JSONP callback sanitizes to empty string

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -277,13 +277,16 @@ res.jsonp = function jsonp(obj) {
     callback = callback[0];
   }
 
+  // sanitize callback before entering JSONP branch
+  if (typeof callback === 'string' && callback.length !== 0) {
+    // restrict callback charset
+    callback = callback.replace(/[^\[\]\w$.]/g, '');
+  }
+
   // jsonp
   if (typeof callback === 'string' && callback.length !== 0) {
     this.set('X-Content-Type-Options', 'nosniff');
     this.set('Content-Type', 'text/javascript');
-
-    // restrict callback charset
-    callback = callback.replace(/[^\[\]\w$.]/g, '');
 
     if (body === undefined) {
       // empty argument

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -87,6 +87,47 @@ describe('res', function(){
       .expect(200, /foobar\(\{\}\);/, done);
     })
 
+    it('should fall back to JSON when callback sanitizes to empty', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonp({ count: 1 });
+      });
+
+      request(app)
+      .get('/?callback=!!!')
+      .expect('Content-Type', 'application/json; charset=utf-8')
+      .expect(200, '{"count":1}', done);
+    })
+
+    it('should fall back to JSON for callback with only special chars', function(done){
+      var app = express();
+
+      app.get('/', function(req, res){
+        res.type('application/vnd.example+json');
+        res.jsonp({ hello: 'world' });
+      });
+
+      request(app)
+      .get('/?callback=%3C%3E%21%40%23')
+      .expect('Content-Type', 'application/vnd.example+json; charset=utf-8')
+      .expect(utils.shouldNotHaveHeader('X-Content-Type-Options'))
+      .expect(200, '{"hello":"world"}', done);
+    })
+
+    it('should use sanitized callback with mixed valid/invalid chars', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.jsonp({ count: 1 });
+      });
+
+      request(app)
+      .get('/?callback=foo!bar')
+      .expect('Content-Type', 'text/javascript; charset=utf-8')
+      .expect(200, /foobar\(\{"count":1\}\);/, done);
+    })
+
     it('should escape utf whitespace', function(done){
       var app = express();
 


### PR DESCRIPTION
## Summary
When `res.jsonp()` receives a callback containing only characters that get
stripped by the sanitization regex (e.g. `?callback=!!!` or `?callback=<>@#`),
the current code sets `Content-Type: text/javascript` *before* sanitizing,
then produces invalid JavaScript output:

```js
/**/ typeof  === 'function' &&  ({"count":1});

This happens because the callback.length !== 0 check runs on the
unsanitized value. After callback.replace(/[^\[\]\w$.]/g, '') strips
everything, the empty string gets interpolated into the JSONP wrapper.

Fix

Move the charset sanitization before the JSONP branch conditional,
so the length check applies to the sanitized callback. When the sanitized
result is empty, the response falls back to a normal JSON response — the
same behavior as when no callback parameter is provided at all.

Test plan

- Added test: callback of only invalid chars (!!!) → falls back to application/json
- Added test: URL-encoded special chars (<>!@#) → JSON fallback, no X-Content-Type-Options override
- Added test: mixed valid/invalid chars (foo!bar) → JSONP with sanitized callback foobar
- All 1252 existing tests pass
- ESLint clean