### PR TITLE
.2385318931605690:8fd05f61eb02eaa45697a878a5c2abda_69f72cb5eb4415a9574e62f3.69f74c3deb4415a9574e6596.69f74c3dd546db09c657d136:Trae CN.T(2026/5/3 21:23:09)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -21,6 +21,7 @@ var methods = require('./utils').methods;
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
+var matchHeaders = require('./utils').matchHeaders;
 var resolve = require('node:path').resolve;
 var once = require('once')
 var Router = require('router');
@@ -250,11 +251,21 @@ app.use = function use(fn) {
  * Routes are isolated middleware stacks for specific paths.
  * See the Route api docs for details.
  *
+ * @param {String} path
+ * @param {Object} [options] - Route options
+ * @param {Object} [options.headers] - Request headers to match
+ * @return {Route}
  * @public
  */
 
-app.route = function route(path) {
-  return this.router.route(path);
+app.route = function route(path, options) {
+  var route = this.router.route(path);
+
+  if (options && options.headers) {
+    return wrapRouteWithHeaders(route, options.headers);
+  }
+
+  return route;
 };
 
 /**
@@ -475,8 +486,16 @@ methods.forEach(function (method) {
       return this.set(path);
     }
 
-    var route = this.route(path);
-    route[method].apply(route, slice.call(arguments, 1));
+    var args = slice.call(arguments, 1);
+    var options = null;
+
+    if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+      options = args[0];
+      args = args.slice(1);
+    }
+
+    var route = this.route(path, options);
+    route[method].apply(route, args);
     return this;
   };
 });
@@ -486,14 +505,23 @@ methods.forEach(function (method) {
  * middleware, and callback to _every_ HTTP method.
  *
  * @param {String} path
+ * @param {Object} [options] - Route options
+ * @param {Object} [options.headers] - Request headers to match
  * @param {Function} ...
  * @return {app} for chaining
  * @public
  */
 
 app.all = function all(path) {
-  var route = this.route(path);
   var args = slice.call(arguments, 1);
+  var options = null;
+
+  if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+    options = args[0];
+    args = args.slice(1);
+  }
+
+  var route = this.route(path, options);
 
   for (var i = 0; i < methods.length; i++) {
     route[methods[i]].apply(route, args);
@@ -628,4 +656,56 @@ function tryRender(view, options, callback) {
   } catch (err) {
     callback(err);
   }
+}
+
+/**
+ * Wrap a Route object with header matching middleware.
+ * Returns a proxy Route object that adds header checking middleware
+ * before each handler.
+ *
+ * @param {Route} route - The original Route object
+ * @param {Object} headers - The headers to match
+ * @return {Object} A wrapped Route object
+ * @private
+ */
+
+function wrapRouteWithHeaders(route, headers) {
+  var wrappedRoute = Object.create(route);
+
+  wrappedRoute.headers = function(newHeaders) {
+    headers = Object.assign({}, headers, newHeaders);
+    return wrappedRoute;
+  };
+
+  var headerMiddleware = function createHeaderMiddleware(expectedHeaders) {
+    return function headerCheck(req, res, next) {
+      if (matchHeaders(req.headers, expectedHeaders)) {
+        next();
+      } else {
+        next('route');
+      }
+    };
+  };
+
+  methods.forEach(function(method) {
+    var originalMethod = route[method];
+    if (typeof originalMethod === 'function') {
+      wrappedRoute[method] = function() {
+        var args = slice.call(arguments);
+        args.unshift(headerMiddleware(headers));
+        return originalMethod.apply(route, args);
+      };
+    }
+  });
+
+  var originalAll = route.all;
+  if (typeof originalAll === 'function') {
+    wrappedRoute.all = function() {
+      var args = slice.call(arguments);
+      args.unshift(headerMiddleware(headers));
+      return originalAll.apply(route, args);
+    };
+  }
+
+  return wrappedRoute;
 }

--- a/lib/application.js
+++ b/lib/application.js
@@ -21,10 +21,9 @@ var methods = require('./utils').methods;
 var compileETag = require('./utils').compileETag;
 var compileQueryParser = require('./utils').compileQueryParser;
 var compileTrust = require('./utils').compileTrust;
-var matchHeaders = require('./utils').matchHeaders;
 var resolve = require('node:path').resolve;
 var once = require('once')
-var Router = require('router');
+var Router = require('./router');
 
 /**
  * Module variables.
@@ -259,13 +258,7 @@ app.use = function use(fn) {
  */
 
 app.route = function route(path, options) {
-  var route = this.router.route(path);
-
-  if (options && options.headers) {
-    return wrapRouteWithHeaders(route, options.headers);
-  }
-
-  return route;
+  return this.router.route(path, options);
 };
 
 /**
@@ -486,17 +479,8 @@ methods.forEach(function (method) {
       return this.set(path);
     }
 
-    var args = slice.call(arguments, 1);
-    var options = null;
-
-    if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
-      options = args[0];
-      args = args.slice(1);
-    }
-
-    var route = this.route(path, options);
-    route[method].apply(route, args);
-    return this;
+    var router = this.router;
+    return router[method].apply(router, arguments);
   };
 });
 
@@ -513,21 +497,8 @@ methods.forEach(function (method) {
  */
 
 app.all = function all(path) {
-  var args = slice.call(arguments, 1);
-  var options = null;
-
-  if (args.length > 0 && typeof args[0] === 'object' && typeof args[0] !== 'function' && !Array.isArray(args[0])) {
-    options = args[0];
-    args = args.slice(1);
-  }
-
-  var route = this.route(path, options);
-
-  for (var i = 0; i < methods.length; i++) {
-    route[methods[i]].apply(route, args);
-  }
-
-  return this;
+  var router = this.router;
+  return router.all.apply(router, arguments);
 };
 
 /**
@@ -656,56 +627,4 @@ function tryRender(view, options, callback) {
   } catch (err) {
     callback(err);
   }
-}
-
-/**
- * Wrap a Route object with header matching middleware.
- * Returns a proxy Route object that adds header checking middleware
- * before each handler.
- *
- * @param {Route} route - The original Route object
- * @param {Object} headers - The headers to match
- * @return {Object} A wrapped Route object
- * @private
- */
-
-function wrapRouteWithHeaders(route, headers) {
-  var wrappedRoute = Object.create(route);
-
-  wrappedRoute.headers = function(newHeaders) {
-    headers = Object.assign({}, headers, newHeaders);
-    return wrappedRoute;
-  };
-
-  var headerMiddleware = function createHeaderMiddleware(expectedHeaders) {
-    return function headerCheck(req, res, next) {
-      if (matchHeaders(req.headers, expectedHeaders)) {
-        next();
-      } else {
-        next('route');
-      }
-    };
-  };
-
-  methods.forEach(function(method) {
-    var originalMethod = route[method];
-    if (typeof originalMethod === 'function') {
-      wrappedRoute[method] = function() {
-        var args = slice.call(arguments);
-        args.unshift(headerMiddleware(headers));
-        return originalMethod.apply(route, args);
-      };
-    }
-  });
-
-  var originalAll = route.all;
-  if (typeof originalAll === 'function') {
-    wrappedRoute.all = function() {
-      var args = slice.call(arguments);
-      args.unshift(headerMiddleware(headers));
-      return originalAll.apply(route, args);
-    };
-  }
-
-  return wrappedRoute;
 }

--- a/lib/express.js
+++ b/lib/express.js
@@ -16,7 +16,7 @@ var bodyParser = require('body-parser')
 var EventEmitter = require('node:events').EventEmitter;
 var mixin = require('merge-descriptors');
 var proto = require('./application');
-var Router = require('router');
+var Router = require('./router');
 var req = require('./request');
 var res = require('./response');
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var BaseRouter = require('router');
+var methods = require('../utils').methods;
+var matchHeaders = require('../utils').matchHeaders;
+
+/**
+ * Module variables.
+ */
+
+var slice = Array.prototype.slice;
+
+/**
+ * Create a custom Router with header matching support.
+ *
+ * @param {Object} options - Router options
+ * @return {Function} Router function
+ * @api public
+ */
+
+function Router(options) {
+  var router = BaseRouter(options);
+
+  var originalRoute = router.route.bind(router);
+  router.route = function route(path, opts) {
+    var r = originalRoute(path);
+
+    if (opts && opts.headers) {
+      return wrapRouteWithHeaders(r, opts.headers);
+    }
+
+    return r;
+  };
+
+  methods.forEach(function(method) {
+    var originalMethod = router[method];
+    if (typeof originalMethod === 'function') {
+      router[method] = function(path) {
+        var args = slice.call(arguments, 1);
+        var opts = null;
+
+        if (args.length > 0 && typeof args[0] === 'object' &&
+            typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+          opts = args[0];
+          args = args.slice(1);
+        }
+
+        var r = this.route(path, opts);
+        r[method].apply(r, args);
+        return this;
+      };
+    }
+  });
+
+  var originalAll = router.all;
+  if (typeof originalAll === 'function') {
+    router.all = function all(path) {
+      var args = slice.call(arguments, 1);
+      var opts = null;
+
+      if (args.length > 0 && typeof args[0] === 'object' &&
+          typeof args[0] !== 'function' && !Array.isArray(args[0])) {
+        opts = args[0];
+        args = args.slice(1);
+      }
+
+      var r = this.route(path, opts);
+      for (var i = 0; i < methods.length; i++) {
+        r[methods[i]].apply(r, args);
+      }
+      return this;
+    };
+  }
+
+  return router;
+}
+
+/**
+ * Expose Route from BaseRouter.
+ */
+
+Router.Route = BaseRouter.Route;
+
+/**
+ * Wrap a Route object with header matching middleware.
+ * Returns a proxy Route object that adds header checking middleware
+ * before each handler.
+ *
+ * @param {Route} route - The original Route object
+ * @param {Object} headers - The headers to match
+ * @return {Object} A wrapped Route object
+ * @private
+ */
+
+function wrapRouteWithHeaders(route, headers) {
+  var wrappedRoute = Object.create(route);
+
+  wrappedRoute.headers = function(newHeaders) {
+    headers = Object.assign({}, headers, newHeaders);
+    return wrappedRoute;
+  };
+
+  var headerMiddleware = function createHeaderMiddleware(expectedHeaders) {
+    return function headerCheck(req, res, next) {
+      if (matchHeaders(req.headers, expectedHeaders)) {
+        next();
+      } else {
+        next('route');
+      }
+    };
+  };
+
+  methods.forEach(function(method) {
+    var originalMethod = route[method];
+    if (typeof originalMethod === 'function') {
+      wrappedRoute[method] = function() {
+        var args = slice.call(arguments);
+        args.unshift(headerMiddleware(headers));
+        return originalMethod.apply(route, args);
+      };
+    }
+  });
+
+  var originalAll = route.all;
+  if (typeof originalAll === 'function') {
+    wrappedRoute.all = function() {
+      var args = slice.call(arguments);
+      args.unshift(headerMiddleware(headers));
+      return originalAll.apply(route, args);
+    };
+  }
+
+  return wrappedRoute;
+}
+
+/**
+ * Expose `Router()`.
+ */
+
+module.exports = Router;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,3 +269,50 @@ function parseExtendedQueryString(str) {
     allowPrototypes: true
   });
 }
