### PR TITLE
fix: handle Infinity/NaN maxAge in res.cookie() without crashing

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -760,7 +760,12 @@ res.cookie = function (name, value, options) {
     var maxAge = opts.maxAge - 0
 
     if (maxAge === Infinity || maxAge === -Infinity || (typeof opts.maxAge === 'number' && isNaN(maxAge))) {
-      // strip non-finite numeric maxAge (Infinity, -Infinity, NaN)
+      // strip non-finite numeric maxAge (Infinity, -Infinity, NaN) so the
+      // cookie falls back to a session cookie (no Max-Age). The typeof
+      // guard ensures non-numeric strings like 'foobar' still flow through
+      // to cookie.serialize() and throw, rather than being silently dropped.
+      // (String 'Infinity' coerces to numeric Infinity above and is
+      // intentionally stripped here, consistent with numeric Infinity.)
       delete opts.maxAge
     } else if (!isNaN(maxAge)) {
       opts.expires = new Date(Date.now() + maxAge)

--- a/lib/response.js
+++ b/lib/response.js
@@ -759,7 +759,10 @@ res.cookie = function (name, value, options) {
   if (opts.maxAge != null) {
     var maxAge = opts.maxAge - 0
 
-    if (!isNaN(maxAge)) {
+    if (maxAge === Infinity || maxAge === -Infinity || (typeof opts.maxAge === 'number' && isNaN(maxAge))) {
+      // strip non-finite numeric maxAge (Infinity, -Infinity, NaN)
+      delete opts.maxAge
+    } else if (!isNaN(maxAge)) {
       opts.expires = new Date(Date.now() + maxAge)
       opts.maxAge = Math.floor(maxAge / 1000)
     }

--- a/test/res.cookie.js
+++ b/test/res.cookie.js
@@ -183,6 +183,51 @@ describe('res', function(){
           .get('/')
           .expect(500, /option maxAge is invalid/, done)
       })
+
+      it('should strip Infinity maxAge and produce a session cookie', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { maxAge: Infinity })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Set-Cookie', 'name=tobi; Path=/')
+          .end(done)
+      })
+
+      it('should strip -Infinity maxAge and produce a session cookie', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { maxAge: -Infinity })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Set-Cookie', 'name=tobi; Path=/')
+          .end(done)
+      })
+
+      it('should strip NaN maxAge and produce a session cookie', function (done) {
+        var app = express()
+
+        app.use(function (req, res) {
+          res.cookie('name', 'tobi', { maxAge: NaN })
+          res.end()
+        })
+
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Set-Cookie', 'name=tobi; Path=/')
+          .end(done)
+      })
     })
 
     describe('priority', function () {


### PR DESCRIPTION
Noticed that passing { maxAge: Infinity } to res.cookie() throws an unhandled TypeError: option maxAge is invalid from the cookie package. The old !isNaN() check passes for Infinity (since it's not NaN), so the code tries to compute Math.floor(Infinity / 1000) and passes Infinity straight to cookie.serialize(), which rightfully rejects it.

Same issue with NaN and -Infinity.

The fix adds an early guard: if maxAge is a number and non-finite (Infinity, -Infinity, NaN), just delete it from opts so the cookie falls back to a session cookie (no Max-Age). Non-numeric garbage like 'foobar' still throws as before that path is unchanged.

Checked all edge cases manually and ran the suite a few times 1249 passing, 0 failing.