### PR TITLE
fix: improve error message for BigInt serialization in res.json()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1023,9 +1023,21 @@ function sendfile(res, file, options, callback) {
 function stringify (value, replacer, spaces, escape) {
   // v8 checks arguments.length for optimizing simple call
   // https://bugs.chromium.org/p/v8/issues/detail?id=4730
-  var json = replacer || spaces
-    ? JSON.stringify(value, replacer, spaces)
-    : JSON.stringify(value);
+  var json;
+  try {
+    json = replacer || spaces
+      ? JSON.stringify(value, replacer, spaces)
+      : JSON.stringify(value);
+  } catch (err) {
+    if (err instanceof TypeError && err.message.indexOf('BigInt') !== -1) {
+      throw new TypeError(
+        "res.json() cannot serialize BigInt values by default. " +
+        "Use app.set('json replacer') with a custom replacer function to handle BigInt serialization. " +
+        "Example: app.set('json replacer', (key, val) => typeof val === 'bigint' ? val.toString() : val)"
+      );
+    }
+    throw err;
+  }
 
   if (escape && typeof json === 'string') {
     json = json.replace(/[<>&]/g, function (c) {


### PR DESCRIPTION
## Problem

When `res.json()` is called with an object containing a `BigInt` value, Node's `JSON.stringify()` throws:

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at stringify (.../node_modules/express/lib/response.js:...)
```

The error correctly identifies BigInt as the cause, but gives no hint that Express has a built-in escape hatch — `app.set('json replacer')` — to handle it. Developers unfamiliar with Express's replacer option have to go searching to find the fix.

Closes #7186

## Solution

Catch the BigInt `TypeError` inside the `stringify()` helper in `lib/response.js` and re-throw it with an Express-specific message that points directly to the `json replacer` option:

```
res.json() cannot serialize BigInt values by default. Use app.set('json replacer') with a custom replacer function to handle BigInt serialization. Example: app.set('json replacer', (key, val) => typeof val === 'bigint' ? val.toString() : val)
```

All other errors from `JSON.stringify` are re-thrown unchanged — no behaviour change for non-BigInt cases.

## Changes

- `lib/response.js`: wrap `JSON.stringify` in `try/catch` inside `stringify()`, detect BigInt errors by message, and re-throw with a message that surfaces the `json replacer` option

I attest that I wrote this code and agree to the Developer Certificate of Origin (DCO).