### PR TITLE
fix: remove implicit Content-Type magic in res.set (#7145)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -652,8 +652,9 @@ res.append = function append(field, val) {
  *
  * Aliased as `res.header()`.
  *
- * When the set header is "Content-Type", the type is expanded to include
- * the charset if not present using `mime.contentType()`.
+ * This method is a generic header setter: for `Content-Type` it does not
+ * perform any MIME lookup or charset injection. If you want shorthand
+ * resolution and charset handling, use `res.type()`.
  *
  * @param {String|Object} field
  * @param {String|Array} val
@@ -673,7 +674,6 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
     }
 
     this.setHeader(field, value);

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -174,7 +174,7 @@ describe('res', function(){
 
       request(app)
       .get('/')
-      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect('Content-Type', 'text/plain')
       .expect(200, 'hey', done);
     })
 
@@ -187,7 +187,7 @@ describe('res', function(){
 
       request(app)
         .get("/")
-        .expect("Content-Type", "text/plain; charset=utf-8")
+        .expect("Content-Type", "text/plain")
         .expect(200, "hey", done);
     })
 

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -18,6 +18,33 @@ describe('res', function(){
       .end(done);
     })
 
+    it('should not add charset when Content-Type is set without one', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'text/plain').end();
+      });
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'text/plain')
+        .expect(200, done);
+    })
+
+    it('should not resolve shorthand Content-Type values', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        // "html" looks like a shorthand; res.set should be pass-through.
+        res.set('Content-Type', 'html').end();
+      });
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'html')
+        .expect(200, done);
+    })
+
     it('should coerce to a string', function (done) {
       var app = express();
 


### PR DESCRIPTION
### **What’s included in the PR**
`lib/response.js`: removed the Content-Type “magic” from `res.set` (no implicit MIME lookup / no charset injection); updated JSDoc
`test/res.set.js`: added assertions for pass-through `Content-Type`
`test/res.send.js`: updated expectations for Buffer/Uint8Array cases that previously depended on the old `res.set` behavior
Tests I ran locally
`npx mocha ... test/res.set.js` (passing)
`npx mocha ... test/res.send.js` (passing)