### PR TITLE
Skip default logging for client errors

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -609,12 +609,52 @@ app.listen = function listen() {
  * Log error using console.error.
  *
  * @param {Error} err
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
  * @private
  */
 
-function logerror(err) {
+function logerror(err, req, res) {
+  if (isClientError(err, res)) return
+
   /* istanbul ignore next */
   if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+}
+
+/**
+ * Check if an error should be considered a client error.
+ *
+ * @param {Error} err
+ * @param {ServerResponse} res
+ * @private
+ */
+
+function isClientError(err, res) {
+  var status = getErrorStatusCode(err)
+
+  if (status === undefined && res) {
+    status = res.statusCode
+  }
+
+  return typeof status === 'number' && status >= 400 && status < 500
+}
+
+/**
+ * Get status code from Error object.
+ *
+ * @param {Error} err
+ * @return {number}
+ * @private
+ */
+
+function getErrorStatusCode(err) {
+  if (typeof err.status === 'number' && err.status >= 400 && err.status < 600) {
+    return err.status
+  }
+
+  if (typeof err.statusCode === 'number' && err.statusCode >= 400 && err.statusCode < 600) {
+    return err.statusCode
+  }
 }
 
 /**

--- a/test/app.js
+++ b/test/app.js
@@ -21,6 +21,65 @@ describe('app', function(){
     .get('/')
     .expect(404, done);
   })
+
+  it('should not log client errors', function(done){
+    var app = express()
+    var errors = []
+    var original = console.error
+
+    app.set('env', 'development')
+    app.use(function (req, res, next) {
+      var err = new Error('missing')
+      err.status = 404
+      next(err)
+    })
+
+    console.error = function (err) {
+      errors.push(err)
+    }
+
+    request(app)
+      .get('/')
+      .expect(404, function (err) {
+        setImmediate(function () {
+          console.error = original
+
+          if (err) return done(err)
+
+          assert.strictEqual(errors.length, 0)
+          done()
+        })
+      })
+  })
+
+  it('should log server errors', function(done){
+    var app = express()
+    var errors = []
+    var original = console.error
+
+    app.set('env', 'development')
+    app.use(function (req, res, next) {
+      next(new Error('boom'))
+    })
+
+    console.error = function (err) {
+      errors.push(err)
+    }
+
+    request(app)
+      .get('/')
+      .expect(500, function (err) {
+        setImmediate(function () {
+          console.error = original
+
+          if (err) return done(err)
+
+          assert.strictEqual(errors.length, 1)
+          assert.match(errors[0], /Error: boom/)
+          done()
+        })
+      })
+  })
 })
 
 describe('app.parent', function(){


### PR DESCRIPTION
## Summary

Avoid logging errors from the default final handler when the resolved response status is a client error (`4xx`). Server errors continue to be logged in non-test environments.

## Why

Express currently logs any error object that reaches the default final handler. For expected client errors such as `404` or `400`, this adds noisy `console.error` output even though the response is already a client-error response.

Fixes #2263.

## Testing

- `npx mocha --require test/support/env --reporter spec --check-leaks test/app.js`
- `npx eslint lib/application.js test/app.js`
- `npm test`
- `npm run lint`