### PR TITLE
Skip ETag generation for no-store responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -49,6 +49,32 @@ var res = Object.create(http.ServerResponse.prototype)
 module.exports = res
 
 /**
+ * Check if a Cache-Control header contains the no-store directive.
+ *
+ * @param {string|number|string[]} value
+ * @return {boolean}
+ * @private
+ */
+
+function hasNoStoreDirective (value) {
+  if (!value) {
+    return false
+  }
+
+  var values = Array.isArray(value)
+    ? value
+    : [String(value)]
+
+  for (var i = 0; i < values.length; i++) {
+    if (/(?:^|,)\s*no-store\s*(?:,|$)/i.test(values[i])) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
  * Set the HTTP status code for the response.
  *
  * Expects an integer value between 100 and 999 inclusive.
@@ -159,7 +185,9 @@ res.send = function send(body) {
 
   // determine if ETag should be generated
   var etagFn = app.get('etag fn')
-  var generateETag = !this.get('ETag') && typeof etagFn === 'function'
+  var generateETag = !this.get('ETag') &&
+    !hasNoStoreDirective(this.get('Cache-Control')) &&
+    typeof etagFn === 'function'
 
   // populate Content-Length
   var len

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -442,6 +442,41 @@ describe('res', function(){
         .expect(200, done);
       });
 
+      it('should not send ETag when Cache-Control is no-store', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'private, no-store');
+          res.send('hello!');
+        });
+
+        app.enable('etag');
+
+        request(app)
+        .get('/')
+        .expect('Cache-Control', 'private, no-store')
+        .expect(utils.shouldNotHaveHeader('ETag'))
+        .expect(200, done);
+      });
+
+      it('should send manually set ETag when Cache-Control is no-store', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.set('Cache-Control', 'no-store');
+          res.set('etag', '"asdf"');
+          res.send('hello!');
+        });
+
+        app.enable('etag');
+
+        request(app)
+        .get('/')
+        .expect('Cache-Control', 'no-store')
+        .expect('ETag', '"asdf"')
+        .expect(200, done);
+      });
+
       it('should not send ETag for res.send()', function (done) {
         var app = express();
 


### PR DESCRIPTION
## Summary

Skip automatic ETag generation from `res.send()` when the response already has a `Cache-Control` header containing the `no-store` directive. Manually set ETags are still preserved.

## Why

`Cache-Control: no-store` tells clients and intermediaries not to store the response. Generating a validator for a response that must not be stored adds unnecessary work and can be surprising for routes that intentionally opt out of caching.

Fixes #2472.

## Testing

- `npx mocha --require test/support/env --reporter spec --check-leaks test/res.send.js`
- `npx eslint lib/response.js test/res.send.js`
- `npm test`
- `npm run lint`