### PR TITLE
release: 4.22.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
-unreleased
+4.22.2 / 2026-05-011
 ==========
 
-* fix: restore >20 array parsing for req.query repeated keys (8d09bfe6)
+* fix: restore >20 array parsing for `req.query` repeated keys ([`8d09bfe6`](https://github.com/expressjs/express/commit/8d09bfe6d88983da5c3e12cfdd54782c4dc675db))
   * This also unifies array-cap behavior across notations. Indexed notation (`a[0]=...`) was historically capped at qs's default `arrayLimit` of 20 even in older qs versions; after this change it also allows up to 1000 items.
 * deps: qs@~6.15.1
 * deps: body-parser@~1.20.5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express",
   "description": "Fast, unopinionated, minimalist web framework",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",


### PR DESCRIPTION
## What's Changed
- Closes the `req.query` array parsing regression introduced in 4.22.0 once qs 6.14.1 was published. The fix sets `arrayLimit: 1000` on the extended query parser. https://github.com/expressjs/express/commit/8d09bfe6d88983da5c3e12cfdd54782c4dc675db
- Coordinated `body-parser@~1.20.5` + `qs@~6.15.1` bumps so express and body-parser dedup to a single qs install.

**Full Changelog**: https://github.com/expressjs/express/compare/v4.22.1...4.x
