### PR TITLE
Fix res.render() TypeError for view names ending in '.'

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -55,6 +55,10 @@ function View(name, options) {
   this.defaultEngine = opts.defaultEngine;
   this.ext = extname(name);
   this.name = name;
+
+  if (this.ext === '.') {
+    this.ext = '';
+  }
   this.root = opts.root;
 
   if (!this.ext && !this.defaultEngine) {


### PR DESCRIPTION
Fix expressjs/express#7350

## Problem
`res.render('index.')` / `app.render('index.')` throws an opaque `TypeError: The argument 'id' must be a non-empty string` from `require('')` instead of returning a proper "Failed to lookup view" error through the callback.

## Root cause
`path.extname('index.')` returns `'.'`, which is truthy, so Express skips the "no extension → use default engine" fallback. `this.ext.slice(1)` becomes `''`, leading to `require('')`.

## Fix
When `path.extname()` returns exactly `'.'` (name ends with a dot), normalize `this.ext` to empty string so Express falls through to the standard no-extension handling. This produces the expected "Failed to lookup view" error instead of an opaque TypeError.