### PR TITLE
fix(res.set): ignore inherited header fields

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -681,7 +681,9 @@ res.header = function header(field, val) {
 
     this.setHeader(field, value);
   } else {
-    for (var key in field) {
+    var keys = Object.keys(field);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       this.set(key, field[key]);
     }
   }

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -120,5 +120,27 @@ describe('res', function(){
       .expect('X-Number', '123')
       .expect(200, 'string', done);
     })
+
+    it('should ignore inherited properties', function (done) {
+      var app = express();
+      var headers = Object.create({ 'X-Inherited': 'nope' });
+
+      headers['X-Own'] = 'yes';
+
+      app.use(function (req, res) {
+        res.set(headers);
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('X-Own', 'yes')
+      .expect(function (res) {
+        if (res.headers['x-inherited'] !== undefined) {
+          throw new Error('should not set inherited header');
+        }
+      })
+      .expect(200, done);
+    })
   })
 })


### PR DESCRIPTION
This changes `res.set(object)` to iterate over own enumerable keys only, so inherited properties are not copied into response headers.

The regression test passes an object with an inherited `X-Inherited` field and confirms only the own `X-Own` header is set.

Validation:

- `npx mocha --require test/support/env --check-leaks test/res.set.js`
- `npm run lint`
- `git diff --check`

AI-assisted: Codex helped prepare this focused change; I reviewed the diff and ran the validation above before submitting.