+
+/**
+ * Check if request headers match the expected headers.
+ * Supports string exact match, RegExp match, and function match.
+ *
+ * @param {Object} reqHeaders - The request headers object (req.headers)
+ * @param {Object} expectedHeaders - The expected headers to match
+ * @return {Boolean}
+ * @api private
+ */
+
+exports.matchHeaders = function matchHeaders(reqHeaders, expectedHeaders) {
+  if (!expectedHeaders || typeof expectedHeaders !== 'object') {
+    return true;
+  }
+
+  var keys = Object.keys(expectedHeaders);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i].toLowerCase();
+    var expected = expectedHeaders[keys[i]];
+    var actual = reqHeaders[key];
+
+    if (actual === undefined) {
+      return false;
+    }
+
+    if (typeof expected === 'function') {
+      if (!expected(actual)) {
+        return false;
+      }
+    } else if (expected instanceof RegExp) {
+      if (!expected.test(actual)) {
+        return false;
+      }
+    } else if (typeof expected === 'string') {
+      if (actual.toLowerCase() !== expected.toLowerCase()) {
+        return false;
+      }
+    } else {
+      if (actual !== expected) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};

--- a/test-header-routing.js
+++ b/test-header-routing.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var express = require('./');
+
+console.log('Testing header-based routing...');
+
+var app = express();
+var results = [];
+
+app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+  results.push('v1');
+});
+
+app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+  results.push('v2');
+});
+
+app.get('/test', function (req, res) {
+  results.push('default');
+});
+
+function testCase(name, headers, expected) {
+  console.log('\nTest: ' + name);
+  var initialLength = results.length;
+
+  var req = {
+    url: '/test',
+    method: 'GET',
+    headers: headers || {}
+  };
+
+  var res = {
+    end: function () {},
+    json: function () {}
+  };
+
+  app.handle(req, res, function (err) {
+    if (err) {
+      console.log('  Error:', err);
+    }
+  });
+
+  var actual = results.slice(initialLength);
+  console.log('  Expected:', expected);
+  console.log('  Actual:', actual);
+
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    console.log('  ✓ PASS');
+    return true;
+  } else {
+    console.log('  ✗ FAIL');
+    return false;
+  }
+}
+
+var allPassed = true;
+
+allPassed = testCase('Header v1.0 matches v1 route', { 'x-api-version': '1.0' }, ['v1']) && allPassed;
+allPassed = testCase('Header v2.0 matches v2 route', { 'x-api-version': '2.0' }, ['v2']) && allPassed;
+allPassed = testCase('Missing header falls back to default', {}, ['default']) && allPassed;
+allPassed = testCase('Unknown version falls back to default', { 'x-api-version': '99.0' }, ['default']) && allPassed;
+
+console.log('\n' + (allPassed ? 'All tests passed!' : 'Some tests failed!'));
+process.exit(allPassed ? 0 : 1);

