### PR TITLE
Fix 3 bugs: no-arg redirect, cookie option leak, view render context.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -744,6 +744,8 @@ res.cookie = function (name, value, options) {
   var secret = this.req.secret;
   var signed = opts.signed;
 
+  delete opts.signed;
+
   if (signed && !secret) {
     throw new Error('cookieParser("secret") required for signed cookies');
   }
@@ -810,9 +812,9 @@ res.location = function location(url) {
  */
 
 res.redirect = function redirect(url) {
-  var address = url;
   var body;
   var status = 302;
+  var address = url;
 
   // allow status / url
   if (arguments.length === 2) {
@@ -830,6 +832,11 @@ res.redirect = function redirect(url) {
 
   if (typeof status !== 'number') {
     deprecate('Status must be a number');
+  }
+
+  // default to safe redirect
+  if (!address) {
+    address = '/';
   }
 
   // Set location header

--- a/lib/view.js
+++ b/lib/view.js
@@ -137,16 +137,18 @@ View.prototype.render = function render(options, callback) {
 
   // render, normalizing sync callbacks
   this.engine(this.path, options, function onRender() {
-    if (!sync) {
-      return callback.apply(this, arguments);
-    }
-
     // copy arguments
     var args = new Array(arguments.length);
     var cntx = this;
 
     for (var i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];
+    }
+
+    if (!sync) {
+      return process.nextTick(function renderTick() {
+        return callback.apply(cntx, args);
+      });
     }
 
     // force callback to be async


### PR DESCRIPTION
Found a few things that needed fixing:


1. res.redirect() with no args - if you call it without a URL, it'd redirect to the literal string "undefined". The deprecation warning was there but didn't stop it from doing something broken. Added a safe fallback to '/'.

2. res.cookie() leaked opts.signed - the signed property was being read from options but never cleaned up before passing the whole object to cookie.serialize(). The cookie package ignores unknown keys so it works today, but it's a leak waiting to bite if that ever changes.

3. View.prototype.render inconsistent this - the sync and async paths used different this values when calling back. Both come from wherever the template engine sets it, but they could differ between the first call and subsequent calls. Unified it so both paths use the same captured context.