### PR TITLE
fix: check referer before referrer in req.get()

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -75,8 +75,8 @@ req.header = function header(name) {
   switch (lc) {
     case 'referer':
     case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
+      return this.headers.referer
+        || this.headers.referrer;
     default:
       return this.headers[lc];
   }


### PR DESCRIPTION
Good day

This PR addresses issue #3951 by changing the order in which `req.get('Referer')` checks the HTTP headers.

## Changes

In `lib/request.js`, the `req.header()` function now checks for the standard `referer` (single r) header before the commonly confused `referrer` (double r) header:

```javascript
// Before
return this.headers.referrer || this.headers.referer;

// After
return this.headers.referer || this.headers.referrer;
``

## Rationale

1. **Standards compliance**: According to HTTP specification, `Referer` (single r) is the correct header name
2. **Security**: The single-r variant is harder to spoof as some browsers block attempts to modify it
3. **Consistency**: This makes the behavior more intuitive and standards-compliant

This is a non-breaking change as existing code that uses `req.get('Referer')` will still work - if only `Referrer` is set, it will be returned via the fallback.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof