### PR TITLE
fix(res.format): ignore inherited default handler

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -571,6 +571,7 @@ res.type = function contentType(type) {
 res.format = function(obj){
   var req = this.req;
   var next = req.next;
+  var hasDefault = Object.prototype.hasOwnProperty.call(obj, 'default');
 
   var keys = Object.keys(obj)
     .filter(function (v) { return v !== 'default' })
@@ -584,7 +585,7 @@ res.format = function(obj){
   if (key) {
     this.set('Content-Type', normalizeType(key).value);
     obj[key](req, this, next);
-  } else if (obj.default) {
+  } else if (hasDefault && obj.default) {
     obj.default(req, this, next)
   } else {
     next(createError(406, {

--- a/test/res.format.js
+++ b/test/res.format.js
@@ -149,6 +149,33 @@ describe('res', function(){
           .expect('json')
           .end(done)
       })
+
+      it('should ignore inherited default callbacks', function (done) {
+        var app = express()
+        var formats = Object.create({
+          default: function () {
+            throw new Error('should not be called')
+          }
+        })
+
+        formats.text = function () {
+          throw new Error('should not be called')
+        }
+
+        app.use(function (req, res) {
+          res.format(formats)
+        })
+
+        app.use(function (err, req, res, next) {
+          res.status(err.status)
+          res.send('Supports: ' + err.types.join(', '))
+        })
+
+        request(app)
+          .get('/')
+          .set('Accept', 'application/json')
+          .expect(406, 'Supports: text/plain', done)
+      })
     })
 
     describe('in router', function(){


### PR DESCRIPTION
This makes `res.format()` invoke the `default` handler only when it is an own property of the formatter object.

The regression test proves inherited default callbacks are ignored and the normal 406 path is preserved.

Validation:

- `npx mocha --require test/support/env --check-leaks test/res.format.js`
- `npm run lint`
- `git diff --check`

AI-assisted: Codex helped prepare this focused change; I reviewed the diff and ran the validation above before submitting.