### PR TITLE
fix(res.send): handle raw ArrayBuffer as binary data

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,11 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
+      } else if (chunk instanceof ArrayBuffer) {
+        chunk = Buffer.from(chunk);
+        if (!this.get('Content-Type')) {
+          this.type('bin');
+        }
       } else {
         return this.json(chunk);
       }

--- a/lib/response.js
+++ b/lib/response.js
@@ -152,7 +152,7 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
-      } else if (chunk instanceof ArrayBuffer) {
+      } else if (isArrayBuffer(chunk)) {
         chunk = Buffer.from(chunk);
         if (!this.get('Content-Type')) {
           this.type('bin');
@@ -1014,6 +1014,20 @@ function sendfile(res, file, options, callback) {
 
   // pipe
   file.pipe(res);
+}
+
+/**
+ * Determine if value is an ArrayBuffer or SharedArrayBuffer.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ * @private
+ */
+
+function isArrayBuffer (value) {
+  return typeof value === 'object' &&
+    value !== null &&
+    value[Symbol.toStringTag]?.endsWith('ArrayBuffer')
 }
 
 /**

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -217,6 +217,31 @@ describe('res', function(){
         .expect(200, "hey", done);
     })
 
+    it('should accept ArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        const encodedHey = new TextEncoder().encode("hey");
+        res.set("Content-Type", "text/plain").send(encodedHey.buffer);
+      })
+
+      request(app)
+        .get("/")
+        .expect("Content-Type", "text/plain; charset=utf-8")
+        .expect(200, "hey", done);
+    })
+
+    it('should set Content-Type to application/octet-stream for ArrayBuffer without type', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.send(new ArrayBuffer(4));
+      })
+
+      request(app)
+        .get("/")
+        .expect("Content-Type", "application/octet-stream")
+        .expect(200, done);
+    })
+
     it('should not override ETag', function (done) {
       var app = express()
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -239,7 +239,83 @@ describe('res', function(){
       request(app)
         .get("/")
         .expect("Content-Type", "application/octet-stream")
-        .expect(200, done);
+        .expect(200)
+        .expect(utils.shouldHaveBody(Buffer.alloc(4)))
+        .end(done);
+    })
+
+    it('should accept SharedArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        const sab = new SharedArrayBuffer(3);
+        new Uint8Array(sab).set(new TextEncoder().encode('hey'));
+        res.set('Content-Type', 'text/plain').send(sab);
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(200, 'hey', done);
+    })
+
+    it('should set Content-Type to application/octet-stream for SharedArrayBuffer without type', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.send(new SharedArrayBuffer(4));
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200)
+        .expect(utils.shouldHaveBody(Buffer.alloc(4)))
+        .end(done);
+    })
+
+    it('should send same bytes for Buffer, ArrayBuffer, and SharedArrayBuffer', function(done){
+      var expected = Buffer.alloc(4, 0xab);
+
+      function createApp(body) {
+        var app = express();
+        app.use(function(req, res) {
+          res.send(body);
+        });
+        return app;
+      }
+
+      var ab = new ArrayBuffer(4);
+      new Uint8Array(ab).fill(0xab);
+
+      var sab = new SharedArrayBuffer(4);
+      new Uint8Array(sab).fill(0xab);
+
+      var pending = 3;
+
+      function check(err) {
+        if (err) return done(err);
+        if (--pending === 0) done();
+      }
+
+      request(createApp(expected))
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200)
+        .expect(utils.shouldHaveBody(expected))
+        .end(check);
+
+      request(createApp(ab))
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200)
+        .expect(utils.shouldHaveBody(expected))
+        .end(check);
+
+      request(createApp(sab))
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200)
+        .expect(utils.shouldHaveBody(expected))
+        .end(check);
     })
 
     it('should not override ETag', function (done) {


### PR DESCRIPTION
## Summary

- Fixes `res.send(ArrayBuffer)` silently sending `{}` as JSON with `Content-Type: application/json`
- Adds a private `isArrayBuffer()` helper in `lib/response.js` based on `Symbol.toStringTag`, so both `ArrayBuffer` and `SharedArrayBuffer` are converted to `Buffer` and sent with a binary content type — consistent with the existing `ArrayBuffer.isView` branch from #6285
- The `Symbol.toStringTag` check also handles buffers from other realms, where `instanceof` would fail
- Adds tests for `ArrayBuffer` and `SharedArrayBuffer` with explicit and default content types, plus a regression test comparing `Buffer.alloc(size)`, `new ArrayBuffer(size)`, and `new SharedArrayBuffer(size)` byte-for-byte (as suggested in review)

Closes #7362

## Test plan

- [x] `npm test -- test/res.send.js` — all ArrayBuffer/SharedArrayBuffer tests pass
- [x] `npm run lint` — clean
- [x] Verified `res.send(new ArrayBuffer(4))` and `res.send(new SharedArrayBuffer(4))` return `application/octet-stream` with the correct bytes instead of `{}` as `application/json`
