### PR TITLE
fix(app): validate render() callback and preserve mountpath on multiple mounts

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -223,7 +223,9 @@ app.use = function use(fn) {
     }
 
     debug('.use app under %s', path);
-    fn.mountpath = path;
+    fn.mountpath = fn.mountpath
+      ? (Array.isArray(fn.mountpath) ? fn.mountpath.concat(path) : [fn.mountpath, path])
+      : path;
     fn.parent = this;
 
     // restore .app property on req and res
@@ -530,6 +532,10 @@ app.render = function render(name, options, callback) {
   if (typeof options === 'function') {
     done = options;
     opts = {};
+  }
+
+  if (typeof done !== 'function') {
+    throw new TypeError('app.render() requires a callback function');
   }
 
   // merge options


### PR DESCRIPTION
## Summary

- **Bug #15** (`lib/application.js`): `app.render()` called without a callback crashes with a cryptic `TypeError: done is not a function` deep inside the rendering pipeline. This PR adds an early guard that throws a clear `TypeError('app.render() requires a callback function')` before any rendering starts.

- **Bug #16** (`lib/application.js`): When a sub-app is mounted at multiple paths via `app.use(['/a', '/b'], subApp)`, the `fns.forEach` loop overwrote `fn.mountpath` on each iteration, leaving only the last path. The fix accumulates paths into an array when the same sub-app is registered more than once.

## Test plan

- [ ] `app.render('view')` with no callback throws `TypeError: app.render() requires a callback function`
- [ ] `app.render('view', fn)` still works (callback as second arg)
- [ ] `app.render('view', opts, fn)` still works (normal usage)
- [ ] Sub-app mounted at single path: `mountpath` is a string (unchanged behavior)
- [ ] Sub-app mounted at two paths: `mountpath` is an array containing both paths
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)