### PR TITLE
Preserve unknown Content-Type values in res.set()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -676,7 +676,7 @@ res.header = function header(field, val) {
       if (Array.isArray(value)) {
         throw new TypeError('Content-Type cannot be set to an Array');
       }
-      value = mime.contentType(value)
+      value = mime.contentType(value) || value;
     }
 
     this.setHeader(field, value);

--- a/test/res.set.js
+++ b/test/res.set.js
@@ -87,6 +87,20 @@ describe('res', function(){
       .get('/')
       .expect(500, /TypeError: Content-Type cannot be set to an Array/, done)
     })
+
+    it('should preserve an unknown Content-Type', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.set('Content-Type', 'blahblah')
+        res.end()
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'blahblah')
+      .expect(200, done)
+    })
   })
 
   describe('.set(object)', function(){


### PR DESCRIPTION
## Summary

When `res.set('Content-Type', value)` is called with an unknown content type,
`mime.contentType(value)` returns `false`. Express currently forwards that
value to `setHeader`, resulting in a `Content-Type: false` header.

This change preserves the original value when MIME lookup fails.

## Changes

- Preserve unknown `Content-Type` values by falling back to the original input.
- Add a regression test covering this behavior.

Fixes #7034