--- a/test-header-routing.js
+++ b/test-header-routing.js
@@ -2,63 +2,319 @@
 
 var express = require('./');
 
-console.log('Testing header-based routing...');
+console.log('Testing header-based routing at Router level...');
 
-var app = express();
-var results = [];
+var allPassed = true;
 
-app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
-  results.push('v1');
-});
-
-app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
-  results.push('v2');
-});
-
-app.get('/test', function (req, res) {
-  results.push('default');
-});
-
-function testCase(name, headers, expected) {
+function testCase(name, testFn) {
   console.log('\nTest: ' + name);
-  var initialLength = results.length;
-
-  var req = {
-    url: '/test',
-    method: 'GET',
-    headers: headers || {}
-  };
-
-  var res = {
-    end: function () {},
-    json: function () {}
-  };
-
-  app.handle(req, res, function (err) {
-    if (err) {
-      console.log('  Error:', err);
+  try {
+    var result = testFn();
+    if (result === true || result === undefined) {
+      console.log('  ✓ PASS');
+      return true;
+    } else {
+      console.log('  ✗ FAIL');
+      return false;
     }
-  });
-
-  var actual = results.slice(initialLength);
-  console.log('  Expected:', expected);
-  console.log('  Actual:', actual);
-
-  if (JSON.stringify(actual) === JSON.stringify(expected)) {
-    console.log('  ✓ PASS');
-    return true;
-  } else {
-    console.log('  ✗ FAIL');
+  } catch (err) {
+    console.log('  ✗ FAIL:', err.message);
     return false;
   }
 }
 
-var allPassed = true;
+allPassed = testCase('Router.get with headers option - exact string match', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
 
-allPassed = testCase('Header v1.0 matches v1 route', { 'x-api-version': '1.0' }, ['v1']) && allPassed;
-allPassed = testCase('Header v2.0 matches v2 route', { 'x-api-version': '2.0' }, ['v2']) && allPassed;
-allPassed = testCase('Missing header falls back to default', {}, ['default']) && allPassed;
-allPassed = testCase('Unknown version falls back to default', { 'x-api-version': '99.0' }, ['default']) && allPassed;
+  router.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+    results.push('v1');
+  });
+
+  router.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+    results.push('v2');
+  });
+
+  router.get('/test', function (req, res) {
+    results.push('default');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } };
+  var req2 = { url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } };
+  var req3 = { url: '/test', method: 'GET', headers: {} };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+  router.handle(req3, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'v1') throw new Error('Expected v1, got ' + results[0]);
+  if (results[1] !== 'v2') throw new Error('Expected v2, got ' + results[1]);
+  if (results[2] !== 'default') throw new Error('Expected default, got ' + results[2]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router.get with headers option - regex match', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.get('/test', { headers: { 'Accept': /^application\/json/ } }, function (req, res) {
+    results.push('json');
+  });
+
+  router.get('/test', { headers: { 'Accept': /^text\/html/ } }, function (req, res) {
+    results.push('html');
+  });
+
+  router.get('/test', function (req, res) {
+    results.push('default');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'accept': 'application/json' } };
+  var req2 = { url: '/test', method: 'GET', headers: { 'accept': 'text/html' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'json') throw new Error('Expected json, got ' + results[0]);
+  if (results[1] !== 'html') throw new Error('Expected html, got ' + results[1]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router.get with headers option - function match', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.get('/test', { 
+    headers: { 
+      'X-API-Version': function(val) { return parseInt(val, 10) < 2; } 
+    } 
+  }, function (req, res) {
+    results.push('old');
+  });
+
+  router.get('/test', { 
+    headers: { 
+      'X-API-Version': function(val) { return parseInt(val, 10) >= 2; } 
+    } 
+  }, function (req, res) {
+    results.push('new');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1' } };
+  var req2 = { url: '/test', method: 'GET', headers: { 'x-api-version': '2' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'old') throw new Error('Expected old, got ' + results[0]);
+  if (results[1] !== 'new') throw new Error('Expected new, got ' + results[1]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router.route with headers option', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.route('/test', { headers: { 'X-API-Version': '1.0' } })
+    .get(function (req, res) {
+      results.push('v1-get');
+    })
+    .post(function (req, res) {
+      results.push('v1-post');
+    });
+
+  router.route('/test', { headers: { 'X-API-Version': '2.0' } })
+    .get(function (req, res) {
+      results.push('v2-get');
+    });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } };
+  var req2 = { url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } };
+  var req3 = { url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+  router.handle(req3, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'v1-get') throw new Error('Expected v1-get, got ' + results[0]);
+  if (results[1] !== 'v1-post') throw new Error('Expected v1-post, got ' + results[1]);
+  if (results[2] !== 'v2-get') throw new Error('Expected v2-get, got ' + results[2]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router.all with headers option', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.all('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+    results.push(req.method + '-v1');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } };
+  var req2 = { url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } };
+  var req3 = { url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+  router.handle(req3, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'GET-v1') throw new Error('Expected GET-v1, got ' + results[0]);
+  if (results[1] !== 'POST-v1') throw new Error('Expected POST-v1, got ' + results[1]);
+  if (results.length !== 2) throw new Error('Expected only 2 results, got ' + results.length);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('App.get with headers option - backward compatibility', function() {
+  var app = express();
+  var results = [];
+
+  app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+    results.push('v1');
+  });
+
+  app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+    results.push('v2');
+  });
+
+  app.get('/test', function (req, res) {
+    results.push('default');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } };
+  var req2 = { url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } };
+  var req3 = { url: '/test', method: 'GET', headers: {} };
+  var res = { end: function () {} };
+
+  app.handle(req1, res, function() {});
+  app.handle(req2, res, function() {});
+  app.handle(req3, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'v1') throw new Error('Expected v1, got ' + results[0]);
+  if (results[1] !== 'v2') throw new Error('Expected v2, got ' + results[1]);
+  if (results[2] !== 'default') throw new Error('Expected default, got ' + results[2]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router with multiple header conditions', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.get('/test', {
+    headers: {
+      'X-API-Version': '1.0',
+      'Accept': 'application/json'
+    }
+  }, function (req, res) {
+    results.push('v1-json');
+  });
+
+  router.get('/test', {
+    headers: {
+      'X-API-Version': '1.0',
+      'Accept': 'text/html'
+    }
+  }, function (req, res) {
+    results.push('v1-html');
+  });
+
+  var req1 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0', 'accept': 'application/json' } };
+  var req2 = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0', 'accept': 'text/html' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'v1-json') throw new Error('Expected v1-json, got ' + results[0]);
+  if (results[1] !== 'v1-html') throw new Error('Expected v1-html, got ' + results[1]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router.post with headers option', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.post('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+    results.push('v1');
+  });
+
+  router.post('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+    results.push('v2');
+  });
+
+  var req1 = { url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } };
+  var req2 = { url: '/test', method: 'POST', headers: { 'x-api-version': '2.0' } };
+  var res = { end: function () {} };
+
+  router.handle(req1, res, function() {});
+  router.handle(req2, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'v1') throw new Error('Expected v1, got ' + results[0]);
+  if (results[1] !== 'v2') throw new Error('Expected v2, got ' + results[1]);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router - headers not match skips to next route', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.get('/test', { headers: { 'X-API-Version': 'nonexistent' } }, function (req, res) {
+    results.push('wrong');
+  });
+
+  router.get('/test', function (req, res) {
+    results.push('correct');
+  });
+
+  var req = { url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } };
+  var res = { end: function () {} };
+
+  router.handle(req, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'correct') throw new Error('Expected correct, got ' + results[0]);
+  if (results.length !== 1) throw new Error('Expected only 1 result, got ' + results.length);
+  return true;
+}) && allPassed;
+
+allPassed = testCase('Router - backward compatibility without headers option', function() {
+  var Router = express.Router;
+  var router = new Router();
+  var results = [];
+
+  router.get('/test', function (req, res) {
+    results.push('normal');
+  });
+
+  var req = { url: '/test', method: 'GET', headers: {} };
+  var res = { end: function () {} };
+
+  router.handle(req, res, function() {});
+
+  console.log('  Results:', results);
+  if (results[0] !== 'normal') throw new Error('Expected normal, got ' + results[0]);
+  return true;
+}) && allPassed;
 
 console.log('\n' + (allPassed ? 'All tests passed!' : 'Some tests failed!'));
 process.exit(allPassed ? 0 : 1);

