### PR TITLE
fix: normalize all-slash mount paths in app.use to '/'

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -207,6 +207,12 @@ app.use = function use(fn) {
     }
   }
 
+  // normalize all-slash mount paths (e.g. '//', '///') to '/' so they don't
+  // collapse to '' in the router's loosen() and match every request
+  if (typeof path === 'string' && /^\/+$/.test(path)) {
+    path = '/';
+  }
+
   var fns = flatten.call(slice.call(arguments, offset), Infinity);
 
   if (fns.length === 0) {

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -361,6 +361,47 @@ describe('app', function(){
       .expect(200, 'saw POST /bar', cb);
     })
 
+    it('should treat all-slash paths as a root mount', function (done) {
+      var app = express();
+      var sub = express();
+      var cb = after(4, done);
+
+      sub.get('/', function (req, res) {
+        res.send('sub-root');
+      });
+
+      sub.get('/secret', function (req, res) {
+        res.send('sub-secret');
+      });
+
+      app.use('//', sub);
+
+      request(app)
+      .get('/')
+      .expect(200, 'sub-root', cb);
+
+      request(app)
+      .get('/secret')
+      .expect(200, 'sub-secret', cb);
+
+      // unrelated paths must still 404 — '//' must not match every request
+      request(app)
+      .get('/missing')
+      .expect(404, cb);
+
+      // '///' (and longer) must normalize to '/' the same way as '//'
+      var triple = express();
+      var sub2 = express();
+      sub2.get('/', function (req, res) {
+        res.send('triple-root');
+      });
+      triple.use('///', sub2);
+
+      request(triple)
+      .get('/')
+      .expect(200, 'triple-root', cb);
+    })
+
     it('should accept array of middleware', function (done) {
       var app = express();
 


### PR DESCRIPTION
```markdown
## What

Normalize string mount paths that are only slashes (`'/'`, `'//'`, `'///'`, …) to `'/'` inside `app.use()` before handing them to the underlying router.

Fixes #4557 — `app.use('//', subApp)` no longer takes a divergent path through the router that depends on `path-to-regexp` matching the empty pattern.

## Root cause

`router`'s `Layer` constructor sets a `/`-fast-path flag with `this.slash = path === '/' && opts.end === false`, then runs the pattern through `loosen()`:

```js
const TRAILING_SLASH_REGEXP = /\/+$/
// ...
return String(path).replace(TRAILING_SLASH_REGEXP, '')
```

For `'//'`, `loosen` strips both slashes to `''`. The layer's `slash` flag is `false` (because `path !== '/'`), so matching falls through to `pathRegexp.match('', { end: false, trailing: true })`. That matcher matches every request — the layer behaves like a wildcard prefix, just without the fast-path metadata. Mounting at `'///'` and longer reduces to the same case.

In the issue, the reporter mounted dev/test routes under `'//'` expecting them to be unreachable from `/`, but the layer matched anyway and exposed those routes.

## Fix

One guard, right after `app.use` resolves the path arg:

```js
if (typeof path === 'string' && /^\/+$/.test(path)) {
  path = '/';
}
```

The fix stays scoped to all-slash strings. Inner repeated slashes like `'/foo//bar'` are deliberately left alone — collapsing them is a broader behavior change, the same one that took PR #7054 out of scope.

## Testing

- `npm test` — 1250 passing, including the new `should treat all-slash paths as a root mount` case in `test/app.use.js` that exercises `'//'` and `'///'` end-to-end.
- `npm run lint` — clean.

The new test locks in three things: `/` and `/secret` reach the sub-app, an unrelated path like `/missing` still 404s (i.e. the layer is not a global wildcard), and `'///'` normalizes the same way as `'//'`.

## Notes

Root cause technically lives in `router`'s `loosen()` (treating `'//'` as `''`). Fixing it in express is a surface workaround — if `router` ever normalizes this itself, the guard here is harmless but redundant.

Fixes #4557.
```