### PR TITLE
test: add unit tests for res.contentType alias and parameters in res.type

### DIFF
--- a/test/res.type.js
+++ b/test/res.type.js
@@ -43,6 +43,19 @@ describe('res', function(){
       .expect('Content-Type', 'application/vnd.amazon.ebook', done);
     })
 
+    it('should set the Content-Type with type/subtype and parameters', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.type('text/html; charset=utf-8')
+          .end('<p>hello</p>');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8', done);
+    })
+
     describe('edge cases', function(){
       it('should handle empty string gracefully', function(done){
         var app = express();
@@ -106,6 +119,62 @@ describe('res', function(){
         request(app)
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8')
+        .end(done);
+      })
+    })
+  })
+
+  describe('.contentType(str)', function(){
+    it('should set the Content-Type based on a filename', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.contentType('foo.js').end('var name = "tj";');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/javascript; charset=utf-8')
+      .end(done)
+    })
+
+    it('should set the Content-Type with type/subtype', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.contentType('application/vnd.amazon.ebook')
+          .end('var name = "tj";');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'application/vnd.amazon.ebook', done);
+    })
+
+    it('should set the Content-Type with type/subtype and parameters', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.contentType('text/html; charset=utf-8')
+          .end('<p>hello</p>');
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8', done);
+    })
+
+    describe('edge cases', function(){
+      it('should handle empty string gracefully', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.contentType('').end('test');
+        });
+
+        request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
         .end(done);
       })
     })


### PR DESCRIPTION
### Description
This PR adds explicit unit test coverage for:
1. The `res.contentType(str)` alias. In `lib/response.js`, `res.contentType` is defined as an alias for `res.type(str)`, but it had no unit tests in `test/res.type.js` to ensure it works correctly and behaves identically.
2. Preserving media type parameters (like charsets or custom parameters) when passing type/subtype strings directly to `res.type(str)` (e.g. `res.type('text/html; charset=utf-8')`).

### Changes
* **`test/res.type.js`**:
  - Added test case for parameter preservation when calling `res.type()`.
  - Added a `.contentType(str)` test block to verify that the alias behaves identically to `res.type()` for file lookups, literal types, and literal types with parameters.

### Checklist
- [x] All tests pass locally (`npx mocha test/res.type.js` passed)
- [x] Code conforms to ESLint formatting standards (`npm run lint` passed)
