### PR TITLE
fix: preserve error details (cause, nested errors) in logerror

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Description

The `logerror` function uses `console.error(err.stack || err.toString())` which strips non-standard error properties like `Error.cause`, Sequelize's `parent`/`original`, and async stack traces.

Modern JavaScript Error objects carry additional metadata (e.g. `cause`, nested errors). Using `err.stack` discards these. `console.error(err)` logs the full error object including all enumerable properties.

### Example

```js
// Before: logs just "Error: outer" with stack
console.error(err.stack)

// After: logs "Error: outer { cause: Error: inner }" with full details
console.error(err)
```

Fixes #6462
