### PR TITLE
Res.redirect: Code examples should show default HTTP status code 302 instead of 301

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -803,7 +803,7 @@ res.location = function location(url) {
  *
  *    res.redirect('/foo/bar');
  *    res.redirect('http://example.com');
- *    res.redirect(301, 'http://example.com');
+ *    res.redirect(302, 'http://example.com');
  *    res.redirect('../login'); // /blog/post/1 -> /blog/login
  *
  * @public


### PR DESCRIPTION
## Summary
Root cause: The `res.redirect` JSDoc example in `lib/response.js` showed `res.redirect(301, 'http://example.com')`, which misled readers into treating `301` (a permanent redirect) as a canonical default instead of the actual default `302`. Change: Updated the `res.redirect` JSDoc example in `lib/response.js` to use `302` so the documented `(status, url)` example matches the method's documented default and avoids steering migrators toward an accidental permanent redirect. Closes https://github.com/expressjs/expressjs.com/issues/2308