### PR TITLE
Upgrade `content-type`

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,13 @@
     app.render('index', null, callback); // now works as expected
     ```
 
+* Upgrade `content-type` to `^2.0.0`, bringing a faster parser (~1.5x quicker `Content-Type` parsing/formatting in `res.send()`) along with a behavior change: `res.send()` now keeps any existing parameters when adding the charset and no longer throws on a `Content-Type` that fails to parse - by [@blakeembrey](https://github.com/blakeembrey) in [#7234](https://github.com/expressjs/express/pull/7234)
+
+    ```js
+    res.set('Content-Type', 'text/plain; foo=bar').send('hey');
+    // -> Content-Type: text/plain; foo=bar; charset=utf-8
+    ```
+
 ## ⚡ Performance
 
 * Avoid duplicate Content-Type header processing in `res.send()` when sending string responses without an explicit Content-Type header - by [@bjohansebas](https://github.com/bjohansebas) in [#6991](https://github.com/expressjs/express/pull/6991)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "accepts": "^2.0.0",
     "body-parser": "^2.2.1",
     "content-disposition": "^1.0.0",
-    "content-type": "^1.0.5",
+    "content-type": "^2.0.0",
     "cookie": "^0.7.1",
     "cookie-signature": "^1.2.1",
     "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "send": "^1.1.0",
     "serve-static": "^2.2.0",
     "statuses": "^2.0.1",
-    "type-is": "^2.0.1",
+    "type-is": "^2.1.0",
     "vary": "^1.1.2"
   },
   "devDependencies": {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -122,6 +122,32 @@ describe('res', function(){
       .expect(200, 'hey', done);
     })
 
+    it('should preserve existing parameters when adding charset', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Content-Type', 'text/plain; foo=bar').send('hey');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/plain; foo=bar; charset=utf-8')
+      .expect(200, 'hey', done);
+    })
+
+    it('should not throw on a Content-Type that fails to parse', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Content-Type', 'text/plain; foo').send('hey');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(200, 'hey', done);
+    })
+
     it('should keep charset in Content-Type for Buffers', function(done){
       var app = express();
 


### PR DESCRIPTION
Only used in https://github.com/expressjs/express/blob/f873ac23124ffcff8c040b4bd257b32c29828d53/lib/utils.js#L225-L238. There will be a minor change in behavior for invalid `content-type` headers as `parse` no longer fails but instead does its best, but the `format` below it will validate anything that was parsed.

This only leaves edge cases like unterminated `"` or trailing content after `""xyz` as omitted. 100% backward compatibility can be achieved for these edge cases if its wanted, but I'm not sure it's worth it.

Version 2 of `content-type` was focused on performance and since this is the only method in the package using it, it's not a critical upgrade and would only serve to deduplicate with any dependencies that also upgrade.