### PR TITLE
feat: allow conditional revalidation for QUERY requests

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,16 @@
 
 ## 🚀 Improvements
 
+* Allow conditional revalidation for QUERY requests. `req.fresh` previously only validated freshness for GET and HEAD requests, so QUERY responses never returned 304 despite a matching validator. Since QUERY is a safe, idempotent, and cacheable method that supports conditional requests, it is now included in the freshness check - by [@Cherry](https://github.com/Cherry) in [#7366](https://github.com/expressjs/express/pull/7366)
+
+    ```js
+    // QUERY /reports with If-None-Match: "12345"
+    app.query('/reports', (req, res) => {
+      res.set('ETag', '"12345"');
+      res.send(results); // now responds 304 Not Modified
+    });
+    ```
+
 * Improve HTML structure in `res.redirect()` responses when HTML format is accepted by adding `<!DOCTYPE html>`, `<title>`, and `<body>` tags for better browser compatibility - by [@Bernice55231](https://github.com/Bernice55231) in [#5167](https://github.com/expressjs/express/pull/5167)
 
 * When calling `app.render` with options set to null, the locals object is handled correctly, preventing unexpected errors and making the method behave the same as when options is omitted or an empty object is passed - by [AkaHarshit](https://github.com/AkaHarshit) in [#6903](https://github.com/expressjs/express/pull/6903)

--- a/lib/request.js
+++ b/lib/request.js
@@ -471,8 +471,8 @@ defineGetter(req, 'fresh', function(){
   var res = this.res
   var status = res.statusCode
 
-  // GET or HEAD for weak freshness validation only
-  if ('GET' !== method && 'HEAD' !== method) return false;
+  // GET, HEAD, or QUERY for weak freshness validation only
+  if ('GET' !== method && 'HEAD' !== method && 'QUERY' !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
   if ((status >= 200 && status < 300) || 304 === status) {

--- a/test/req.fresh.js
+++ b/test/req.fresh.js
@@ -2,6 +2,7 @@
 
 var express = require('../')
   , request = require('supertest');
+var shouldSkipQuery = require('./support/utils').shouldSkipQuery
 
 describe('req', function(){
   describe('.fresh', function(){
@@ -44,6 +45,43 @@ describe('req', function(){
 
       request(app)
       .get('/')
+      .expect(200, 'false', done);
+    })
+
+    it('should return true for a QUERY request with a body when the resource is not modified', function(done){
+      if (shouldSkipQuery(process.versions.node)) {
+        this.skip()
+      }
+      var app = express();
+      var etag = '"12345"';
+
+      app.use(function(req, res){
+        res.set('ETag', etag);
+        res.send(req.fresh);
+      });
+
+      request(app)
+      .query('/')
+      .set('If-None-Match', etag)
+      .send({ ids: ['a', 'b'] })
+      .expect(304, done);
+    })
+
+    it('should return false for a QUERY request with a body when the resource is modified', function(done){
+      if (shouldSkipQuery(process.versions.node)) {
+        this.skip()
+      }
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('ETag', '"123"');
+        res.send(req.fresh);
+      });
+
+      request(app)
+      .query('/')
+      .set('If-None-Match', '"12345"')
+      .send({ ids: ['a', 'b'] })
       .expect(200, 'false', done);
     })
 


### PR DESCRIPTION
`req.fresh` only performed weak freshness validation for `GET` and `HEAD`, so responses to `QUERY` requests never returned `304 Not Modified` even when the client sent a matching `If-None-Match`. This extends the method guard to include `QUERY`.

```diff
-  // GET or HEAD for weak freshness validation only
-  if ('GET' !== method && 'HEAD' !== method) return false;
+  // GET, HEAD, or QUERY for weak freshness validation only
+  if ('GET' !== method && 'HEAD' !== method && 'QUERY' !== method) return false;
```

---
As far as I can tell, QUERY is a safe, idempotent, cacheable method whose responses explicitly support conditional revalidation, as per https://datatracker.ietf.org/doc/rfc10008/, so it should behave like `GET`/`HEAD` here.

I've added tests where it makes sense, and would also be happy to backport this to v4.x if accepted.

Fixes #7365 