### PR TITLE
fix(req): ignore trailing root dot in subdomains

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -385,6 +385,10 @@ defineGetter(req, 'subdomains', function subdomains() {
 
   if (!hostname) return [];
 
+  // Strip the optional DNS root label so fully-qualified domain names
+  // produce the same subdomain list as their non-root-qualified form.
+  hostname = hostname.replace(/\.$/, '');
+
   var offset = this.app.get('subdomain offset');
   var subdomains = !isIP(hostname)
     ? hostname.split('.').reverse()

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -19,6 +19,19 @@ describe('req', function(){
         .expect(200, ['ferrets', 'tobi'], done);
       })
 
+      it('should ignore a trailing root dot', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.send(req.subdomains);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'tobi.ferrets.example.com.')
+        .expect(200, ['ferrets', 'tobi'], done);
+      })
+
       it('should work with IPv4 address', function(done){
         var app = express();
 


### PR DESCRIPTION
This strips an optional trailing DNS root dot before calculating `req.subdomains`, so fully qualified hostnames behave like their ordinary hostname form.

The regression test covers `tobi.ferrets.example.com.` and keeps existing subdomain offset behavior unchanged.

Validation:

- `npx mocha --require test/support/env --check-leaks test/req.subdomains.js`
- `npm run lint`
- `git diff --check`

AI-assisted: Codex helped prepare this focused change; I reviewed the diff and ran the validation above before submitting.