### PR TITLE
fix(res.append): preserve empty header values

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -633,7 +633,7 @@ res.append = function append(field, val) {
   var prev = this.get(field);
   var value = val;
 
-  if (prev) {
+  if (prev !== undefined) {
     // concat the new and prev vals
     value = Array.isArray(prev) ? prev.concat(val)
       : Array.isArray(val) ? [prev].concat(val)

--- a/test/res.append.js
+++ b/test/res.append.js
@@ -82,6 +82,21 @@ describe('res', function () {
         .end(done)
     })
 
+    it('should preserve an existing empty header value', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Warning', '')
+        res.append('Warning', '199 Miscellaneous warning')
+        res.end(JSON.stringify(res.get('Warning')))
+      })
+
+      request(app)
+        .get('/')
+        .expect(200, '["","199 Miscellaneous warning"]')
+        .end(done)
+    })
+
     it('should work together with res.cookie', function (done) {
       var app = express()
 


### PR DESCRIPTION
This makes `res.append()` preserve an existing empty-string header value instead of treating it as absent.

The regression test appends to an empty `Warning` header and verifies the empty value remains part of the emitted header list.

Validation:

- `npx mocha --require test/support/env --check-leaks test/res.append.js`
- `npm run lint`
- `git diff --check`

AI-assisted: Codex helped prepare this focused change; I reviewed the diff and ran the validation above before submitting.