### PR TITLE
fix(view): handle view names ending with a dot

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -55,6 +55,10 @@ function View(name, options) {
   this.defaultEngine = opts.defaultEngine;
   this.ext = extname(name);
   this.name = name;
+
+  if (this.ext === '.') {
+    this.ext = '';
+  }
   this.root = opts.root;
 
   if (!this.ext && !this.defaultEngine) {

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -90,6 +90,18 @@ describe('app', function(){
           done();
         });
       })
+
+      it('should provide a helpful error when view name ends with a dot', function(done){
+        var app = createApp();
+        app.set('view engine', 'tmpl');
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.render('rawr.', function (err) {
+          assert.ok(err)
+          assert.equal(err.message, 'Failed to lookup view "rawr." in views directory "' + path.join(__dirname, 'fixtures') + '"')
+          done();
+        });
+      })
     })
 
     describe('when an error occurs', function(){


### PR DESCRIPTION
Avoid calling require("") with an empty string when the resolved extension is a single dot (e.g., "index."). This prevents an opaque TypeError and correctly falls back to resolving the view or yielding a clean lookup error.

Also adds an automated regression test in test/app.render.js.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
