### PR TITLE
fix: preserve Error.cause chain in logerror by logging full error object

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,11 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
-}
-
-/**
- * Try rendering a view.
+  if (this.get('env') !== 'test') console.error(err)g a view.
  * @private
  */
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,11 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err)g a view.
+  if (this.get('env') !== 'test') console.error(err);
+}
+
+/**
+ * Try rendering a view.
  * @private
  */
 


### PR DESCRIPTION
## What

Change `logerror` in `lib/application.js` to pass the full error object to `console.error()` instead of `err.stack || err.toString()`.

**Before:**
```js
if (this.get('env') !== 'test') console.error(err.stack || err.toString());
```

**After:**
```js
if (this.get('env') !== 'test') console.error(err);
```

## Why

`err.stack || err.toString()` only captures the top-level stack trace of an error. It silently drops:

- **`Error.cause`** chains (introduced in Node.js 16.9). `new Error("outer", { cause: new Error("inner") })` — the inner cause never appears.
- - **Custom error properties** attached by libraries like Sequelize (`parent`, `original`) or any error with enumerable properties beyond `message` and `stack`.
- - **Async stack traces** and other runtime-enriched error metadata.
Passing the error object directly to `console.error(err)` lets Node.js format it with its full representation, including the cause chain and any custom properties. This is the same behavior you get from an unhandled exception.

## Reproducer

```js
const app = require('express')();

app.get('/', (req, res, next) => {
  const inner = new Error('database connection refused');
  const outer = new Error('could not load user', { cause: inner });
  next(outer);
});

app.listen(3000);
// curl http://localhost:3000/
// Before this fix: only "Error: could not load user" + its stack — cause is invisible
// After this fix:  full cause chain is printed by the runtime
```

## Related

Fixes #6462

By making this contribution I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.