### PR TITLE
fix: replace deprecated trimRight() with trimEnd()

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -424,7 +424,7 @@ defineGetter(req, 'host', function host(){
   } else if (val.indexOf(',') !== -1) {
     // Note: X-Forwarded-Host is normally only ever a
     //       single value, but this is to be safe.
-    val = val.substring(0, val.indexOf(',')).trimRight()
+    val = val.substring(0, val.indexOf(',')).trimEnd()
   }
 
   return val || undefined;


### PR DESCRIPTION
## Description
The `host` getter in `lib/request.js:427` uses the deprecated `trimRight()` method, which is an Annex B legacy alias for `trimEnd()`.

## Why This Matters
- `trimRight()` is deprecated and may emit warnings in future Node.js/V8 versions
- `trimEnd()` is the ES2019 standard equivalent with identical behavior
- This aligns with Express's modernization efforts

## Changes
- Replaced `.trimRight()` with `.trimEnd()` in the host getter

## Testing
- Existing tests pass (run `npm test`)
- No new tests needed (this is a 1:1 method replacement with identical behavior)

Closes #XXXX (only if linking to an existing issue)