### PR TITLE
feat(request): add req.hasBody getter

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -511,6 +511,19 @@ defineGetter(req, 'xhr', function xhr(){
 });
 
 /**
+ * Check if the request has a body.
+ *
+ * @return {Boolean}
+ * @public
+ */
+
+defineGetter(req, 'hasBody', function hasBody(){
+  var len = this.headers['content-length'];
+  if (len !== undefined) return parseInt(len, 10) > 0;
+  return 'transfer-encoding' in this.headers;
+});
+
+/**
  * Helper function for creating a getter on an object.
  *
  * @param {Object} obj

--- a/test/req.hasBody.js
+++ b/test/req.hasBody.js
@@ -1,0 +1,43 @@
+'use strict'
+
+var express = require('../')
+  , request = require('supertest');
+
+describe('req', function(){
+  describe('.hasBody', function(){
+    before(function () {
+      this.app = express()
+      this.app.all('/', function (req, res) {
+        res.send(req.hasBody)
+      })
+    })
+
+    it('should return true when Content-Length > 0', function(done){
+      request(this.app)
+        .post('/')
+        .set('Content-Length', '10')
+        .send('test body')
+        .expect(200, 'true', done)
+    })
+
+    it('should return false when Content-Length: 0', function(done){
+      request(this.app)
+        .get('/')
+        .set('Content-Length', '0')
+        .expect(200, 'false', done)
+    })
+
+    it('should return true when Transfer-Encoding: chunked', function(done){
+      request(this.app)
+        .post('/')
+        .set('Transfer-Encoding', 'chunked')
+        .expect(200, 'true', done)
+    })
+
+    it('should return false when no content headers', function(done){
+      request(this.app)
+        .get('/')
+        .expect(200, 'false', done)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `req.hasBody` boolean getter to `lib/request.js`
- Returns `true` if request carries a non-empty body: `Content-Length > 0` OR `Transfer-Encoding` header present
- Returns `false` for `Content-Length: 0`, missing content headers
- Follows existing `defineGetter` pattern (same as `req.fresh`, `req.xhr`, etc.)
- No new dependencies

## Motivation

Express has no built-in way to check if a request has a body before parsing. Developers currently repeat `req.headers["content-length"]` checks across middleware. `req.hasBody` surfaces this as a first-class property.

## Test plan

- [x] POST with Content-Length > 0 → true
- [x] GET with Content-Length: 0 → false
- [x] Request with Transfer-Encoding: chunked → true
- [x] Request with no content headers → false
- [x] All 4 tests pass: `mocha --require test/support/env test/req.hasBody.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)