### PR TITLE
test: cover function-based "trust proxy" hop behavior

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -333,6 +333,11 @@ defineGetter(req, 'secure', function secure(){
  * The is the remote address on the socket unless
  * "trust proxy" is set.
  *
+ * When "trust proxy" is a function, it is invoked once per hop as
+ * `fn(addr, i)` starting from the socket address (i === 0) and moving
+ * outward through the X-Forwarded-For hops. Return true to trust the
+ * hop; the first untrusted hop becomes the resolved client address.
+ *
  * @return {String}
  * @public
  */

--- a/test/req.ip.js
+++ b/test/req.ip.js
@@ -1,6 +1,7 @@
 'use strict'
 
-var express = require('../')
+var assert = require('node:assert')
+  , express = require('../')
   , request = require('supertest');
 
 describe('req', function(){
@@ -97,6 +98,77 @@ describe('req', function(){
 
         var test = request(app).get('/')
         test.expect(200, getExpectedClientAddress(test._server), done)
+      })
+    })
+
+    describe('when "trust proxy" is a function', function(){
+      it('should be called once per hop with an incrementing index', function(done){
+        var app = express();
+        var calls = [];
+
+        app.set('trust proxy', function (addr, i) {
+          calls.push([addr, i]);
+          return true;
+        });
+
+        app.use(function(req, res, next){
+          res.send(req.ip);
+        });
+
+        var test = request(app).get('/')
+        var socketAddr = getExpectedClientAddress(test._server)
+        test.set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.3')
+        test.expect(200, '10.0.0.1', function (err) {
+          if (err) return done(err);
+          // addrs[0] is the socket address (i === 0), then each
+          // X-Forwarded-For hop outward toward the original client.
+          // The last address is never passed to the trust function.
+          assert.deepEqual(calls, [
+            [socketAddr, 0],
+            ['10.0.0.3', 1],
+            ['10.0.0.2', 2]
+          ]);
+          done();
+        })
+      })
+
+      it('should resolve req.ip to the first untrusted hop', function(done){
+        var app = express();
+
+        // trust every hop except 10.0.0.2, which becomes the boundary
+        app.set('trust proxy', function (addr) {
+          return addr !== '10.0.0.2';
+        });
+
+        app.use(function(req, res, next){
+          res.send(req.ip);
+        });
+
+        request(app)
+        .get('/')
+        .set('X-Forwarded-For', '10.0.0.1, 10.0.0.2, 10.0.0.3')
+        .expect(200, '10.0.0.2', done);
+      })
+
+      it('should not be called when X-Forwarded-For is not present', function(done){
+        var app = express();
+        var calls = [];
+
+        app.set('trust proxy', function (addr, i) {
+          calls.push([addr, i]);
+          return true;
+        });
+
+        app.use(function(req, res, next){
+          res.send(req.ip);
+        });
+
+        var test = request(app).get('/')
+        test.expect(200, getExpectedClientAddress(test._server), function (err) {
+          if (err) return done(err);
+          assert.strictEqual(calls.length, 0);
+          done();
+        })
       })
     })
   })


### PR DESCRIPTION
Closes #6541.

`trust proxy` as a function is undocumented and had zero test coverage, which is exactly why #6541 got filed as a bug when it isn't one. `req.ip` calls the function once per forwarded hop via `proxyaddr`, `fn(addr, i)`, starting from the socket address (`i === 0`) and moving outward through `X-Forwarded-For`, stopping at the first hop that returns false. That's the intended behavior per proxy-addr, just never pinned down anywhere.

@dougwilson said in the issue thread that undocumented/untested behavior like this is exactly what he wants contributors to lock down, so here's that:

- test asserting the exact `(addr, i)` call sequence
- test asserting `req.ip` resolves to the first untrusted hop
- test asserting the function isn't called when there's no `X-Forwarded-For`
- short doc comment above the `ip` getter describing the callback contract

No production logic changed, the getter itself is untouched. Ran the full suite locally (1263 passing) plus lint, both clean.