### PR TITLE
fix: confine view lookup to the views root

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -27,6 +27,8 @@ var basename = path.basename;
 var extname = path.extname;
 var join = path.join;
 var resolve = path.resolve;
+var relative = path.relative;
+var isAbsolute = path.isAbsolute;
 
 /**
  * Module exports.
@@ -112,6 +114,13 @@ View.prototype.lookup = function lookup(name) {
 
     // resolve the path
     var loc = resolve(root, name);
+
+    // relative names must stay under the views root (absolute names are allowed)
+    if (!isAbsolute(name) && !isPathInside(root, loc)) {
+      debug('skip "%s"; outside root "%s"', loc, root);
+      continue;
+    }
+
     var dir = dirname(loc);
     var file = basename(loc);
 
@@ -202,4 +211,18 @@ function tryStat(path) {
   } catch (e) {
     return undefined;
   }
+}
+
+/**
+ * Determine if `target` resolves inside `root`.
+ *
+ * @param {string} root
+ * @param {string} target
+ * @return {boolean}
+ * @private
+ */
+
+function isPathInside(root, target) {
+  var rel = relative(resolve(root), resolve(target));
+  return rel === '' || (rel && !rel.startsWith('..') && !isAbsolute(rel));
 }

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -92,6 +92,49 @@ describe('app', function(){
       })
     })
 
+    describe('when the name escapes the views root', function(){
+      it('should reject relative paths outside the root', function(done){
+        var app = createApp();
+        var views = path.join(__dirname, 'fixtures', 'default_layout')
+
+        app.set('views', views)
+        app.locals.user = { name: 'tobi' };
+
+        app.render('../user.tmpl', function (err) {
+          assert.ok(err)
+          assert.equal(err.message, 'Failed to lookup view "../user.tmpl" in views directory "' + views + '"')
+          done();
+        });
+      })
+
+      it('should allow relative paths that stay within the root', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl');
+        app.locals.user = { name: 'tobi' };
+
+        app.render('blog/../user', function (err, str) {
+          if (err) return done(err);
+          assert.strictEqual(str, '<p>tobi</p>')
+          done();
+        });
+      })
+
+      it('should still support absolute paths outside the root', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures', 'default_layout'))
+        app.locals.user = { name: 'tobi' };
+
+        app.render(path.join(__dirname, 'fixtures', 'user.tmpl'), function (err, str) {
+          if (err) return done(err);
+          assert.strictEqual(str, '<p>tobi</p>')
+          done();
+        });
+      })
+    })
+
     describe('when an error occurs', function(){
       it('should invoke the callback', function(done){
         var app = createApp();


### PR DESCRIPTION
## Summary
- Reject relative view names that resolve outside the configured `views` root in `View.lookup`
- Keep support for absolute view paths and relative paths that stay within the root
- Aligns view rendering with the existing `sendFile` path-escape protection

## Test plan
- [x] `npx mocha --require test/support/env test/app.render.js` (24 passing)
- [ ] Confirm `res.render('../secret')` fails lookup when the name escapes the views root
- [ ] Confirm `app.render(absolutePath)` still works
- [ ] Confirm nested views like `blog/post` still resolve