### PR TITLE
docs(readme): clarify package.json setup for quick start

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,6 +106,8 @@ express /tmp/foo && cd /tmp/foo
 npm install
 ```
 
+  If you are starting from the minimal example above instead of using `express-generator`, create a `package.json`, install `express`, and then run your entry file with Node.js.
+
   Start the server:
 
 ```bash


### PR DESCRIPTION
## What changed

Improved the README installation and quickstart flow:

- clarified that new users should run `npm init` first
- explained the `package.json` setup step
- clarified when to run Node directly vs using the generator

## Why

Beginners often get confused because the Express quickstart assumes existing Node.js project knowledge. This makes the setup path clearer for first-time users.

<!-- Certificate of Origin: By making this contribution, I certify that my contribution is made under the terms of the DCO. -->