### PR TITLE
fix(req.get): perform case-insensitive header lookup

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -75,10 +75,10 @@ req.header = function header(name) {
   switch (lc) {
     case 'referer':
     case 'referrer':
-      return this.headers.referrer
-        || this.headers.referer;
+      return getHeader(this.headers, 'referrer')
+        || getHeader(this.headers, 'referer');
     default:
-      return this.headers[lc];
+      return getHeader(this.headers, lc);
   }
 };
 
@@ -524,4 +524,27 @@ function defineGetter(obj, name, getter) {
     enumerable: true,
     get: getter
   });
+}
+
+/**
+ * Get a header value with case-insensitive matching.
+ *
+ * @param {Object} headers
+ * @param {String} name
+ * @return {String}
+ * @private
+ */
+
+function getHeader(headers, name) {
+  var value = headers[name];
+
+  if (value !== undefined) {
+    return value;
+  }
+
+  for (var key in headers) {
+    if (key.toLowerCase() === name) {
+      return headers[key];
+    }
+  }
 }

--- a/test/req.get.js
+++ b/test/req.get.js
@@ -20,6 +20,23 @@ describe('req', function(){
       .expect('application/json', done);
     })
 
+    it('should return header field value set with non-lowercase key', function (done) {
+      var app = express()
+
+      app.use(function (req, res, next) {
+        req.headers['X-Filipe'] = 'filipe'
+        next()
+      })
+
+      app.use(function (req, res) {
+        res.end(req.get('x-filipe'))
+      })
+
+      request(app)
+      .get('/')
+      .expect('filipe', done)
+    })
+
     it('should special-case Referer', function(done){
       var app = express();
 


### PR DESCRIPTION
Fixes #5288

This updates `req.get()` / `req.header()` to perform a case-insensitive lookup when a header is present under a non-lowercase key.

Previously, custom headers added directly to `req.headers` with mixed-case names, such as `X-filipe`, could not be read with `req.get('x-filipe')`.  This change preserves the fast direct lookup path, then falls back to scanning header keys case-insensitively.

```js
req.headers['X-filipe'] = 'filipe'

req.get('x-filipe') // before: undefined
```

After this change, the same lookup returns the header value:
  ```js
req.headers['X-filipe'] = 'filipe'

req.get('x-filipe') // after: 'filipe'
 ```

A regression test was added for custom mixed-case request headers.