### PR TITLE
feat: handle circular structure serialization

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 ## 🚀 Improvements
 
+* Add `"json circular"` setting for `res.json` and `res.jsonp` to replace circular references with `"[Circular]"` when enabled.
+
 * Improve HTML structure in `res.redirect()` responses when HTML format is accepted by adding `<!DOCTYPE html>`, `<title>`, and `<body>` tags for better browser compatibility - by [@Bernice55231](https://github.com/Bernice55231) in [#5167](https://github.com/expressjs/express/pull/5167)
 
 * When calling `app.render` with options set to null, the locals object is handled correctly, preventing unexpected errors and making the method behave the same as when options is omitted or an empty object is passed - by [AkaHarshit](https://github.com/AkaHarshit) in [#6903](https://github.com/expressjs/express/pull/6903)

--- a/lib/response.js
+++ b/lib/response.js
@@ -233,9 +233,10 @@ res.json = function json(obj) {
   // settings
   var app = this.app;
   var escape = app.get('json escape')
+  var circular = app.get('json circular')
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = stringify(obj, replacer, spaces, escape)
+  var body = stringify(obj, replacer, spaces, escape, circular)
 
   // content-type
   if (!this.get('Content-Type')) {
@@ -261,9 +262,10 @@ res.jsonp = function jsonp(obj) {
   // settings
   var app = this.app;
   var escape = app.get('json escape')
+  var circular = app.get('json circular')
   var replacer = app.get('json replacer');
   var spaces = app.get('json spaces');
-  var body = stringify(obj, replacer, spaces, escape)
+  var body = stringify(obj, replacer, spaces, escape, circular)
   var callback = this.req.query[app.get('jsonp callback name')];
 
   // content-type
@@ -1016,12 +1018,13 @@ function sendfile(res, file, options, callback) {
  * @param {function} replacer
  * @param {number} spaces
  * @param {boolean} escape
+ * @param {boolean} circular
  * @returns {string}
  * @private
  */
 
-function stringify (value, replacer, spaces, escape) {
-  var json = stringifyWithFallback(value, replacer, spaces);
+function stringify (value, replacer, spaces, escape, circular) {
+  var json = stringifyWithFallback(value, replacer, spaces, circular);
 
   if (escape && typeof json === 'string') {
     json = json.replace(/[<>&]/g, function (c) {
@@ -1042,7 +1045,7 @@ function stringify (value, replacer, spaces, escape) {
   return json
 }
 
-function stringifyWithFallback(value, replacer, spaces) {
+function stringifyWithFallback(value, replacer, spaces, circular) {
   try {
     // v8 checks arguments.length for optimizing simple call
     // https://bugs.chromium.org/p/v8/issues/detail?id=4730
@@ -1050,7 +1053,7 @@ function stringifyWithFallback(value, replacer, spaces) {
       ? JSON.stringify(value, replacer, spaces)
       : JSON.stringify(value);
   } catch (err) {
-    if (!isCircularJsonError(err)) {
+    if (!circular || !isCircularJsonError(err) || Array.isArray(replacer)) {
       throw err;
     }
 
@@ -1064,18 +1067,11 @@ function createCircularReplacer(replacer) {
   return function (key, value) {
     var replacement = value;
 
-    if (typeof replacer === "function") {
+    if (typeof replacer === 'function') {
       replacement = replacer.call(this, key, value);
-    } else if (
-      Array.isArray(replacer) &&
-      key !== "" &&
-      !Array.isArray(this) &&
-      !hasReplacerKey(replacer, key)
-    ) {
-      return undefined;
     }
 
-    if (typeof replacement !== "object" || replacement === null) {
+    if (typeof replacement !== 'object' || replacement === null) {
       return replacement;
     }
 
@@ -1084,7 +1080,7 @@ function createCircularReplacer(replacer) {
     }
 
     if (stack.indexOf(replacement) !== -1) {
-      return "[Circular]";
+      return '[Circular]';
     }
 
     stack.push(replacement);
@@ -1092,26 +1088,8 @@ function createCircularReplacer(replacer) {
   };
 }
 
-function hasReplacerKey(replacer, key) {
-  for (var i = 0; i < replacer.length; i++) {
-    var value = replacer[i];
-
-    if (typeof value === "string" || typeof value === "number") {
-      if (String(value) === key) {
-        return true;
-      }
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      String(value) === key
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 function isCircularJsonError(err) {
+  // JSON.stringify does not expose a specialized error for circular
+  // structures, so this depends on the current V8/Node error message.
   return err instanceof TypeError && /circular structure/i.test(err.message);
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -1021,11 +1021,7 @@ function sendfile(res, file, options, callback) {
  */
 
 function stringify (value, replacer, spaces, escape) {
-  // v8 checks arguments.length for optimizing simple call
-  // https://bugs.chromium.org/p/v8/issues/detail?id=4730
-  var json = replacer || spaces
-    ? JSON.stringify(value, replacer, spaces)
-    : JSON.stringify(value);
+  var json = stringifyWithFallback(value, replacer, spaces);
 
   if (escape && typeof json === 'string') {
     json = json.replace(/[<>&]/g, function (c) {
@@ -1044,4 +1040,78 @@ function stringify (value, replacer, spaces, escape) {
   }
 
   return json
+}
+
+function stringifyWithFallback(value, replacer, spaces) {
+  try {
+    // v8 checks arguments.length for optimizing simple call
+    // https://bugs.chromium.org/p/v8/issues/detail?id=4730
+    return replacer || spaces
+      ? JSON.stringify(value, replacer, spaces)
+      : JSON.stringify(value);
+  } catch (err) {
+    if (!isCircularJsonError(err)) {
+      throw err;
+    }
+
+    return JSON.stringify(value, createCircularReplacer(replacer), spaces);
+  }
+}
+
+function createCircularReplacer(replacer) {
+  var stack = [];
+
+  return function (key, value) {
+    var replacement = value;
+
+    if (typeof replacer === "function") {
+      replacement = replacer.call(this, key, value);
+    } else if (
+      Array.isArray(replacer) &&
+      key !== "" &&
+      !Array.isArray(this) &&
+      !hasReplacerKey(replacer, key)
+    ) {
+      return undefined;
+    }
+
+    if (typeof replacement !== "object" || replacement === null) {
+      return replacement;
+    }
+
+    while (stack.length > 0 && stack[stack.length - 1] !== this) {
+      stack.pop();
+    }
+
+    if (stack.indexOf(replacement) !== -1) {
+      return "[Circular]";
+    }
+
+    stack.push(replacement);
+    return replacement;
+  };
+}
+
+function hasReplacerKey(replacer, key) {
+  for (var i = 0; i < replacer.length; i++) {
+    var value = replacer[i];
+
+    if (typeof value === "string" || typeof value === "number") {
+      if (String(value) === key) {
+        return true;
+      }
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      String(value) === key
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isCircularJsonError(err) {
+  return err instanceof TypeError && /circular structure/i.test(err.message);
 }

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -101,6 +101,23 @@ describe('res', function(){
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect(200, '{"name":"tobi"}', done)
       })
+
+      it('should replace circular references', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          var error = { message: 'boom' }
+
+          error.self = error
+
+          res.json(error)
+        })
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(200, '{"message":"boom","self":"[Circular]"}', done)
+      })
     })
 
     describe('"json escape" setting', function () {

--- a/test/res.json.js
+++ b/test/res.json.js
@@ -102,8 +102,26 @@ describe('res', function(){
         .expect(200, '{"name":"tobi"}', done)
       })
 
-      it('should replace circular references', function (done) {
+      it('should throw on circular references by default', function (done) {
         var app = express()
+
+        app.use(function (req, res) {
+          var error = { message: 'boom' }
+
+          error.self = error
+
+          res.json(error)
+        })
+
+        request(app)
+        .get('/')
+        .expect(500, /circular structure/i, done)
+      })
+
+      it('should replace circular references when "json circular" is enabled', function (done) {
+        var app = express()
+
+        app.enable('json circular')
 
         app.use(function (req, res) {
           var error = { message: 'boom' }
@@ -117,6 +135,26 @@ describe('res', function(){
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect(200, '{"message":"boom","self":"[Circular]"}', done)
+      })
+
+      it('should replace nested circular references when "json circular" is enabled', function (done) {
+        var app = express()
+
+        app.enable('json circular')
+
+        app.use(function (req, res) {
+          var child = { name: 'child' }
+          var parent = { child: child }
+
+          child.parent = parent
+
+          res.json(parent)
+        })
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(200, '{"child":{"name":"child","parent":"[Circular]"}}', done)
       })
     })
 
@@ -175,6 +213,50 @@ describe('res', function(){
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect(200, '{"name":"tobi"}', done)
+      })
+
+      it('should replace circular references with function replacer when "json circular" is enabled', function(done){
+        var app = express();
+
+        app.enable('json circular')
+
+        app.set('json replacer', function(key, val){
+          return key[0] === '_'
+            ? undefined
+            : val;
+        });
+
+        app.use(function(req, res){
+          var user = { name: 'tobi', _id: 12345 }
+
+          user.self = user
+
+          res.json(user);
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(200, '{"name":"tobi","self":"[Circular]"}', done)
+      })
+
+      it('should throw on circular references with array replacer', function(done){
+        var app = express();
+
+        app.enable('json circular')
+        app.set('json replacer', ['message', 'self']);
+
+        app.use(function(req, res){
+          var error = { message: 'boom' }
+
+          error.self = error
+
+          res.json(error);
+        });
+
+        request(app)
+        .get('/')
+        .expect(500, /circular structure/i, done)
       })
     })
 

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -245,6 +245,23 @@ describe('res', function(){
           .expect('Content-Type', 'text/javascript; charset=utf-8')
           .expect(200, /cb\(\{"name":"tobi"\}\)/, done)
       })
+
+      it('should replace circular references', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          var error = { message: 'boom' }
+
+          error.self = error
+
+          res.jsonp(error)
+        })
+
+        request(app)
+          .get('/?callback=cb')
+          .expect('Content-Type', 'text/javascript; charset=utf-8')
+          .expect(200, /cb\(\{"message":"boom","self":"\[Circular\]"\}\)/, done)
+      })
     })
 
     describe('"json escape" setting', function () {

--- a/test/res.jsonp.js
+++ b/test/res.jsonp.js
@@ -246,8 +246,26 @@ describe('res', function(){
           .expect(200, /cb\(\{"name":"tobi"\}\)/, done)
       })
 
-      it('should replace circular references', function (done) {
+      it('should throw on circular references by default', function (done) {
         var app = express()
+
+        app.use(function (req, res) {
+          var error = { message: 'boom' }
+
+          error.self = error
+
+          res.jsonp(error)
+        })
+
+        request(app)
+          .get('/?callback=cb')
+          .expect(500, /circular structure/i, done)
+      })
+
+      it('should replace circular references when "json circular" is enabled', function (done) {
+        var app = express()
+
+        app.enable('json circular')
 
         app.use(function (req, res) {
           var error = { message: 'boom' }


### PR DESCRIPTION
## Problem

`res.json` in `lib/response.js` calls `stringify` which fails if a object with circular structure is passed.

This is pretty common when you have calls using `axios` lib, the axios errors include the response object which have circular structure. Since a bunch a libs rely on axios, this is a pretty common cause of issues.

## Example of Stack Trace
Doing a `soap` call with `routing-controllers` on top of `express`, fails to parse the error.

```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Agent'

--- property 'agent' closes the circle
    at JSON.stringify (<anonymous>)
    at stringify (/app/node_modules/express/lib/response.js:1034:12)
    at ServerResponse.json (/app/node_modules/express/lib/response.js:245:14)
    at ExpressDriver.handleError (/app/node_modules/routing-controllers/cjs/driver/express/ExpressDriver.js:351:26)
    at /app/node_modules/routing-controllers/cjs/RoutingControllers.js:115:36
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

## Tests

Added tests in `test/res.json` and `test/res.jsonp`  simulating the circular structure.