### PR TITLE
fix(res.links): skip empty-array rel values to prevent trailing comma in Link header

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 🐞 Bug fixes
 
 - Fixed HTTP header conflict between Content-Length and Transfer-Encoding in res.send - by [@YuryShkoda](https://github.com/YuryShkoda) in [#4893](https://github.com/expressjs/express/pull/4893)
+- Fixed `res.links()` producing a trailing comma in the `Link` header when a rel value is an empty array - by [@JSap0914](https://github.com/JSap0914)
 
 
     Fixed the behavior of `res.send()` to prevent conflicts between `Content-Length` and `Transfer-Encoding` HTTP headers in responses. The `Content-Length` header in `res.send()` is now only added when a `Transfer-Encoding` header is not present, complying with the HTTP specification that states both headers should not coexist in the same response

--- a/lib/response.js
+++ b/lib/response.js
@@ -97,8 +97,7 @@ res.status = function status(code) {
 
 res.links = function(links) {
   var link = this.get('Link') || '';
-  if (link) link += ', ';
-  return this.set('Link', link + Object.keys(links).map(function(rel) {
+  var newLinks = Object.keys(links).map(function(rel) {
     // Allow multiple links if links[rel] is an array
     if (Array.isArray(links[rel])) {
       return links[rel].map(function (singleLink) {
@@ -107,7 +106,10 @@ res.links = function(links) {
     } else {
       return `<${links[rel]}>; rel="${rel}"`;
     }
-  }).join(', '));
+  }).filter(Boolean).join(', ');
+
+  if (link && newLinks) link += ', ';
+  return this.set('Link', link + newLinks);
 };
 
 /**

--- a/test/res.links.js
+++ b/test/res.links.js
@@ -61,5 +61,38 @@ describe('res', function(){
       .expect('Link', '<http://api.example.com/users?page=2>; rel="next", <http://api.example.com/users?page=5>; rel="last", <http://api.example.com/users?page=1>; rel="last"')
       .expect(200, done);
     })
+
+    it('should skip empty-array rel values without producing trailing commas', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.links({
+          next: 'http://api.example.com/users?page=2',
+          prev: []
+        });
+
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Link', '<http://api.example.com/users?page=2>; rel="next"')
+      .expect(200, done);
+    })
+
+    it('should not set a trailing comma when appending and new rel values are all empty arrays', function (done) {
+      var app = express();
+
+      app.use(function (req, res) {
+        res.links({ next: 'http://api.example.com/users?page=2' });
+        res.links({ prev: [] });
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('Link', '<http://api.example.com/users?page=2>; rel="next"')
+      .expect(200, done);
+    })
   })
 })


### PR DESCRIPTION
## Bug

When `res.links()` is called with an empty array `[]` for a rel value, the inner `.map().join(', ')` produces an empty string `''`. The outer `.join(', ')` then includes that empty entry, yielding an invalid Link header:

```js
res.links({ next: 'http://example.com/2', prev: [] })
// Before: Link: <http://example.com/2>; rel="next",   ← trailing comma, invalid
// After:  Link: <http://example.com/2>; rel="next"
```

A second call appending only empty-array rels also produced a trailing comma:

```js
res.links({ next: 'http://example.com/2' })
res.links({ prev: [] })
// Before: Link: <http://example.com/2>; rel="next",
// After:  Link: <http://example.com/2>; rel="next"
```

RFC 8288 requires the `Link` header to be a comma-separated list of link-values; a trailing comma or empty entry is invalid and may confuse clients or intermediaries.

## Fix

Extract the new link entries into `newLinks`, filter out empty strings with `.filter(Boolean)`, then only prepend `', '` when both the existing `Link` value and the new entries are non-empty.

## Verification

```
npx mocha --require test/support/env --reporter spec --check-leaks test/res.links.js
```



> Note: This fix was developed with AI-assist.