### PR TITLE
deps: bump body-parser to ^2.3.0 to fix CVE-2026-12590

### DIFF
--- a/History.md
+++ b/History.md
@@ -44,6 +44,8 @@
     // after  -> Content-Disposition: attachment; filename=user.html
     ```
 
+* Upgrade `body-parser` to `^2.3.0`, which fixes [CVE-2026-12590](https://www.cve.org/CVERecord?id=CVE-2026-12590) ([GHSA-v422-hmwv-36x6](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6)): an invalid `limit` option value caused request body size enforcement to be silently disabled (fail-open), allowing a denial of service via arbitrarily large payloads. Invalid `limit` values now throw at parser initialization instead of being ignored
+
 ## ⚡ Performance
 
 * Avoid duplicate Content-Type header processing in `res.send()` when sending string responses without an explicit Content-Type header - by [@bjohansebas](https://github.com/bjohansebas) in [#6991](https://github.com/expressjs/express/pull/6991)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "accepts": "^2.0.0",
-    "body-parser": "^2.2.1",
+    "body-parser": "^2.3.0",
     "content-disposition": "^2.0.1",
     "content-type": "^2.0.0",
     "cookie": "^0.7.1",


### PR DESCRIPTION
## Summary

Bumps `body-parser` from `^2.2.1` to `^2.3.0` to remediate **CVE-2026-12590** (GHSA-v422-hmwv-36x6).

body-parser `>=2.0.0 <2.3.0` (and `<1.20.6` on the 1.x line) fails open when
given an invalid `limit` option value: `bytes.parse()` returns `null`, which
silently disables request body size enforcement and allows a denial of service
via arbitrarily large payloads. body-parser 2.3.0 (expressjs/body-parser#698)
now throws on an invalid `limit` at parser initialization instead of ignoring it.

Express's existing `^2.2.1` range technically already permits 2.3.0, but
declaring `^2.3.0` makes the security intent explicit and ensures consumers
(and scanners like Trivy) resolve to the patched release.

## Changes
- `package.json`: `body-parser` `^2.2.1` → `^2.3.0`
- `History.md`: changelog entry under Unreleased → 🚀 Improvements

## Testing
- `body-parser`-backed middleware tests pass (211 passing): `express.json`, `express.urlencoded`, `express.raw`, `express.text`.

## References
- https://www.cve.org/CVERecord?id=CVE-2026-12590
- https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6