### PR TITLE
feat: validate status code range in res.status()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -52,13 +52,14 @@ module.exports = res
 /**
  * Set the HTTP status code for the response.
  *
- * Expects an integer value between 100 and 999 inclusive.
- * Throws an error if the provided status code is not an integer or if it's outside the allowable range.
+ * Expects an integer value between 100 and 599 inclusive.
+ * Throws an error if the provided status code is not an integer or if it's
+ * outside the allowable range.
  *
  * @param {number} code - The HTTP status code to set.
  * @return {ServerResponse} - Returns itself for chaining methods.
  * @throws {TypeError} If `code` is not an integer.
- * @throws {RangeError} If `code` is outside the range 100 to 999.
+ * @throws {RangeError} If `code` is outside the range 100 to 599.
  * @public
  */
 
@@ -67,9 +68,9 @@ res.status = function status(code) {
   if (!Number.isInteger(code)) {
     throw new TypeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be an integer.`);
   }
-  // Check if the status code is outside of Node's valid range
-  if (code < 100 || code > 999) {
-    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be greater than 99 and less than 1000.`);
+  // Check if the status code is outside of HTTP's valid range
+  if (code < 100 || code > 599) {
+    throw new RangeError(`Invalid status code: ${JSON.stringify(code)}. Status code must be between 100 and 599.`);
   }
 
   this.statusCode = code;

--- a/test/res.status.js
+++ b/test/res.status.js
@@ -78,42 +78,6 @@ describe('res', function () {
           .get('/')
           .expect(501, done)
       })
-
-      it('should set the response status code to 700', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.status(700).end()
-        })
-
-        request(app)
-          .get('/')
-          .expect(700, done)
-      })
-
-      it('should set the response status code to 800', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.status(800).end()
-        })
-
-        request(app)
-          .get('/')
-          .expect(800, done)
-      })
-
-      it('should set the response status code to 900', function (done) {
-        var app = express()
-
-        app.use(function (req, res) {
-          res.status(900).end()
-        })
-
-        request(app)
-          .get('/')
-          .expect(900, done)
-      })
     })
 
     describe('invalid status codes', function () {
@@ -129,11 +93,47 @@ describe('res', function () {
           .expect(500, /Invalid status code/, done);
       });
 
-      it('should raise error for status code above 999', function (done) {
+      it('should raise error for status code above 599', function (done) {
         var app = express();
 
         app.use(function (req, res) {
-          res.status(1000).end();
+          res.status(600).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done);
+      });
+
+      it('should raise error for status code 700', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(700).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done);
+      });
+
+      it('should raise error for status code 800', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(800).end();
+        });
+
+        request(app)
+          .get('/')
+          .expect(500, /Invalid status code/, done);
+      });
+
+      it('should raise error for status code 900', function (done) {
+        var app = express();
+
+        app.use(function (req, res) {
+          res.status(900).end();
         });
 
         request(app)


### PR DESCRIPTION
Fixes #5623. Validates that status codes are integers between 100 and 599. Throws TypeError for non-integer codes and RangeError for codes outside the valid HTTP status range.