### PR TITLE
fix: prevent invalid Content-Type and Location headers

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -676,7 +676,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value
     }
 
     this.setHeader(field, value);
@@ -825,10 +825,12 @@ res.redirect = function redirect(url) {
 
   if (!address) {
     deprecate('Provide a url argument');
+    return this;
   }
 
   if (typeof address !== 'string') {
     deprecate('Url must be a string');
+    return this;
   }
 
   if (typeof status !== 'number') {


### PR DESCRIPTION
Two small fixes in `lib/response.js`:

1. **`res.set('Content-Type', value)` with an unrecognized type** (fixes #7034)  
   When `mime.contentType(value)` returns `false` for unknown types, the header was set to the literal string `false`. Added a fallback to the original value.

2. **`res.redirect(undefined)` sending malformed `Location: undefined`** (fixes #6941)  
   Added early return when `address` is falsy or not a string, preventing `encodeUrl(undefined)` from setting an invalid Location header.

Closes #7034
Closes #6941