### PR TITLE
fix: prevent Content-Type header from being set to "false"

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -673,7 +673,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -75,6 +75,20 @@ describe('res', function(){
       .expect(200, done);
     })
 
+    it('should not set Content-Type to "false" for unknown type', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'bogus');
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'bogus')
+      .expect(200, done);
+    })
+
     it('should throw when Content-Type is an array', function (done) {
       var app = express()
 


### PR DESCRIPTION
When `res.set('Content-Type', value)` is called with an unrecognized MIME type, `mime.contentType(value)` returns `false`. This `false` was passed directly to `setHeader`, corrupting the Content-Type header to the literal string "false". Fall back to the original value when `mime.contentType()` cannot resolve the type.