### PR TITLE
.2385318931605690:399aa0dcd9ad99b29d132e53a98f5346_69f72cb5eb4415a9574e62f3.69f733a4eb4415a9574e638d.69f733a4d546db09c657d135:Trae CN.T(2026/5/3 19:38:12)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -21,6 +21,7 @@ var methods = require('./utils').methods;
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
+var matchHeaders = require('./utils').matchHeaders;
 var resolve = require('node:path').resolve;
 var once = require('once')
 var Router = require('router');
@@ -250,11 +251,21 @@ app.use = function use(fn) {
  * Routes are isolated middleware stacks for specific paths.
  * See the Route api docs for details.
  *
+ * @param {String} path
+ * @param {Object} [options] - Route options
+ * @param {Object} [options.headers] - Request headers to match
+ * @return {Route}
  * @public
  */
 
-app.route = function route(path) {
-  return this.router.route(path);
+app.route = function route(path, options) {
+  var route = this.router.route(path);
+
+  if (options && options.headers) {
+    return wrapRouteWithHeaders(route, options.headers);
+  }
+
+  return route;
 };
 
 /**
@@ -475,8 +486,16 @@ methods.forEach(function (method) {
       return this.set(path);
     }
 
-    var route = this.route(path);
-    route[method].apply(route, slice.call(arguments, 1));
+    var args = slice.call(arguments, 1);
+    var options = null;
+
+    if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+      options = args[0];
+      args = args.slice(1);
+    }
+
+    var route = this.route(path, options);
+    route[method].apply(route, args);
     return this;
   };
 });
@@ -486,14 +505,23 @@ methods.forEach(function (method) {
  * middleware, and callback to _every_ HTTP method.
  *
  * @param {String} path
+ * @param {Object} [options] - Route options
+ * @param {Object} [options.headers] - Request headers to match
  * @param {Function} ...
  * @return {app} for chaining
  * @public
  */
 
 app.all = function all(path) {
-  var route = this.route(path);
   var args = slice.call(arguments, 1);
+  var options = null;
+
+  if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+    options = args[0];
+    args = args.slice(1);
+  }
+
+  var route = this.route(path, options);
 
   for (var i = 0; i < methods.length; i++) {
     route[methods[i]].apply(route, args);
@@ -628,4 +656,56 @@ function tryRender(view, options, callback) {
   } catch (err) {
     callback(err);
   }
+}
+
+/**
+ * Wrap a Route object with header matching middleware.
+ * Returns a proxy Route object that adds header checking middleware
+ * before each handler.
+ *
+ * @param {Route} route - The original Route object
+ * @param {Object} headers - The headers to match
+ * @return {Object} A wrapped Route object
+ * @private
+ */
+
+function wrapRouteWithHeaders(route, headers) {
+  var wrappedRoute = Object.create(route);
+
+  wrappedRoute.headers = function(newHeaders) {
+    headers = Object.assign({}, headers, newHeaders);
+    return wrappedRoute;
+  };
+
+  var headerMiddleware = function createHeaderMiddleware(expectedHeaders) {
+    return function headerCheck(req, res, next) {
+      if (matchHeaders(req.headers, expectedHeaders)) {
+        next();
+      } else {
+        next('route');
+      }
+    };
+  };
+
+  methods.forEach(function(method) {
+    var originalMethod = route[method];
+    if (typeof originalMethod === 'function') {
+      wrappedRoute[method] = function() {
+        var args = slice.call(arguments);
+        args.unshift(headerMiddleware(headers));
+        return originalMethod.apply(route, args);
+      };
+    }
+  });
+
+  var originalAll = route.all;
+  if (typeof originalAll === 'function') {
+    wrappedRoute.all = function() {
+      var args = slice.call(arguments);
+      args.unshift(headerMiddleware(headers));
+      return originalAll.apply(route, args);
+    };
+  }
+
+  return wrappedRoute;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,3 +269,50 @@ function parseExtendedQueryString(str) {
     allowPrototypes: true
   });
 }
+
+/**
+ * Check if request headers match the expected headers.
+ * Supports string exact match, RegExp match, and function match.
+ *
+ * @param {Object} reqHeaders - The request headers object (req.headers)
+ * @param {Object} expectedHeaders - The expected headers to match
+ * @return {Boolean}
+ * @api private
+ */
+
+exports.matchHeaders = function matchHeaders(reqHeaders, expectedHeaders) {
+  if (!expectedHeaders || typeof expectedHeaders !== 'object') {
+    return true;
+  }
+
+  var keys = Object.keys(expectedHeaders);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i].toLowerCase();
+    var expected = expectedHeaders[keys[i]];
+    var actual = reqHeaders[key];
+
+    if (actual === undefined) {
+      return false;
+    }
+
+    if (typeof expected === 'function') {
+      if (!expected(actual)) {
+        return false;
+      }
+    } else if (expected instanceof RegExp) {
+      if (!expected.test(actual)) {
+        return false;
+      }
+    } else if (typeof expected === 'string') {
+      if (actual.toLowerCase() !== expected.toLowerCase()) {
+        return false;
+      }
+    } else {
+      if (actual !== expected) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};

--- a/test-header-routing.js
+++ b/test-header-routing.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var express = require('./');
+
+console.log('Testing header-based routing...');
+
+var app = express();
+var results = [];
+
+app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+  results.push('v1');
+});
+
+app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+  results.push('v2');
+});
+
+app.get('/test', function (req, res) {
+  results.push('default');
+});
+
+function testCase(name, headers, expected) {
+  console.log('\nTest: ' + name);
+  var initialLength = results.length;
+
+  var req = {
+    url: '/test',
+    method: 'GET',
+    headers: headers || {}
+  };
+
+  var res = {
+    end: function () {},
+    json: function () {}
+  };
+
+  app.handle(req, res, function (err) {
+    if (err) {
+      console.log('  Error:', err);
+    }
+  });
+
+  var actual = results.slice(initialLength);
+  console.log('  Expected:', expected);
+  console.log('  Actual:', actual);
+
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    console.log('  ✓ PASS');
+    return true;
+  } else {
+    console.log('  ✗ FAIL');
+    return false;
+  }
+}
+
+var allPassed = true;
+
+allPassed = testCase('Header v1.0 matches v1 route', { 'x-api-version': '1.0' }, ['v1']) && allPassed;
+allPassed = testCase('Header v2.0 matches v2 route', { 'x-api-version': '2.0' }, ['v2']) && allPassed;
+allPassed = testCase('Missing header falls back to default', {}, ['default']) && allPassed;
+allPassed = testCase('Unknown version falls back to default', { 'x-api-version': '99.0' }, ['default']) && allPassed;
+
+console.log('\n' + (allPassed ? 'All tests passed!' : 'Some tests failed!'));
+process.exit(allPassed ? 0 : 1);

