### PR TITLE
test: add coverage for req.is() with array argument

### DIFF
--- a/test/req.is.js
+++ b/test/req.is.js
@@ -166,4 +166,34 @@ describe('req.is()', function () {
       .expect(200, '"application/json"', done)
     })
   })
+
+  describe('when given an array', function(){
+    it('should return the type when matching', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['html', 'json']))
+      })
+
+      request(app)
+      .post('/')
+      .type('application/json')
+      .send('{}')
+      .expect(200, '"json"', done)
+    })
+
+    it('should return false when not matching', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['html', 'xml']))
+      })
+
+      request(app)
+      .post('/')
+      .type('application/json')
+      .send('{}')
+      .expect(200, 'false', done)
+    })
+  })
 })


### PR DESCRIPTION
   Closes #7348

   Adds test coverage for `req.is()` when called with an array
   argument directly (e.g. `req.is(['html', 'json'])`), which was
   previously untested and showed up as an uncovered branch on
   lib/request.js line 273.

   Before:
   - request.js branch coverage: 98.07%, line 273 uncovered

   After:
   - request.js: 100% across all metrics