### PR TITLE
Workflow modified

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -1,0 +1,71 @@
+name: CI Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - monkci-ubuntu-24.04
+          - monkci-ubuntu-24.04-4-6000iops
+          - monkci-ubuntu-24.04-4-3600iops
+          - monkci-ubuntu-24.04-4-4000iops
+          - monkci-ubuntu-24.04-4-3900iops
+        node-version: [22]
+
+    name: build-and-test (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Record start time
+        id: start
+        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Configure npm loglevel
+        run: npm config set loglevel error
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Output Node and NPM versions
+        run: |
+          echo "Node.js version: $(node -v)"
+          echo "NPM version: $(npm -v)"
+
+      - name: Run tests
+        run: npm run test-ci
+
+      - name: Record end time and compute duration
+        if: always()
+        run: |
+          END=$(date +%s)
+          START=${{ steps.start.outputs.start }}
+          DURATION=$((END - START))
+          echo "Runner     : ${{ matrix.runner }}"
+          echo "Total time : ${DURATION}s"
+          echo "duration=${DURATION}" >> $GITHUB_OUTPUT
+        id: end
+
+      - name: Timing summary
+        if: always()
+        run: |
+          echo "### Benchmark result" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner | Duration (s) |" >> $GITHUB_STEP_SUMMARY
+          echo "| ------ | ------------ |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`${{ matrix.runner }}\` | ${{ steps.end.outputs.duration }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -12,11 +12,8 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - monkci-ubuntu-24.04
-          - monkci-ubuntu-24.04-4-6000iops
+          - monkci-runners-4vcpu
           - monkci-ubuntu-24.04-4-3600iops
-          - monkci-ubuntu-24.04-4-4000iops
-          - monkci-ubuntu-24.04-4-3900iops
         node-version: [22]
 
     name: build-and-test (${{ matrix.runner }})


### PR DESCRIPTION
# Add CI Benchmark workflow for MonkCI vs GitHub-hosted runner comparison

## 📝 Summary
Added `.github/workflows/ci-benchmark.yml` — a new workflow designed to benchmark `build-and-test` job timing across various MonkCI runners against the standard `ubuntu-latest` GitHub-hosted runner. 

### Key Changes:
* **Job Renamed**: The job is now named `build-and-test` with a dynamic display name: `name: build-and-test (${{ matrix.runner }})`.
* **Runner Matrix**: Implemented a `matrix.runner` strategy running in parallel with `fail-fast: false`. It covers 5 MonkCI variants alongside `ubuntu-latest` as the baseline.
* **CI Test Steps**: Replaced previous build steps with a standard Node.js CI pipeline for an accurate apples-to-apples comparison.
* **Timing Instrumentation**: Added step-level timing to capture Unix timestamps (`date +%s`) at the start and end (using `always()`). It computes `duration = end - start` and writes a Markdown table row to `$GITHUB_STEP_SUMMARY`.

## 🎯 Motivation
To quantify the performance difference between MonkCI runners (varying IOPS tiers) and the standard GitHub-hosted `ubuntu-latest` runner on a real Node.js CI workload (install + test).

## 🚀 Runners Under Test

| Runner | Role / Type |
| :--- | :--- |
| `ubuntu-latest` | GitHub standard (baseline) |
| `monkci-ubuntu-24.04` | MonkCI default |
| `monkci-ubuntu-24.04-4-6000iops` | MonkCI 6000 IOPS |
| `monkci-ubuntu-24.04-4-3600iops` | MonkCI 3600 IOPS |
| `monkci-ubuntu-24.04-4-4000iops` | MonkCI 4000 IOPS |
| `monkci-ubuntu-24.04-4-3900iops` | MonkCI 3900 IOPS |

## 🛠️ What each job does
1.  **Records start timestamp** into `$GITHUB_OUTPUT` before any work begins.
2.  **Checks out the repo** (`actions/checkout@v4`).
3.  **Sets up Node.js 22** (`actions/setup-node@v4`).
4.  **Configures npm** (`npm config set loglevel error`).
5.  **Installs dependencies** (`npm install`).
6.  **Runs tests** (`npm run test-ci`).
7.  **Records end time and computes duration**, appending a Markdown table row to the Action's Job Summary.

## 📊 How to read the results
After the workflow completes, open the Actions run and check each job's Summary tab. Each runner will output a summary table looking like this:

| Runner                         | Duration (s) |
| ------------------------------ | ------------ |
| ubuntu-latest                  | 85           |
| monkci-ubuntu-24.04-4-6000iops | 47           |

Compare each MonkCI row against `ubuntu-latest` to see the absolute time saved per runner tier from a single workflow run.

## ✅ Test Plan
- [ ] Trigger workflow via `workflow_dispatch` to confirm all 6 matrix jobs start.
- [ ] Verify timing summary appears in each job's Summary tab.
- [ ] Confirm `ubuntu-latest` job completes successfully as the baseline reference.
- [ ] Compare durations across MonkCI IOPS tiers to identify the best-performing runner.