--- a/test/route-headers.js
+++ b/test/route-headers.js
@@ -1,0 +1,310 @@
+'use strict';
+
+var express = require('../');
+var assert = require('node:assert');
+
+describe('Route headers matching', function () {
+  describe('app.METHOD with headers option', function () {
+    it('should match route with exact header value', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+        res.end('v1');
+      });
+
+      app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+        res.end('v2');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v2'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should match route with regex header value', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'Accept': /^application\/json/ } }, function (req, res) {
+        res.end('json');
+      });
+
+      app.get('/test', { headers: { 'Accept': /^text\/html/ } }, function (req, res) {
+        res.end('html');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'json'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'html'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'accept': 'application/json' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'accept': 'text/html' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should match route with function header matcher', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'X-API-Version': function (val) { return parseInt(val, 10) < 2; } } }, function (req, res) {
+        res.end('old');
+      });
+
+      app.get('/test', { headers: { 'X-API-Version': function (val) { return parseInt(val, 10) >= 2; } } }, function (req, res) {
+        res.end('new');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'old'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'new'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should skip to next route when headers do not match', function (done) {
+      var app = express();
+      var called = [];
+
+      app.get('/test', { headers: { 'X-API-Version': 'nonexistent' } }, function (req, res) {
+        called.push('wrong');
+        res.end('wrong');
+      });
+
+      app.get('/test', function (req, res) {
+        called.push('correct');
+        res.end('correct');
+      });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'correct');
+          assert.deepStrictEqual(called, ['correct']);
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should work with multiple header conditions', function (done) {
+      var app = express();
+
+      app.get('/test', {
+        headers: {
+          'X-API-Version': '1.0',
+          'Accept': 'application/json'
+        }
+      }, function (req, res) {
+        res.end('v1-json');
+      });
+
+      app.get('/test', {
+        headers: {
+          'X-API-Version': '1.0',
+          'Accept': 'text/html'
+        }
+      }, function (req, res) {
+        res.end('v1-html');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1-json'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v1-html'); done(); } };
+
+      app.handle({
+        url: '/test',
+        method: 'GET',
+        headers: { 'x-api-version': '1.0', 'accept': 'application/json' }
+      }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({
+        url: '/test',
+        method: 'GET',
+        headers: { 'x-api-version': '1.0', 'accept': 'text/html' }
+      }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should maintain backward compatibility without headers option', function (done) {
+      var app = express();
+
+      app.get('/test', function (req, res) {
+        res.end('normal');
+      });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'normal');
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: {} }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+
+  describe('app.route with headers option', function () {
+    it('should work with app.route and headers option', function (done) {
+      var app = express();
+
+      app.route('/test', { headers: { 'X-API-Version': '1.0' } })
+        .get(function (req, res) {
+          res.end('v1-get');
+        })
+        .post(function (req, res) {
+          res.end('v1-post');
+        });
+
+      app.route('/test', { headers: { 'X-API-Version': '2.0' } })
+        .get(function (req, res) {
+          res.end('v2-get');
+        });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1-get'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v1-post'); } };
+      var res3 = { end: function (val) { assert.strictEqual(val, 'v2-get'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } }, res3, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should work with app.route and chained .all()', function (done) {
+      var app = express();
+      var called = [];
+
+      app.route('/test', { headers: { 'X-API-Version': '1.0' } })
+        .all(function (req, res, next) {
+          called.push('all-v1');
+          next();
+        })
+        .get(function (req, res) {
+          called.push('get-v1');
+          res.end('v1');
+        });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'v1');
+          assert.deepStrictEqual(called, ['all-v1', 'get-v1']);
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+
+  describe('app.all with headers option', function () {
+    it('should work with app.all and headers option', function (done) {
+      var app = express();
+      var methods = [];
+
+      app.all('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+        methods.push(req.method);
+        res.end('ok');
+      });
+
+      var res = { end: function () {} };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'PUT', headers: { 'x-api-version': '2.0' } }, res, function () {
+        assert.deepStrictEqual(methods, ['GET', 'POST']);
+        done();
+      });
+    });
+  });
+
+  describe('API versioning use case', function () {
+    it('should support typical API versioning pattern', function (done) {
+      var app = express();
+
+      app.get('/api/users', { headers: { 'X-API-Version': '1' } }, function (req, res) {
+        res.json([{ id: 1, name: 'John' }]);
+      });
+
+      app.get('/api/users', { headers: { 'X-API-Version': '2' } }, function (req, res) {
+        res.json({ data: [{ id: 1, firstName: 'John', lastName: 'Doe' }], meta: { total: 1 } });
+      });
+
+      app.get('/api/users', function (req, res) {
+        res.statusCode = 400;
+        res.json({ error: 'API version required' });
+      });
+
+      var v1Res = {
+        statusCode: 200,
+        json: function (val) {
+          assert.deepStrictEqual(val, [{ id: 1, name: 'John' }]);
+        }
+      };
+
+      var v2Res = {
+        statusCode: 200,
+        json: function (val) {
+          assert.deepStrictEqual(val, {
+            data: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+            meta: { total: 1 }
+          });
+        }
+      };
+
+      var defaultRes = {
+        statusCode: 200,
+        json: function (val) {
+          assert.strictEqual(this.statusCode, 400);
+          assert.deepStrictEqual(val, { error: 'API version required' });
+          done();
+        }
+      };
+
+      app.handle({ url: '/api/users', method: 'GET', headers: { 'x-api-version': '1' } }, v1Res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/api/users', method: 'GET', headers: { 'x-api-version': '2' } }, v2Res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/api/users', method: 'GET', headers: {} }, defaultRes, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+});


### PR DESCRIPTION
feat(路由): 添加基于请求头的路由匹配功能

新增 matchHeaders 工具函数用于匹配请求头，支持字符串、正则和函数匹配
扩展 app.route、app.METHOD 和 app.all 方法，支持 headers 选项
添加测试用例验证功能正确性