### PR TITLE
fix: enable conditional revalidation (304) for QUERY requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -471,8 +471,8 @@ defineGetter(req, 'fresh', function(){
   var res = this.res
   var status = res.statusCode
 
-  // GET or HEAD for weak freshness validation only
-  if ('GET' !== method && 'HEAD' !== method) return false;
+  // GET, HEAD, or QUERY for weak freshness validation only
+  if ('GET' !== method && 'HEAD' !== method && 'QUERY' !== method) return false;
 
   // 2xx or 304 as per rfc2616 14.26
   if ((status >= 200 && status < 300) || 304 === status) {

--- a/test/req.fresh.js
+++ b/test/req.fresh.js
@@ -2,6 +2,7 @@
 
 var express = require('../')
   , request = require('supertest');
+var shouldSkipQuery = require('./support/utils').shouldSkipQuery
 
 describe('req', function(){
   describe('.fresh', function(){
@@ -18,6 +19,41 @@ describe('req', function(){
       .get('/')
       .set('If-None-Match', etag)
       .expect(304, done);
+    })
+
+    it('should return true for QUERY when the resource is not modified', function(done){
+      if (shouldSkipQuery(process.versions.node)) {
+        this.skip()
+      }
+      var app = express();
+      var etag = '"12345"';
+
+      app.use(function(req, res){
+        res.set('ETag', etag);
+        res.send(req.fresh);
+      });
+
+      request(app)
+      .query('/')
+      .set('If-None-Match', etag)
+      .expect(304, done);
+    })
+
+    it('should return false for QUERY when the resource is modified', function(done){
+      if (shouldSkipQuery(process.versions.node)) {
+        this.skip()
+      }
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('ETag', '"123"');
+        res.send(req.fresh);
+      });
+
+      request(app)
+      .query('/')
+      .set('If-None-Match', '"12345"')
+      .expect(200, 'false', done);
     })
 
     it('should return false when the resource is modified', function(done){


### PR DESCRIPTION
Fixes #7365

## Problem

`req.fresh` (`lib/request.js`) short-circuits to `false` for any method other than `GET`/`HEAD`, so `res.send`/`res.json` never emit `304 Not Modified` for a `QUERY` request even when the client sends a matching `If-None-Match`. QUERY is a safe, idempotent, cacheable method whose responses explicitly support conditional revalidation, so it should participate in freshness checks the same way `GET`/`HEAD` do.

Express already supports routing QUERY (#5615), and the test suite already has the `shouldSkipQuery` helper for running QUERY tests on Node >= 22 — this closes the freshness gap.

## Change

Add `QUERY` to the method allowlist in the `req.fresh` getter. The 304 body-stripping path in `res.send` is method-agnostic, so no other changes are needed.

## Tests

Two new cases in `test/req.fresh.js`, mirroring the existing GET cases and using the established `shouldSkipQuery` guard:
- QUERY with matching `If-None-Match` → 304
- QUERY with non-matching `If-None-Match` → 200 `'false'`

Full suite: 1260 passing, lint clean.