--- a/test/route-headers.js
+++ b/test/route-headers.js
@@ -1,0 +1,310 @@
+'use strict';
+
+var express = require('../');
+var assert = require('node:assert');
+
+describe('Route headers matching', function () {
+  describe('app.METHOD with headers option', function () {
+    it('should match route with exact header value', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+        res.end('v1');
+      });
+
+      app.get('/test', { headers: { 'X-API-Version': '2.0' } }, function (req, res) {
+        res.end('v2');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v2'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should match route with regex header value', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'Accept': /^application\/json/ } }, function (req, res) {
+        res.end('json');
+      });
+
+      app.get('/test', { headers: { 'Accept': /^text\/html/ } }, function (req, res) {
+        res.end('html');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'json'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'html'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'accept': 'application/json' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'accept': 'text/html' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should match route with function header matcher', function (done) {
+      var app = express();
+
+      app.get('/test', { headers: { 'X-API-Version': function (val) { return parseInt(val, 10) < 2; } } }, function (req, res) {
+        res.end('old');
+      });
+
+      app.get('/test', { headers: { 'X-API-Version': function (val) { return parseInt(val, 10) >= 2; } } }, function (req, res) {
+        res.end('new');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'old'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'new'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should skip to next route when headers do not match', function (done) {
+      var app = express();
+      var called = [];
+
+      app.get('/test', { headers: { 'X-API-Version': 'nonexistent' } }, function (req, res) {
+        called.push('wrong');
+        res.end('wrong');
+      });
+
+      app.get('/test', function (req, res) {
+        called.push('correct');
+        res.end('correct');
+      });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'correct');
+          assert.deepStrictEqual(called, ['correct']);
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should work with multiple header conditions', function (done) {
+      var app = express();
+
+      app.get('/test', {
+        headers: {
+          'X-API-Version': '1.0',
+          'Accept': 'application/json'
+        }
+      }, function (req, res) {
+        res.end('v1-json');
+      });
+
+      app.get('/test', {
+        headers: {
+          'X-API-Version': '1.0',
+          'Accept': 'text/html'
+        }
+      }, function (req, res) {
+        res.end('v1-html');
+      });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1-json'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v1-html'); done(); } };
+
+      app.handle({
+        url: '/test',
+        method: 'GET',
+        headers: { 'x-api-version': '1.0', 'accept': 'application/json' }
+      }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({
+        url: '/test',
+        method: 'GET',
+        headers: { 'x-api-version': '1.0', 'accept': 'text/html' }
+      }, res2, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should maintain backward compatibility without headers option', function (done) {
+      var app = express();
+
+      app.get('/test', function (req, res) {
+        res.end('normal');
+      });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'normal');
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: {} }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+
+  describe('app.route with headers option', function () {
+    it('should work with app.route and headers option', function (done) {
+      var app = express();
+
+      app.route('/test', { headers: { 'X-API-Version': '1.0' } })
+        .get(function (req, res) {
+          res.end('v1-get');
+        })
+        .post(function (req, res) {
+          res.end('v1-post');
+        });
+
+      app.route('/test', { headers: { 'X-API-Version': '2.0' } })
+        .get(function (req, res) {
+          res.end('v2-get');
+        });
+
+      var res1 = { end: function (val) { assert.strictEqual(val, 'v1-get'); } };
+      var res2 = { end: function (val) { assert.strictEqual(val, 'v1-post'); } };
+      var res3 = { end: function (val) { assert.strictEqual(val, 'v2-get'); done(); } };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res1, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } }, res2, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '2.0' } }, res3, function () {
+        throw new Error('should not be called');
+      });
+    });
+
+    it('should work with app.route and chained .all()', function (done) {
+      var app = express();
+      var called = [];
+
+      app.route('/test', { headers: { 'X-API-Version': '1.0' } })
+        .all(function (req, res, next) {
+          called.push('all-v1');
+          next();
+        })
+        .get(function (req, res) {
+          called.push('get-v1');
+          res.end('v1');
+        });
+
+      var res = {
+        end: function (val) {
+          assert.strictEqual(val, 'v1');
+          assert.deepStrictEqual(called, ['all-v1', 'get-v1']);
+          done();
+        }
+      };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+
+  describe('app.all with headers option', function () {
+    it('should work with app.all and headers option', function (done) {
+      var app = express();
+      var methods = [];
+
+      app.all('/test', { headers: { 'X-API-Version': '1.0' } }, function (req, res) {
+        methods.push(req.method);
+        res.end('ok');
+      });
+
+      var res = { end: function () {} };
+
+      app.handle({ url: '/test', method: 'GET', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'POST', headers: { 'x-api-version': '1.0' } }, res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/test', method: 'PUT', headers: { 'x-api-version': '2.0' } }, res, function () {
+        assert.deepStrictEqual(methods, ['GET', 'POST']);
+        done();
+      });
+    });
+  });
+
+  describe('API versioning use case', function () {
+    it('should support typical API versioning pattern', function (done) {
+      var app = express();
+
+      app.get('/api/users', { headers: { 'X-API-Version': '1' } }, function (req, res) {
+        res.json([{ id: 1, name: 'John' }]);
+      });
+
+      app.get('/api/users', { headers: { 'X-API-Version': '2' } }, function (req, res) {
+        res.json({ data: [{ id: 1, firstName: 'John', lastName: 'Doe' }], meta: { total: 1 } });
+      });
+
+      app.get('/api/users', function (req, res) {
+        res.statusCode = 400;
+        res.json({ error: 'API version required' });
+      });
+
+      var v1Res = {
+        statusCode: 200,
+        json: function (val) {
+          assert.deepStrictEqual(val, [{ id: 1, name: 'John' }]);
+        }
+      };
+
+      var v2Res = {
+        statusCode: 200,
+        json: function (val) {
+          assert.deepStrictEqual(val, {
+            data: [{ id: 1, firstName: 'John', lastName: 'Doe' }],
+            meta: { total: 1 }
+          });
+        }
+      };
+
+      var defaultRes = {
+        statusCode: 200,
+        json: function (val) {
+          assert.strictEqual(this.statusCode, 400);
+          assert.deepStrictEqual(val, { error: 'API version required' });
+          done();
+        }
+      };
+
+      app.handle({ url: '/api/users', method: 'GET', headers: { 'x-api-version': '1' } }, v1Res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/api/users', method: 'GET', headers: { 'x-api-version': '2' } }, v2Res, function () {
+        throw new Error('should not be called');
+      });
+
+      app.handle({ url: '/api/users', method: 'GET', headers: {} }, defaultRes, function () {
+        throw new Error('should not be called');
+      });
+    });
+  });
+});


### PR DESCRIPTION
refactor(router): 重构路由模块以支持头部匹配功能

将头部匹配逻辑从应用层移动到路由层，创建自定义Router类继承基础路由功能
添加对路由方法的头部条件支持，包括get/post/all等方法
保持向后兼容性，确保现有应用代码不受影响
添加全面的测试用例验证各种头部匹配场景