### PR TITLE
fix: logError now logs the full error object (cause, parent, original)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -614,7 +614,7 @@ app.listen = function listen() {
 
 function logerror(err) {
   /* istanbul ignore next */
-  if (this.get('env') !== 'test') console.error(err.stack || err.toString());
+	if (this.get('env') !== 'test') console.error(err);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #6462

## Problem

The `logError` function currently uses:
```
console.error(err.stack || err.toString())
```

This drops all custom error properties that are not part of the stack trace, including:
- `Error.cause` (nested errors)
- Sequelize's `parent` and `original` properties
- Any other custom properties attached to error objects

## Fix

Changed to:
```
console.error(err)
```

`console.error()` already prints the stack trace for Error objects, and additionally includes all enumerable properties (cause, parent, original, etc.). This is the standard recommended approach in Node.js and matches how logging libraries handle errors.

## Verification

- `console.error(new Error("outer", { cause: new Error("inner") }))` prints the full error with `cause`
- Sequelize errors now show `parent` and `original` properties in the log

Closes #6462
