### PR TITLE
feat: add 'strict status codes' setting

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -66,9 +66,14 @@ res.status = function status(code) {
   if (!Number.isInteger(code)) {
     throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
   }
+
+  var app = this.app;
+  var strict = app && app.get('strict status codes');
+
   // Check if the status code is outside of Node's valid range
-  if (code < 100 || code > 999) {
-    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than 1000.`);
+  if (code < 100 || (strict ? code > 599 : code > 999)) {
+    var max = strict ? 600 : 1000;
+    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than ${max}.`);
   }
 
   this.statusCode = code;

--- a/test/res.status.strict.js
+++ b/test/res.status.strict.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const express = require('../.');
+const request = require('supertest');
+
+describe('res', function () {
+  describe('.status(code) strict mode', function () {
+    it('should accept 599 when strict mode is enabled', function (done) {
+      const app = express();
+      app.set('strict status codes', true);
+
+      app.use(function (req, res) {
+        res.status(599).end();
+      });
+
+      request(app)
+        .get('/')
+        .expect(599, done);
+    });
+
+    it('should throw RangeError for 600 when strict mode is enabled', function (done) {
+      const app = express();
+      app.set('strict status codes', true);
+
+      app.use(function (req, res) {
+        try {
+          res.status(600).end();
+        } catch (err) {
+          res.status(500).send(err.message);
+        }
+      });
+
+      request(app)
+        .get('/')
+        .expect(500, /Status code must be greater than 99 and less than 600/, done);
+    });
+
+    it('should accept 600 when strict mode is disabled (default)', function (done) {
+      const app = express();
+
+      app.use(function (req, res) {
+        res.status(600).end();
+      });
+
+      request(app)
+        .get('/')
+        .expect(600, done);
+    });
+
+    it('should throw RangeError for 999 when strict mode is enabled', function (done) {
+      const app = express();
+      app.set('strict status codes', true);
+
+      app.use(function (req, res) {
+        try {
+          res.status(999).end();
+        } catch (err) {
+          res.status(500).send(err.message);
+        }
+      });
+
+      request(app)
+          .get('/')
+          .expect(500, /Status code must be greater than 99 and less than 600/, done);
+    });
+  });
+});


### PR DESCRIPTION
### Summary
This PR implements the 'strict status codes' setting for Express v5, as discussed in #5623.

### Changes
- Updated  res.status  to check for the  'strict status codes'  application setting.
- When enabled, status codes are restricted to the range **100-599** (RFC standard).
- When disabled (default), the range remains **100-999** for backward compatibility.
- Added comprehensive tests in  test/res.status.strict.js  covering enabled/disabled states and boundary cases.

### Verification
- All 16 existing tests in  test/res.status.js  pass.
- All new tests in  test/res.status.strict.js  pass.
- Linting (eslint) is clean.