### PR TITLE
Log error objects in the default error handler

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**

--- a/test/app.js
+++ b/test/app.js
@@ -118,3 +118,36 @@ describe('without NODE_ENV', function(){
     assert.strictEqual(app.get('env'), 'development')
   })
 })
+
+describe('default error logging', function () {
+  before(function () {
+    this.error = console.error
+    this.env = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+  })
+
+  after(function () {
+    console.error = this.error
+    process.env.NODE_ENV = this.env
+  })
+
+  it('should log the error object', function (done) {
+    var app = express()
+    var error = new Error('boom', { cause: new Error('cause') })
+
+    console.error = function (value) {
+      assert.strictEqual(value, error)
+      done()
+    }
+
+    app.use(function (req, res, next) {
+      next(error)
+    })
+
+    request(app)
+      .get('/')
+      .expect(500, function (err) {
+        if (err) done(err)
+      })
+  })
+})


### PR DESCRIPTION
## Problem
The default Express final-handler logger currently logs `err.stack || err.toString()`. That stringifies the error too early and can hide structured error details such as `Error.cause` or additional properties provided by libraries.

## Root cause
`logerror` extracts the stack string before passing the error to `console.error`, so Node's object/error formatter cannot include nested details.

## Fix
Pass the error object directly to `console.error`. This preserves existing stack output while allowing runtimes to include richer error object information.

## Testing
- Added a regression test that verifies the default logger receives the original error object.
- Ran `git diff --check` successfully.

Fixes #6462