### PR TITLE
docs: fix typos in JSDoc comments

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -503,7 +503,7 @@ app.all = function all(path) {
 };
 
 /**
- * Render the given view `name` name with `options`
+ * Render the given view `name` with `options`
  * and a callback accepting an error and the
  * rendered template string.
  *

--- a/lib/response.js
+++ b/lib/response.js
@@ -785,7 +785,7 @@ res.cookie = function (name, value, options) {
  *
  * Examples:
  *
- *    res.location('/foo/bar').;
+ *    res.location('/foo/bar');
  *    res.location('http://example.com');
  *    res.location('../login');
  *


### PR DESCRIPTION
## Summary
- Remove duplicated word "name" in `lib/application.js`'s `render()` JSDoc comment
- Fix stray `.;` typo in `lib/response.js`'s `location()` JSDoc example

## Test plan
Doc-comment only changes, no behavior affected.