### PR TITLE
fix(req): normalize forwarded protocol casing

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -309,9 +309,9 @@ defineGetter(req, 'protocol', function protocol(){
   var header = this.get('X-Forwarded-Proto') || proto
   var index = header.indexOf(',')
 
-  return index !== -1
+  return (index !== -1
     ? header.substring(0, index).trim()
-    : header.trim()
+    : header.trim()).toLowerCase()
 });
 
 /**

--- a/test/req.protocol.js
+++ b/test/req.protocol.js
@@ -33,6 +33,36 @@ describe('req', function(){
         .expect('https', done);
       })
 
+      it('should normalize X-Forwarded-Proto casing', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          res.end(req.protocol);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'HTTPS')
+        .expect('https', done);
+      })
+
+      it('should report secure for uppercase X-Forwarded-Proto https', function(done){
+        var app = express();
+
+        app.enable('trust proxy');
+
+        app.use(function(req, res){
+          res.end(String(req.secure));
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-Proto', 'HTTPS')
+        .expect('true', done);
+      })
+
       it('should default to the socket addr if X-Forwarded-Proto not present', function(done){
         var app = express();
 


### PR DESCRIPTION
This normalizes trusted `X-Forwarded-Proto` values to lowercase before exposing `req.protocol`, so `req.secure` handles `HTTPS` the same as `https`.

The regression tests cover both `req.protocol` and `req.secure` with uppercase forwarded protocol input.

Validation:

- `npx mocha --require test/support/env --check-leaks test/req.protocol.js test/req.secure.js`
- `npm run lint`
- `git diff --check`

AI-assisted: Codex helped prepare this focused change; I reviewed the diff and ran the validation above before submitting.