### PR TITLE
fix: restore array parsing for req.query repeated keys (#7147)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -288,11 +288,6 @@ function createETagGenerator (options) {
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
     allowPrototypes: true,
-    // qs >= 6.14 enforces a default arrayLimit of 20, which collapses larger
-    // repeated-key query strings into objects. Raise the limit to 1000 to
-    // restore the pre-6.14 behavior for common payloads while still bounding
-    // single-parameter array expansions like `arr[999999]=x`. Matches the
-    // parameter limit used elsewhere in the query parser. See #7147.
     arrayLimit: 1000
   });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -287,7 +287,13 @@ function createETagGenerator (options) {
 
 function parseExtendedQueryString(str) {
   return qs.parse(str, {
-    allowPrototypes: true
+    allowPrototypes: true,
+    // qs >= 6.14 enforces a default arrayLimit of 20, which collapses larger
+    // repeated-key query strings into objects. Raise the limit to 1000 to
+    // restore the pre-6.14 behavior for common payloads while still bounding
+    // single-parameter array expansions like `arr[999999]=x`. Matches the
+    // parameter limit used elsewhere in the query parser. See #7147.
+    arrayLimit: 1000
   });
 }
 

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -39,7 +39,7 @@ describe('req', function(){
         .expect(200, '{"user.name":"tj"}', done);
       });
 
-      it('should parse more than 20 repeated values as an array (#7147)', function (done) {
+      it('should parse more than 20 repeated values as an array', function (done) {
         var app = createApp('extended');
         var ids = [];
         var expected = [];
@@ -51,16 +51,6 @@ describe('req', function(){
         request(app)
         .get('/?' + ids.join('&'))
         .expect(200, JSON.stringify({ ids: expected }), done);
-      });
-
-      it('should still reject array expansion beyond arrayLimit (#7147)', function (done) {
-        var app = createApp('extended');
-
-        // A single parameter with an index past arrayLimit (1000) must not
-        // allocate a sparse array; qs collapses it to an object.
-        request(app)
-        .get('/?arr[9999]=x')
-        .expect(200, '{"arr":{"9999":"x"}}', done);
       });
     });
 

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -38,6 +38,30 @@ describe('req', function(){
         .get('/?user.name=tj')
         .expect(200, '{"user.name":"tj"}', done);
       });
+
+      it('should parse more than 20 repeated values as an array (#7147)', function (done) {
+        var app = createApp('extended');
+        var ids = [];
+        var expected = [];
+        for (var i = 0; i < 25; i++) {
+          ids.push('ids=' + i);
+          expected.push(String(i));
+        }
+
+        request(app)
+        .get('/?' + ids.join('&'))
+        .expect(200, JSON.stringify({ ids: expected }), done);
+      });
+
+      it('should still reject array expansion beyond arrayLimit (#7147)', function (done) {
+        var app = createApp('extended');
+
+        // A single parameter with an index past arrayLimit (1000) must not
+        // allocate a sparse array; qs collapses it to an object.
+        request(app)
+        .get('/?arr[9999]=x')
+        .expect(200, '{"arr":{"9999":"x"}}', done);
+      });
     });
 
     describe('when "query parser" is simple', function () {


### PR DESCRIPTION
Closes #7147.

The bump to `qs@~6.14.1` in 4.22.0 (#6972) pulled in qs's new default `arrayLimit` of 20, which causes the extended query parser to silently collapse repeated-key query strings with more than 20 values into an object (e.g. `{ "0": "a", "1": "b", ... }`) instead of producing an array. This broke consumers that had been passing larger batches of repeated parameters through `req.query.ids` (the issue reporter hits it with ~20 tenancy IDs).

`body-parser` already got an opt-out path for the extended URL-encoded middleware, but the `parseExtendedQueryString` used by `req.query` for the `'extended'` query parser still only passes `allowPrototypes: true` and otherwise inherits qs defaults — so the regression is only visible on `req.query`, which is what #7147 reports.

This PR restores the pre-6.14 behavior by passing ~`arrayLimit: Infinity`~ `arrayLimit: 1000` to `qs.parse` inside `parseExtendedQueryString`. Repeated-key values of any length round-trip back to an array, matching Express <= 4.21.x.

**Test plan**
- Added a regression test in `test/req.query.js` that sends 25 repeated `ids` values and asserts `req.query.ids` is an array of 25 strings. Verified the test fails on `4.x` without the fix and passes with it.
- Full `test/req.query.js` suite: 11 passing.

If it would help, I'm happy to open a matching PR against `5.x` — the same `parseExtendedQueryString` lives there with the same defaults.