### PR TITLE
fix: log full error object in logerror (fixes #6462)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**

--- a/test/app.logerror.js
+++ b/test/app.logerror.js
@@ -5,12 +5,23 @@ var express = require('..')
 var request = require('supertest')
 
 describe('logerror', function () {
+  var original
+
+  beforeEach(function () {
+    original = console.error
+  })
+
+  afterEach(function () {
+    if (original) {
+      console.error = original
+    }
+  })
+
   it('should log the full error object', function (done) {
     var app = express()
     app.set('env', 'development')
 
     var logged
-    var original = console.error
     console.error = function (err) {
       logged = err
     }
@@ -23,12 +34,8 @@ describe('logerror', function () {
     request(app)
       .get('/')
       .expect(500, function (err) {
-        if (err) {
-          console.error = original
-          return done(err)
-        }
+        if (err) return done(err)
         setImmediate(function () {
-          console.error = original
           assert.ok(logged instanceof Error)
           assert.strictEqual(logged.message, 'outer')
           assert.ok(logged.cause instanceof Error)

--- a/test/app.logerror.js
+++ b/test/app.logerror.js
@@ -1,0 +1,40 @@
+'use strict'
+
+var assert = require('node:assert')
+var express = require('..')
+var request = require('supertest')
+
+describe('logerror', function () {
+  it('should log the full error object', function (done) {
+    var app = express()
+    app.set('env', 'development')
+
+    var logged
+    var original = console.error
+    console.error = function (err) {
+      logged = err
+    }
+
+    app.use(function (req, res, next) {
+      var inner = new Error('inner')
+      next(new Error('outer', { cause: inner }))
+    })
+
+    request(app)
+      .get('/')
+      .expect(500, function (err) {
+        if (err) {
+          console.error = original
+          return done(err)
+        }
+        setImmediate(function () {
+          console.error = original
+          assert.ok(logged instanceof Error)
+          assert.strictEqual(logged.message, 'outer')
+          assert.ok(logged.cause instanceof Error)
+          assert.strictEqual(logged.cause.message, 'inner')
+          done()
+        })
+      })
+  })
+})


### PR DESCRIPTION
﻿## Summary

Changes `logerror` in `lib/application.js` to use `console.error(err)` instead of `console.error(err.stack || err.toString())`, so Node's built-in error inspection preserves `Error.cause`, custom enumerable properties (e.g. Sequelize `parent`/`original`), and `AggregateError` details.

This matches the approach in #6464 (approved in review; vestigial `err.stack` workaround from pre-Node-18 when `console.error(err)` did not print stacks). Express 5 already requires Node >= 18.

**This PR is rebased on current `master` and adds regression test coverage** (`test/app.logerror.js`) for the default error handler logging path.

Fixes #6462

## Related PRs

- #6464 — same one-line fix; happy to close this in favor of #6464 if maintainers prefer, as long as the test lands (here or there).

## Test plan

- [x] `npm test -- test/app.logerror.js`
- [x] Full suite: `npm test` (1250 passing)

## Behavior note

Only affects stderr when the **default** error handler runs and `env !== 'test'`. HTTP responses are unchanged.
