### PR TITLE
Cover array input for `req.acceptsCharsets()`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -143,13 +143,14 @@ req.acceptsEncodings = function(){
 };
 
 /**
- * Checks if the specified `charset`s are acceptable based on the request's `Accept-Charset` header.
- * Returns the best matching charset or an array of acceptable charsets.
+ * Check if the given `charset(s)` are acceptable, returning
+ * the best match when true, otherwise `false`, in which
+ * case you should respond with 406 "Not Acceptable".
  *
- * The `charset` argument(s) can be:
- * - A single charset string (e.g., "utf-8")
- * - Multiple charset strings as arguments (e.g., `"utf-8", "iso-8859-1"`)
- * - A comma-delimited list of charsets (e.g., `"utf-8, iso-8859-1"`)
+ * The `charset` value may be a single charset string
+ * such as "utf-8", an argument list such as
+ * `"utf-8", "iso-8859-1"`, or an array `["utf-8", "iso-8859-1"]`.
+ * When a list or array is given, the _best_ match, if any is returned.
  *
  * Examples:
  *
@@ -160,11 +161,11 @@ req.acceptsEncodings = function(){
  *     req.acceptsCharsets('utf-8', 'iso-8859-1');
  *     // => "utf-8"
  *
- *     req.acceptsCharsets('utf-8, utf-16');
+ *     req.acceptsCharsets(['utf-8', 'iso-8859-1']);
  *     // => "utf-8"
  *
- * @param {...String} charsets - The charset(s) to check against the `Accept-Charset` header.
- * @return {String|Array} - The best matching charset, or an array of acceptable charsets.
+ * @param {String|Array} charset(s)
+ * @return {String|Array|Boolean}
  * @public
  */
 

--- a/test/req.acceptsCharsets.js
+++ b/test/req.acceptsCharsets.js
@@ -58,6 +58,19 @@ describe('req', function(){
         .set('Accept-Charset', 'iso-8859-1, utf-8')
         .expect('iso-8859-1', done);
       })
+
+      it('should return the best matching charset from an array input', function (done) {
+        var app = express();
+
+        app.use(function(req, res, next){
+          res.end(req.acceptsCharsets(['utf-8', 'iso-8859-1']));
+        });
+
+        request(app)
+        .get('/')
+        .set('Accept-Charset', 'iso-8859-1, utf-8')
+        .expect('iso-8859-1', done);
+      })
     })
   })
 })


### PR DESCRIPTION

**Repo:** expressjs/express (⭐ 66000)
**Type:** test
**Files changed:** 2
**Lines:** +23/-9

## What
Adds a focused test that covers passing an array to `req.acceptsCharsets()`, and updates the `req.acceptsCharsets()` JSDoc in `lib/request.js` so it documents the same supported input forms and return behavior as the rest of the `req.accepts*` helpers.

## Why
`req.acceptsCharsets()` already exposes array-style input through the underlying `accepts` API, but that behavior was not covered by tests and the docstring incorrectly described a comma-delimited string form instead. This patch closes that documentation gap and locks the public API behavior down with a small regression test.

## Testing
Verified syntax for the touched files with `node --check lib/request.js` and `node --check test/req.acceptsCharsets.js`. The targeted mocha test was not run locally because this clone does not have `node_modules` installed.

## Risk
Low / documentation-only behavior clarification plus one narrow test for an existing public API path.
