### PR TITLE
`4.x` update qs to 6.15.1, body-parser 1.20.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+* fix: restore >20 array parsing for req.query repeated keys (8d09bfe6)
+  * This also unifies array-cap behavior across notations. Indexed notation (`a[0]=...`) was historically capped at qs's default `arrayLimit` of 20 even in older qs versions; after this change it also allows up to 1000 items.
+* deps: qs@~6.15.1
+* deps: body-parser@~1.20.5
+
 4.22.1 / 2025-12-01
 ==========
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "parseurl": "~1.3.3",
     "path-to-regexp": "~0.1.12",
     "proxy-addr": "~2.0.7",
-    "qs": "~6.14.1",
+    "qs": "~6.15.1",
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
     "send": "~0.19.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "accepts": "~1.3.8",
     "array-flatten": "1.1.1",
-    "body-parser": "~1.20.4",
+    "body-parser": "~1.20.5",
     "content-disposition": "~0.5.4",
     "content-type": "~1.0.4",
     "cookie": "~0.7.1",


### PR DESCRIPTION
Prepping a 4.x release, want to land the qs bump in its own commit before I open the release PR

The qs bump is a follow on from #6972, since it was not released yet and we can take a higher minor w/o impact. ([qs changelog](https://github.com/ljharb/qs/blob/a0a81ea2071acce3eff41a040f719ac8f5c4f64c/CHANGELOG.md#6151))

Edit: checked the dep tree and realized we can bump to body-parser@~1.20.5 to ensure express 4.x only pulls in one copy of qs

