### PR TITLE
Fix view engine resolution for view names ending in a dot

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -57,13 +57,13 @@ function View(name, options) {
   this.name = name;
   this.root = opts.root;
 
-  if (!this.ext && !this.defaultEngine) {
+  if ((!this.ext || (this.ext === '.' && !opts.engines[this.ext])) && !this.defaultEngine) {
     throw new Error('No default engine was specified and no extension was provided.');
   }
 
   var fileName = name;
 
-  if (!this.ext) {
+  if (!this.ext || (this.ext === '.' && !opts.engines[this.ext])) {
     // get extension from default engine name
     this.ext = this.defaultEngine[0] !== '.'
       ? '.' + this.defaultEngine

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -90,6 +90,18 @@ describe('app', function(){
           done();
         });
       })
+
+      it('should provide a helpful error when view name ends in a dot', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl');
+        app.render('rawr.', function (err) {
+          assert.ok(err)
+          assert.equal(err.message, 'Failed to lookup view "rawr." in views directory "' + path.join(__dirname, 'fixtures') + '"')
+          done();
+        });
+      })
     })
 
     describe('when an error occurs', function(){


### PR DESCRIPTION
### Summary

Fixes #7350 where calling `res.render('index.')` or `app.render('index.')` throws an opaque synchronous `TypeError [ERR_INVALID_ARG_VALUE]: The argument 'id' must be a non-empty string. Received ''` instead of resolving the view or reporting a clean view lookup error.

### Root Cause

When a view name ends in a dot (such as `'index.'`), `path.extname('index.')` returns `'.'`.
In `lib/view.js`, `this.ext` is set to `'.'`. Because `'.'` is truthy, `!this.ext` evaluates to `false`, skipping the `defaultEngine` resolution logic. `View` then attempts to load an engine via `require(this.ext.slice(1))` which passes `require()`, throwing a Node `TypeError`.

### Solution

Treat `'.'` as an unprovided extension when `engines['.']` is not explicitly registered. This allows fallback to `defaultEngine` (or returning a clean view lookup error).

### Test Coverage

Added unit test in `test/app.render.js` verifying that `app.render('rawr.')` returns a clean lookup error message (`Failed to lookup view "rawr."`) when view engine is set.