### PR TITLE
test: add edge cases for utils.normalizeType, normalizeTypes, and compileTrust

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -36,6 +36,15 @@ describe('utils.normalizeType acceptParams method', () => {
     });
   });
 
+  it('should handle complex parameters with semicolon backtracing (splitIndex > endIndex)', () => {
+    const result = utils.normalizeType('text/html;q=0.9;invalid;a=1');
+    assert.deepEqual(result, {
+      value: 'text/html',
+      quality: 0.9,
+      params: { a: '1' }
+    });
+  });
+
   it('should default to application/octet-stream when mime lookup fails', () => {
     const result = utils.normalizeType('unknown-extension-xyz');
     assert.deepEqual(result, {
@@ -44,6 +53,17 @@ describe('utils.normalizeType acceptParams method', () => {
     });
   });
 });
+
+describe('utils.normalizeTypes(types)', () => {
+  it('should normalize an array of types', () => {
+    const result = utils.normalizeTypes(['html', 'text/plain;q=0.5']);
+    assert.deepEqual(result, [
+      { value: 'text/html', params: {} },
+      { value: 'text/plain', quality: 0.5, params: {} }
+    ]);
+  });
+});
+
 
 describe('utils.setCharset(type, charset)', function () {
   it('should do anything without type', function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -133,3 +133,36 @@ describe('utils.compileETag()', function () {
     assert.throws(() => utils.compileETag({}), TypeError);
   });
 });
+
+describe('utils.compileTrust()', function () {
+  it('should return the function when given a function', function () {
+    function custom() {}
+    assert.strictEqual(utils.compileTrust(custom), custom);
+  });
+
+  it('should return a function returning true when given true', function () {
+    const fn = utils.compileTrust(true);
+    assert.strictEqual(fn(), true);
+  });
+
+  it('should return a function that respects hop count when given a number', function () {
+    const fn = utils.compileTrust(2);
+    assert.strictEqual(fn('127.0.0.1', 0), true);
+    assert.strictEqual(fn('127.0.0.1', 1), true);
+    assert.strictEqual(fn('127.0.0.1', 2), false);
+  });
+
+  it('should return a proxyaddr compiler when given a string of IPs', function () {
+    const fn = utils.compileTrust('127.0.0.1, 10.0.0.1');
+    assert.strictEqual(fn('127.0.0.1', 0), true);
+    assert.strictEqual(fn('10.0.0.1', 0), true);
+    assert.strictEqual(fn('192.168.1.1', 0), false);
+  });
+
+  it('should handle undefined or falsy values', function () {
+    const fn = utils.compileTrust(undefined);
+    assert.strictEqual(typeof fn, 'function');
+    assert.strictEqual(fn('127.0.0.1', 0), false);
+  });
+});
+


### PR DESCRIPTION
### Description
This PR introduces unit tests for utility functions in `lib/utils.js` that were previously lacking test coverage. Specifically, it tests complex parameter parsing inside `utils.normalizeType`, array-based normalization in `utils.normalizeTypes`, and configuration compiling in `utils.compileTrust`.

### Changes
* **`utils.normalizeType`**: Adds a test case for complex parameter strings involving semicolon backtracing (e.g., `text/html;q=0.9;invalid;a=1`). This validates the `splitIndex > endIndex` condition in `acceptParams` where a parameter without a value (`invalid`) is positioned between valid parameters.
* **`utils.normalizeTypes`**: Adds a test case ensuring arrays of types are correctly normalized.
* **`utils.compileTrust`**: Adds unit tests for the trust configuration compiler covering functions, boolean inputs (`true`), hop counts (numbers), IP/CIDR list strings, and falsy/undefined values.

### Checklist
- [x] All tests pass locally
- [x] Code conforms to ESLint styling rules (`npm run lint` passes)
