### PR TITLE
fix(view): avoid opaque TypeError for view names ending in "."

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -75,16 +75,22 @@ function View(name, options) {
   if (!opts.engines[this.ext]) {
     // load engine
     var mod = this.ext.slice(1)
-    debug('require "%s"', mod)
 
-    // default engine export
-    var fn = require(mod).__express
+    // path.extname('index.') returns '.', so mod is ''. Avoid require('')
+    // which throws an opaque TypeError; leave the engine unset so lookup
+    // fails cleanly with "Failed to lookup view".
+    if (mod) {
+      debug('require "%s"', mod)
 
-    if (typeof fn !== 'function') {
-      throw new Error('Module "' + mod + '" does not provide a view engine.')
+      // default engine export
+      var fn = require(mod).__express
+
+      if (typeof fn !== 'function') {
+        throw new Error('Module "' + mod + '" does not provide a view engine.')
+      }
+
+      opts.engines[this.ext] = fn
     }
-
-    opts.engines[this.ext] = fn
   }
 
   // store loaded engine

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -90,6 +90,18 @@ describe('app', function(){
           done();
         });
       })
+
+      it('should provide a helpful error for a name ending in "."', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl')
+        app.render('index.', function (err) {
+          assert.ok(err)
+          assert.ok(err.message.indexOf('Failed to lookup view "index."') === 0)
+          done();
+        });
+      })
     })
 
     describe('when an error occurs', function(){


### PR DESCRIPTION
## Summary
- `path.extname('index.')` returns `'.'`, so the view engine loader called `require('')` and threw `ERR_INVALID_ARG_VALUE` before lookup could fail cleanly.
- Skip engine loading when the extension body is empty so `app.render` returns the usual `Failed to lookup view` error.

Fixes #7350

## Test plan
- [x] Added test: name ending in `"."` yields helpful lookup error