### PR TITLE
fix: logError logs full error object including cause (#6462)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+  if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Description
Fixes #6462 - logError swallows Error.cause

## Changes
In `lib/application.js`, changed:

```js
console.error(err.stack || err.toString())
```

to:

```js
console.error(err)
```

## Why
When logging `err.stack`, the `Error.cause()` chain is lost because `stack` only contains the stack trace of the specific error, not the cause chain. Logging the full `err` object allows Node.js to print the complete error including the `cause` chain, making debugging much easier.

## Testing
`npm test` passes for the application.js related tests.