### PR TITLE
fix(req): ignore trailing dot in subdomains

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,8 +4,9 @@
 
 - Fixed HTTP header conflict between Content-Length and Transfer-Encoding in res.send - by [@YuryShkoda](https://github.com/YuryShkoda) in [#4893](https://github.com/expressjs/express/pull/4893)
 
-
     Fixed the behavior of `res.send()` to prevent conflicts between `Content-Length` and `Transfer-Encoding` HTTP headers in responses. The `Content-Length` header in `res.send()` is now only added when a `Transfer-Encoding` header is not present, complying with the HTTP specification that states both headers should not coexist in the same response
+
+- Fixed `req.subdomains` handling for fully qualified domain names with a trailing dot, so the root label is ignored when applying the subdomain offset.
 
 ## 🚀 Improvements
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -385,6 +385,8 @@ defineGetter(req, 'subdomains', function subdomains() {
 
   if (!hostname) return [];
 
+  hostname = hostname.replace(/\.$/, '');
+
   var offset = this.app.get('subdomain offset');
   var subdomains = !isIP(hostname)
     ? hostname.split('.').reverse()

--- a/test/req.subdomains.js
+++ b/test/req.subdomains.js
@@ -19,6 +19,19 @@ describe('req', function(){
         .expect(200, ['ferrets', 'tobi'], done);
       })
 
+      it('should ignore trailing dot on fully qualified domain names', function(done){
+        var app = express();
+
+        app.use(function(req, res){
+          res.send(req.subdomains);
+        });
+
+        request(app)
+        .get('/')
+        .set('Host', 'tobi.ferrets.example.com.')
+        .expect(200, ['ferrets', 'tobi'], done);
+      })
+
       it('should work with IPv4 address', function(done){
         var app = express();
 


### PR DESCRIPTION
## Summary

This fixes `req.subdomains` for fully qualified domain names that include a trailing dot. The trailing root label is now ignored before applying the configured subdomain offset, so `tobi.ferrets.example.com.` behaves the same as `tobi.ferrets.example.com`.

## Why

Before this change, the trailing dot was treated as an empty DNS label. With the default subdomain offset, that shifted the result and returned `['example', 'ferrets', 'tobi']` instead of `['ferrets', 'tobi']`.

## Changes

- strip a single trailing dot inside the `req.subdomains` getter before splitting labels
- add a regression test for fully qualified domain names
- add an unreleased bug-fix note

## Tests

- `npx mocha --require test/support/env --reporter spec --check-leaks test/req.subdomains.js`
- `npm test`
- `npm run lint`
- `git diff --check HEAD~1..HEAD`