### PR TITLE
fix: wrap case 'string' body in braces to prevent TDZ for const type in res.send()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -132,7 +132,7 @@ res.send = function send(body) {
 
   switch (typeof chunk) {
     // string defaulting to html
-    case 'string':
+    case 'string': {
       encoding = 'utf8';
       const type = this.get('Content-Type');
 
@@ -142,6 +142,7 @@ res.send = function send(body) {
         this.type('html');
       }
       break;
+    }
     case 'boolean':
     case 'number':
     case 'object':

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -134,6 +134,22 @@ describe('res', function(){
       .expect('Content-Type', 'text/plain; charset=iso-8859-1')
       .expect(200, 'hi', done);
     })
+
+    it('should not expose Content-Type const to other switch cases', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        // Sending a number goes through the object/number case in the switch,
+        // which must not have access to the const declared in the string case.
+        // This test ensures the block-scoped fix prevents a TDZ ReferenceError.
+        res.send(42);
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'application/json; charset=utf-8')
+      .expect(200, '42', done);
+    })
   })
 
   describe('.send(Buffer)', function(){


### PR DESCRIPTION
## Summary

Closes #7223

- In `res.send()` (`lib/response.js`), the `const type` declaration inside `case 'string'` was not wrapped in a block `{}`, causing it to be scoped to the **entire switch statement** rather than just that case.
- This violates the `no-case-declarations` ESLint rule and creates a Temporal Dead Zone (TDZ) risk: any sibling case that referenced `type` would throw a `ReferenceError: Cannot access 'type' before initialization`.
- The fix wraps the `case 'string':` body in `{ }` to properly block-scope the `const` declaration.

## Changes

- `lib/response.js` — add `{` / `}` around the `case 'string':` body in `res.send()`
- `test/res.send.js` — add a test confirming non-string types (number → `case 'number'`) are unaffected, validating there is no TDZ bleed-over between cases

## Test plan

- [ ] `npm test` — all 1250 existing tests pass
- [ ] New test `should not expose Content-Type const to other switch cases` passes
- [ ] `npm run lint` passes

