### PR TITLE
test: cover req.is() array argument and res.redirect() misuse branches

### DIFF
--- a/test/req.is.js
+++ b/test/req.is.js
@@ -166,4 +166,34 @@ describe('req.is()', function () {
       .expect(200, '"application/json"', done)
     })
   })
+
+  describe('when given an array of types', function () {
+    it('should return the first matching type', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['html', 'json']))
+      })
+
+      request(app)
+      .post('/')
+      .type('application/json')
+      .send('{}')
+      .expect(200, '"json"', done)
+    })
+
+    it('should return false when none match', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.json(req.is(['html', 'xml']))
+      })
+
+      request(app)
+      .post('/')
+      .type('application/json')
+      .send('{}')
+      .expect(200, 'false', done)
+    })
+  })
 })

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -44,6 +44,31 @@ describe('res', function(){
       .expect('Location', 'https://google.com?q=%A710')
       .expect(302, done)
     })
+
+    it('should still respond with a 302 when no address is given', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect()
+      })
+
+      request(app)
+      .get('/')
+      .expect(302, done)
+    })
+
+    it('should coerce a non-string address via res.location', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.redirect(['http://example.com'])
+      })
+
+      request(app)
+      .get('/')
+      .expect('Location', 'http://example.com')
+      .expect(302, done)
+    })
   })
 
   describe('.redirect(status, url)', function(){


### PR DESCRIPTION
Two branches were unexercised by the existing test suite:

- `lib/request.js` — `req.is()` was only ever called with a bare string in tests, so `!Array.isArray(types)` never took its `false` path (line 273).
- `lib/response.js` — `res.redirect()`'s deprecation guards for a missing address (`!address`) and a non-string address were never triggered (lines 827, 831).

## Changes

- `test/req.is.js` — `req.is()` given an array of types (matching, and no match)
- `test/res.redirect.js` — `res.redirect()` called with no address, and with a non-string address

## Coverage (measured locally with `npm run test-cov`)

| File | Before | After |
|---|---|---|
| `lib/request.js` | 98.11% branch (line 273 uncovered) | **100% branch** |
| `lib/response.js` | 93.71% branch (lines 827, 831, 835 uncovered) | 94.68% branch (line 835 remains) |

Line 835 (`res.redirect()` called with a non-number `status`) is not covered here: any non-integer status value is rejected by `res.status()` later in the same function, so there's no way to exercise that deprecation branch through a request that completes successfully. Flagging it in case it's worth a follow-up (either loosening the validation order, or accepting it stays untested).

## Testing

Ran the full suite locally (`npm test`) multiple times with this change — passes consistently. Note: I also observed an intermittent, pre-existing `"WebSockets request was expected"` failure in `res.render.js` on `master` (~1 in 10 runs, unrelated to this change, appears to be a port-reuse race between adjacent `supertest` servers). Happy to open a separate issue for that if useful — didn't want to scope-creep this PR.
