### PR TITLE
fix(view): handle view names ending with "." to avoid require("")

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -57,6 +57,13 @@ function View(name, options) {
   this.name = name;
   this.root = opts.root;
 
+  // a name ending in "." yields a bare "." from extname(), which is not a
+  // usable extension; treat it as no extension so the default engine is
+  // applied instead of calling require("") with an empty module id
+  if (this.ext === '.') {
+    this.ext = '';
+  }
+
   if (!this.ext && !this.defaultEngine) {
     throw new Error('No default engine was specified and no extension was provided.');
   }

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -106,6 +106,22 @@ describe('app', function(){
       })
     })
 
+    describe('when the view name ends with a "."', function(){
+      it('should invoke the callback with a lookup error instead of crashing', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl');
+
+        app.render('user.', function (err) {
+          assert.ok(err)
+          assert.notStrictEqual(err.code, 'ERR_INVALID_ARG_VALUE')
+          assert.equal(err.message, 'Failed to lookup view "user." in views directory "' + path.join(__dirname, 'fixtures') + '"')
+          done()
+        })
+      })
+    })
+
     describe('when an extension is given', function(){
       it('should render the template', function(done){
         var app = createApp();


### PR DESCRIPTION
## Problem
A view name ending in "." (e.g. `res.render('index.')` or `app.render('index.', cb)`) makes the View constructor call `require("")`, throwing `TypeError [ERR_INVALID_ARG_VALUE]: The argument 'id' must be a non-empty string`. With `app.render()` this throws past the callback; with `res.render()` it surfaces as an opaque 500.

## Cause
`path.extname('index.')` returns `'.'` (truthy), so the default-engine fallback in `lib/view.js` is skipped, `this.ext` stays `'.'`, and `this.ext.slice(1)` is `''` — leading to `require('')`.

## Fix
Treat a bare `'.'` extension as no extension, so the normal default-engine path runs and an unresolved view yields the usual `Failed to lookup view` error via the callback.

## Tests
Added a regression test in `test/app.render.js`. It fails without the fix (with the `ERR_INVALID_ARG_VALUE` crash) and passes with it. Full suite (1250 tests) and lint pass.

Fixes #7350
