### PR TITLE
feat: emit on route definition

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -254,7 +254,15 @@ app.use = function use(fn) {
  */
 
 app.route = function route(path) {
-  return this.router.route(path);
+  var routeObj = this.router.route(path);
+  var self = this;
+
+  // TODO: This isn't the cleanest, but it's non-blocking and ensures synchronous call chains to the route object (ex: .get()) have ran before we trigger the event.
+  setTimeout(function() {
+    self.emit('route', routeObj);
+  },0);
+
+  return routeObj;
 };
 
 /**
@@ -477,6 +485,8 @@ methods.forEach(function (method) {
 
     var route = this.route(path);
     route[method].apply(route, slice.call(arguments, 1));
+    // The emit call works when placed here for direct METHOD call on the app, but not when using .route()
+    //this.emit('route', route);
     return this;
   };
 });

--- a/test/app.route.js
+++ b/test/app.route.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var assert = require('node:assert')
 var express = require('../');
 var request = require('supertest');
 
@@ -60,6 +61,26 @@ describe('app.route', function(){
     request(app)
     .get('/test')
     .expect(404, done);
+  });
+
+  it('should emit "route" when a new route is defined', function(done){
+    var app = express()
+
+    app.on('route', function(arg){
+      var layer = (app.stack || app.router.stack).find(function(i){
+        return i.route.path === '/:foo';
+      });
+
+      assert.strictEqual(arg, layer.route);
+      assert.strictEqual(arg.path, '/:foo');
+      assert.strictEqual(arg.methods.get, true);
+      done();
+    });
+
+    app.route('/:foo')
+    .get(function(req, res) {
+      res.send(req.params.foo);
+    });
   });
 
   describe('promise support', function () {

--- a/test/app.router.js
+++ b/test/app.router.js
@@ -59,6 +59,25 @@ describe('app.router', function () {
         var app = express();
         assert.throws(app[method].bind(app, '/', 3), /argument handler must be a function/);
       })
+
+      it('should emit "route" when a new route is defined using ' + method.toUpperCase(), function(done){
+        var app = express()
+
+        app.on('route', function(arg){
+          var layer = (app.stack || app.router.stack).find(function(i){
+            return i.route.path === '/:foo';
+          });
+
+          assert.strictEqual(arg, layer.route);
+          assert.strictEqual(arg.path, '/:foo');
+          assert.strictEqual(arg.methods[method], true);
+          done();
+        });
+
+        app[method]('/:foo', function(req, res) {
+          res.send(req.params.foo);
+        });
+      });
     });
 
     it('should re-route when method is altered', function (done) {


### PR DESCRIPTION
## What the feature is

This PR adds a `route` event on the app that emits whenever a new route is defined.

ex:

```
var app = express();

app.on('route', function (route) {
    // The route object
});

// Using the route method
app.route('/:foo')
    .get(function(req, res) {
      res.send(req.params.foo);
    }); // Will trigger
    
// Using direct methods
app.get('/:bar', function(req, res) {
      res.send(req.params.bar);
    }); // Will trigger
```

## Why do we want this

I built a few express plugins and often find myself monkey-patching internal methods in order to get info about the routes an app has. There are already events that can be used by plugin developers such as `mount`. 

In effect, this could offer a clean interface for plugin developers and reduce friction when trying to release new versions of Express.

## Any potential drawbacks

Since this is a new event, it should not impact existing applications. It does not expose new information about the application so the attack surface should also remain unchanged. 

There would of course need to be some updates to the published documentation to add this new event.

## Status of this PR

I currently have a suggested implementation, albeit one I'm not super fond of. It is fairly straightforward to emit the event on direct method calls since the calls are already overloaded in express, but router objects are directly handled by the `router` dependency. The solution I found was to defer the emit in the router call, which is used in all cases.

I have created some tests to validate that the events are triggered.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
