### PR TITLE
fix(response): throw TypeError on invalid redirect url/status

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,7 +14,7 @@
 
 var contentDisposition = require('content-disposition');
 var createError = require('http-errors')
-var deprecate = require('depd')('express');
+
 var encodeUrl = require('encodeurl');
 var escapeHtml = require('escape-html');
 var http = require('node:http');
@@ -823,16 +823,16 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
+  if (typeof status !== 'number') {
+    throw new TypeError('status must be a number');
+  }
+
+  if (address === undefined || address === null) {
+    throw new TypeError('url argument is required to res.redirect');
   }
 
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
-  }
-
-  if (typeof status !== 'number') {
-    deprecate('Status must be a number');
+    throw new TypeError('url must be a string');
   }
 
   // Set location header

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -44,6 +44,48 @@ describe('res', function(){
       .expect('Location', 'https://google.com?q=%A710')
       .expect(302, done)
     })
+
+    it('should throw a TypeError if url is undefined', function (done) {
+      var app = express()
+
+      app.use(function (req, res, next) {
+        try {
+          res.redirect(undefined)
+          next(new Error('should have thrown'))
+        } catch (err) {
+          if (err instanceof TypeError && err.message === 'url argument is required to res.redirect') {
+            res.sendStatus(200)
+          } else {
+            next(err)
+          }
+        }
+      })
+
+      request(app)
+      .get('/')
+      .expect(200, done)
+    })
+
+    it('should throw a TypeError if url is not a string', function (done) {
+      var app = express()
+
+      app.use(function (req, res, next) {
+        try {
+          res.redirect({ foo: 'bar' })
+          next(new Error('should have thrown'))
+        } catch (err) {
+          if (err instanceof TypeError && err.message === 'url must be a string') {
+            res.sendStatus(200)
+          } else {
+            next(err)
+          }
+        }
+      })
+
+      request(app)
+      .get('/')
+      .expect(200, done)
+    })
   })
 
   describe('.redirect(status, url)', function(){
@@ -58,6 +100,27 @@ describe('res', function(){
       .get('/')
       .expect('Location', 'http://google.com')
       .expect(303, done)
+    })
+
+    it('should throw a TypeError if status is not a number', function(done){
+      var app = express();
+
+      app.use(function(req, res, next){
+        try {
+          res.redirect('303', 'http://google.com');
+          next(new Error('should have thrown'))
+        } catch (err) {
+          if (err instanceof TypeError && err.message === 'status must be a number') {
+            res.sendStatus(200)
+          } else {
+            next(err)
+          }
+        }
+      });
+
+      request(app)
+      .get('/')
+      .expect(200, done)
     })
   })
 


### PR DESCRIPTION
Fixes #6941. When `res.redirect(undefined)` is called, it previously logged a deprecation warning and then proceeded to send an invalid `Location: undefined` header. This commit changes the behavior to throw a `TypeError` immediately if the url is undefined, null, or not a string. It also throws a `TypeError` if the status is not a number. Tests have been added to verify this behavior.