### PR TITLE
fix: log Error object directly to preserve Error.cause and nested properties

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**

--- a/test/app.routes.error.js
+++ b/test/app.routes.error.js
@@ -4,6 +4,47 @@ var assert = require('node:assert')
 var express = require('../')
   , request = require('supertest');
 
+describe('app.logerror', function () {
+  var originalEnv;
+  var logged;
+  var originalConsoleError;
+
+  before(function () {
+    originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    originalConsoleError = console.error;
+    console.error = function (val) { logged = val; };
+  });
+
+  after(function () {
+    process.env.NODE_ENV = originalEnv;
+    console.error = originalConsoleError;
+  });
+
+  beforeEach(function () {
+    logged = undefined;
+  });
+
+  it('should log the Error object, not just the stack string', function (done) {
+    var cause = new Error('database connection refused');
+    var err = new Error('request failed', { cause: cause });
+
+    var app = express();
+    app.get('/', function (req, res, next) { next(err); });
+
+    request(app)
+      .get('/')
+      .expect(500, function () {
+        // finalhandler schedules onerror via setImmediate; wait one tick
+        setImmediate(function () {
+          assert.strictEqual(logged, err, 'logerror should pass the Error object to console.error');
+          assert.strictEqual(logged.cause, cause, 'Error.cause should be preserved on the logged object');
+          done();
+        });
+      });
+  });
+});
+
 describe('app', function(){
   describe('.VERB()', function(){
     it('should not get invoked without error handler on error', function(done) {


### PR DESCRIPTION
## Problem

`logerror` in `lib/application.js` serializes errors before logging:

```js
console.error(err.stack || err.toString());
```

This drops any information beyond the top-level stack trace — including:

- **`Error.cause`** (added in Node.js 16.9 / ES2022), which chains the root cause
- Framework-specific nested properties like Sequelize's `parent` and `original` fields
- Any custom enumerable properties attached to the error

When debugging a 500 in production, the logged output is a plain string — the underlying cause is silently discarded.

Fixes #6462.

## Fix

Pass the `Error` object directly to `console.error`:

```js
console.error(err);
```

`console.error` already knows how to format `Error` objects. Starting with Node.js 16.9+, it also traverses and prints the full `cause` chain. This is strictly more informative — nothing is lost.

## Test

Added a test in `test/app.routes.error.js` that:
1. Creates an error with a `cause`
2. Sends a request that triggers the unhandled error path
3. Asserts that `console.error` received the `Error` object itself (not a string), with `cause` intact