### PR TITLE
fix(res.redirect): fallback to 'Redirecting' for non-standard status …

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -839,15 +839,16 @@ res.redirect = function redirect(url) {
   address = this.location(address).get('Location');
 
   // Support text/{plain,html} by default
+  var statusMessage = statuses.message[status] || 'Redirecting';
   this.format({
     text: function(){
-      body = statuses.message[status] + '. Redirecting to ' + address
+      body = statusMessage + '. Redirecting to ' + address
     },
 
     html: function(){
       var u = escapeHtml(address);
-      body = '<!DOCTYPE html><head><title>' + statuses.message[status] + '</title></head>'
-       + '<body><p>' + statuses.message[status] + '. Redirecting to ' + u + '</p></body>'
+      body = '<!DOCTYPE html><head><title>' + statusMessage + '</title></head>'
+       + '<body><p>' + statusMessage + '. Redirecting to ' + u + '</p></body>'
     },
 
     default: function(){

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -211,4 +211,21 @@ describe('res', function(){
         .end(done)
     })
   })
+
+  describe('when status is custom or non-standard', function(){
+    it('should use "Redirecting" fallback in response body', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.redirect(399, 'http://google.com');
+      });
+
+      request(app)
+        .get('/')
+        .set('Accept', 'text/plain')
+        .expect(399)
+        .expect('Location', 'http://google.com')
+        .expect('Redirecting. Redirecting to http://google.com', done);
+    })
+  })
 })


### PR DESCRIPTION
Adds a fallback to "Redirecting" when redirecting with non-standard status codes, preventing "undefined" from rendering in the response body.

Part of the split changes discussed in #7404 