### PR TITLE
feat: add app-aware router creation

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -606,6 +606,23 @@ app.listen = function listen() {
 }
 
 /**
+ * Create a router that inherits this application's routing settings.
+ *
+ * @param {Object} [options]
+ * @return {Router}
+ * @public
+ */
+
+app.createRouter = function createRouter(options) {
+  options = Object.assign({
+    caseSensitive: this.enabled('case sensitive routing'),
+    strict: this.enabled('strict routing')
+  }, options)
+
+  return new Router(options)
+}
+
+/**
  * Log error using console.error.
  *
  * @param {Error} err

--- a/test/app.createRouter.js
+++ b/test/app.createRouter.js
@@ -1,0 +1,40 @@
+'use strict'
+
+var assert = require('node:assert')
+var express = require('../')
+
+describe('app.createRouter()', function () {
+  it('should inherit routing settings from the app', function () {
+    var app = express()
+
+    app.enable('case sensitive routing')
+    app.enable('strict routing')
+
+    var router = app.createRouter()
+
+    assert.strictEqual(router.caseSensitive, true)
+    assert.strictEqual(router.strict, true)
+  })
+
+  it('should allow options to override inherited settings', function () {
+    var app = express()
+
+    app.enable('case sensitive routing')
+    app.enable('strict routing')
+
+    var router = app.createRouter({
+      caseSensitive: false,
+      strict: false
+    })
+
+    assert.strictEqual(router.caseSensitive, false)
+    assert.strictEqual(router.strict, false)
+  })
+
+  it('should pass other options to the router', function () {
+    var app = express()
+    var router = app.createRouter({ mergeParams: true })
+
+    assert.strictEqual(router.mergeParams, true)
+  })
+})


### PR DESCRIPTION
## Description

Closes #2564.

Adds `app.createRouter(options)` to create an app-aware router that inherits the application's applicable routing settings:

- `case sensitive routing`
- `strict routing`

Routers created with `express.Router()` do not inherit these settings:

```js
const app = express()

app.enable('case sensitive routing')
app.enable('strict routing')

const router = express.Router()
// Does not inherit the app settings
// caseSensitive: undefined
// strict: undefined
```

The new method allows these settings to be inherited:

```js
const router = app.createRouter()
// caseSensitive: true
// strict: true
```

Explicit options override inherited settings, while other Router options are passed through:

```js
const router = app.createRouter({
  strict: false,
  mergeParams: true
})
```



## Tests

- Added tests for inherited routing settings
- Added tests for explicit overrides
- Added coverage for additional Router options
- Router-related test suite passes
