### PR TITLE
fix: throw TypeError when res.redirect() receives falsy or non-string URL

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -821,11 +821,11 @@ res.redirect = function redirect(url) {
   }
 
   if (!address) {
-    deprecate('Provide a url argument');
+    throw new TypeError('Provide a url argument');
   }
 
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
+    throw new TypeError('Url must be a string');
   }
 
   if (typeof status !== 'number') {

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -46,6 +46,21 @@ describe('res', function(){
     })
   })
 
+  describe('.redirect(undefined)', function(){
+    it('should throw TypeError', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(undefined);
+      });
+
+      request(app)
+        .get('/')
+        .expect(500)
+        .end(done)
+    })
+  })
+
   describe('.redirect(status, url)', function(){
     it('should set the response status', function(done){
       var app = express();


### PR DESCRIPTION
Fixes #6941

Previously, `res.redirect(undefined)` would silently send a malformed `Location: undefined` header while only printing a deprecation warning. The HTTP response would contain an invalid Location header that clients cannot properly follow.

This change throws a `TypeError` for:
- Falsy URL values (`undefined`, `null`, `''`)  
- Non-string URLs

This prevents invalid HTTP responses and surfaces bugs early during development instead of silently sending broken redirects.