### PR TITLE
Support mixed-case request header lookups in req.get

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -78,8 +78,9 @@ req.header = function header(name) {
       return this.headers.referrer
         || this.headers.referer;
     default:
-      return this.headers[lc];
-  }
+        return this.headers[lc]
+          || this.headers[name];
+    }
 };
 
 /**


### PR DESCRIPTION
Summary
Adds fallback handling for request headers stored with mixed casing when using `req.get()`.

This allows lookups such as:

```js
req.headers['X-Filipe'] = 'present'
req.get('x-filipe')
