### PR TITLE
docs(res.location): clean up deprecated back string references

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -780,12 +780,9 @@ res.cookie = function (name, value, options) {
 /**
  * Set the location header to `url`.
  *
- * The given `url` can also be "back", which redirects
- * to the _Referrer_ or _Referer_ headers or "/".
- *
  * Examples:
  *
- *    res.location('/foo/bar').;
+ *    res.location('/foo/bar');
  *    res.location('http://example.com');
  *    res.location('../login');
  *


### PR DESCRIPTION
Cleans up the JSDoc comments for res.location to remove references to the deprecated "back" magic string.
Part of the split changes discussed in #7404.
