### PR TITLE
fix: prevent path traversal in view lookup

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -25,8 +25,10 @@ var fs = require('node:fs');
 var dirname = path.dirname;
 var basename = path.basename;
 var extname = path.extname;
+var isAbsolute = path.isAbsolute;
 var join = path.join;
 var resolve = path.resolve;
+var sep = path.sep;
 
 /**
  * Module exports.
@@ -112,6 +114,14 @@ View.prototype.lookup = function lookup(name) {
 
     // resolve the path
     var loc = resolve(root, name);
+    
+    // security: ensure resolved path stays within root directory
+    var resolvedRoot = resolve(root);
+    if (!isAbsolute(name) && loc !== resolvedRoot && !loc.startsWith(resolvedRoot + sep)) {
+      debug('path traversal attempt detected: "%s" resolved outside root "%s"', name, root);
+      continue;
+    }
+    
     var dir = dirname(loc);
     var file = basename(loc);
 


### PR DESCRIPTION
## Summary

Fix a path traversal vulnerability in `View.prototype.lookup` where a relative view name containing `../` sequences could resolve to files outside the configured `views` root directories.

## Problem

```js
app.set('views', '/safe/views');
app.render('../../../etc/passwd', callback);
// Previously could read files outside /safe/views
```

## Fix

Added a containment check after path resolution: if the resolved path does not start with the root directory prefix, the lookup is skipped for that root. Absolute paths are intentionally excluded from the check to preserve existing Express behavior (`app.render('/absolute/path')` is supported).

```js
// security: ensure resolved path stays within root directory
var resolvedRoot = resolve(root);
if (!isAbsolute(name) && loc !== resolvedRoot && !loc.startsWith(resolvedRoot + sep)) {
  debug('path traversal attempt detected: "%s" resolved outside root "%s"', name, root);
  continue;
}
```

## Testing

All existing tests pass (`npm test`). The fix preserves:
- Normal relative view lookup
- Multiple `views` roots (array)
- Absolute path rendering (`app.render('/abs/path')`)
- View engine extension resolution
