### PR TITLE
fix: prevent host header injection by sanitizing userinfo in Host header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -23,6 +23,23 @@ var parse = require('parseurl');
 var proxyaddr = require('proxy-addr');
 
 /**
+ * Determine whether a string is a valid port, i.e. only ASCII digits,
+ * per RFC 3986 section 3.2.3 ("port = *DIGIT").
+ *
+ * @param {string} str
+ * @return {boolean}
+ * @private
+ */
+
+function isValidPort (str) {
+  for (var i = 0; i < str.length; i++) {
+    var code = str.charCodeAt(i);
+    if (code < 0x30 || code > 0x39) return false;
+  }
+  return true;
+}
+
+/**
  * Request prototype.
  * @public
  */
@@ -427,7 +444,25 @@ defineGetter(req, 'host', function host(){
     val = val.substring(0, val.indexOf(',')).trimEnd()
   }
 
-  return val || undefined;
+  if (!val) return;
+
+  // A Host header must not contain userinfo (RFC 9110 section 7.2). Drop any
+  // "user@" / "user:pass@" prefix so a crafted value like
+  // "evil.com:x@good.com" cannot inject an attacker-controlled host via
+  // req.hostname; the real host is the part after the last "@".
+  var atIndex = val.lastIndexOf('@');
+  if (atIndex !== -1) val = val.slice(atIndex + 1);
+
+  if (!val) return;
+
+  // The optional port must be numeric (RFC 3986 section 3.2.3). Reject
+  // malformed authorities, e.g. an encoded "@" smuggled in as the port
+  // ("evil.com:x%40good.com"), which would otherwise leak a fake hostname.
+  var portOffset = val[0] === '[' ? val.indexOf(']') + 1 : 0;
+  var portIndex = val.indexOf(':', portOffset);
+  if (portIndex !== -1 && !isValidPort(val.slice(portIndex + 1))) return;
+
+  return val;
 });
 
 /**

--- a/test/req.host.js
+++ b/test/req.host.js
@@ -70,6 +70,34 @@ describe('req', function(){
       .expect(200, '[::1]:3000', done);
     })
 
+    describe('with a Host header containing userinfo', function(){
+      it('should return the real host, dropping the userinfo', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.host);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'evil.com:fake@legitimate.com:3000')
+        .expect(200, 'legitimate.com:3000', done);
+      })
+
+      it('should return undefined for an encoded userinfo separator', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(String(req.host));
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'evil.com:x%40legitimate.com')
+        .expect(200, 'undefined', done);
+      })
+    })
+
     describe('when "trust proxy" is enabled', function(){
       it('should respect X-Forwarded-Host', function(done){
         var app = express();

--- a/test/req.hostname.js
+++ b/test/req.hostname.js
@@ -70,6 +70,125 @@ describe('req', function(){
       .expect('[::1]', done);
     })
 
+    it('should return undefined for a non-numeric port', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.end(String(req.hostname));
+      });
+
+      request(app)
+      .post('/')
+      .set('Host', 'example.com:notaport')
+      .expect('undefined', done);
+    })
+
+    it('should return undefined for an IPv6 Host with a non-numeric port', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.end(String(req.hostname));
+      });
+
+      request(app)
+      .post('/')
+      .set('Host', '[::1]:notaport')
+      .expect('undefined', done);
+    })
+
+    describe('with a Host header containing userinfo', function(){
+      it('should return the real host, not the userinfo prefix', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'evil.com:fake@legitimate.com:3000')
+        .expect('legitimate.com', done);
+      })
+
+      it('should ignore a userinfo section before the host', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'user@example.com')
+        .expect('example.com', done);
+      })
+
+      it('should strip the port after removing userinfo', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'user:pass@example.com:8080')
+        .expect('example.com', done);
+      })
+
+      it('should remove userinfo from an IPv6 Host', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'user@[::1]:8080')
+        .expect('[::1]', done);
+      })
+
+      it('should use the host after the last "@" when several are present', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'a@b@example.com')
+        .expect('example.com', done);
+      })
+
+      it('should return undefined for an encoded userinfo separator', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(String(req.hostname));
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'evil.com:x%40legitimate.com')
+        .expect('undefined', done);
+      })
+
+      it('should return undefined when there is no host after the userinfo', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.end(String(req.hostname));
+        });
+
+        request(app)
+        .post('/')
+        .set('Host', 'user@')
+        .expect('undefined', done);
+      })
+    })
+
     describe('when "trust proxy" is enabled', function(){
       it('should respect X-Forwarded-Host', function(done){
         var app = express();
@@ -85,6 +204,22 @@ describe('req', function(){
         .set('Host', 'localhost')
         .set('X-Forwarded-Host', 'example.com:3000')
         .expect('example.com', done);
+      })
+
+      it('should drop userinfo from a trusted X-Forwarded-Host', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          res.end(req.hostname);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'localhost')
+        .set('X-Forwarded-Host', 'evil.com:fake@legitimate.com')
+        .expect('legitimate.com', done);
       })
 
       it('should ignore X-Forwarded-Host if socket addr not trusted', function(done){


### PR DESCRIPTION
# `req.hostname` / `req.host`: master (unpatched) vs our version

| Host header | master `req.hostname` | ours `req.hostname` | master `req.host` | ours `req.host` |
|---|---|---|---|---|
| `example.com:3000` (control) | `example.com` | `example.com` | `example.com:3000` | `example.com:3000` |
| `example.com:notaport` | `example.com` | `undefined` | `example.com:notaport` | `undefined` |
| `[::1]:notaport` | `[::1]` | `undefined` | `[::1]:notaport` | `undefined` |
| `evil.com:fake@legitimate.com:3000` | `evil.com` ⚠️ | `legitimate.com` | `evil.com:fake@legitimate.com:3000` | `legitimate.com:3000` |
| `user@example.com` | `user@example.com` ⚠️ | `example.com` | `user@example.com` | `example.com` |
| `user:pass@example.com:8080` | `user` ⚠️ | `example.com` | `user:pass@example.com:8080` | `example.com:8080` |
| `user@[::1]:8080` | `user@[` ⚠️ | `[::1]` | `user@[::1]:8080` | `[::1]:8080` |
| `a@b@example.com` | `a@b@example.com` ⚠️ | `example.com` | `a@b@example.com` | `example.com` |
| `evil.com:x%40legitimate.com` | `evil.com` ⚠️ | `undefined` | `evil.com:x%40legitimate.com` | `undefined` |
| `user@` | `user@` ⚠️ | `undefined` | `user@` | `undefined` |
| `X-Forwarded-Host: evil.com:fake@legitimate.com` (trust proxy) | `evil.com` ⚠️ | `legitimate.com` | `evil.com:fake@legitimate.com` | `legitimate.com` |

ref: https://github.com/expressjs/express/security/advisories/GHSA-rvrq-qj4c-w73v (Note that it was closed because it did not meet our criteria for being considered a vulnerability and will instead be treated as a bug)