### PR TITLE
fix: throw TypeError for res.redirect(undefined/null)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -820,8 +820,8 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
+  if (address === undefined || address === null) {
+    throw new TypeError('url argument is required to res.redirect');
   }
 
   if (typeof address !== 'string') {

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -1,11 +1,46 @@
 'use strict'
 
+var assert = require('node:assert');
 var express = require('..');
 var request = require('supertest');
 var utils = require('./support/utils');
 
 describe('res', function(){
   describe('.redirect(url)', function(){
+    it('should throw TypeError when url is undefined', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        try {
+          res.redirect(undefined);
+          done(new Error('expected TypeError'));
+        } catch (e) {
+          assert.ok(e instanceof TypeError);
+          assert.strictEqual(e.message, 'url argument is required to res.redirect');
+          done();
+        }
+      });
+
+      request(app).get('/').end(function() {});
+    })
+
+    it('should throw TypeError when url is null', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        try {
+          res.redirect(null);
+          done(new Error('expected TypeError'));
+        } catch (e) {
+          assert.ok(e instanceof TypeError);
+          assert.strictEqual(e.message, 'url argument is required to res.redirect');
+          done();
+        }
+      });
+
+      request(app).get('/').end(function() {});
+    })
+
     it('should default to a 302 redirect', function(done){
       var app = express();
 


### PR DESCRIPTION
## Issue
Fixes #6941

## Problem
Calling `res.redirect(undefined)` (or `null`) currently emits a deprecation warning but still sends a malformed HTTP response with `Location: undefined`. This is a programming error that should fail fast.

## Solution
Changed `res.redirect` to throw a `TypeError` when the URL argument is `undefined` or `null`, consistent with other Express argument validation patterns (e.g. `res.sendFile` throws `TypeError` for missing `path` argument).

The error message follows existing Express conventions (e.g. "path argument is required to res.sendFile").

## Changes
- **lib/response.js**: Replaced `deprecate('Provide a url argument')` with `throw new TypeError(...)` when address is undefined or null
- **test/res.redirect.js**: Added two tests verifying the TypeError is thrown for undefined and null arguments

## Testing
All 15 tests in test/res.redirect.js pass, including the 2 new ones.
