### PR TITLE
Trim whitespace in forwarded host parsing

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -424,7 +424,9 @@ defineGetter(req, 'host', function host(){
   } else if (val.indexOf(',') !== -1) {
     // Note: X-Forwarded-Host is normally only ever a
     //       single value, but this is to be safe.
-    val = val.substring(0, val.indexOf(',')).trimRight()
+    val = val.substring(0, val.indexOf(',')).trim()
+  } else {
+    val = val.trim()
   }
 
   return val || undefined;

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -87,6 +87,22 @@ describe('req', function(){
         .expect('example.com', done);
       })
 
+      it('should trim whitespace in X-Forwarded-Host', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          res.end(req.host);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'localhost')
+        .set('X-Forwarded-Host', '   example.com   , malicious.example.com')
+        .expect('example.com', done);
+      })
+
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){
         var app = express();
 


### PR DESCRIPTION
## Summary

Fix `req.host` to consistently trim whitespace from X-Forwarded-Host when trust proxy is enabled.

## Changes
- `lib/request.js`: trim `X-Forwarded-Host` in both comma-separated and single-value cases.
- `test/req.host.js`: add regression test for spaced host header.

## Validation
- `npm test -- test/req.host.js`
- `npx mocha --require test/support/env test/req.host.js`