### PR TITLE
feat(res.send): add BigInt support

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -156,6 +156,16 @@ res.send = function send(body) {
         return this.json(chunk);
       }
       break;
+    case 'bigint':
+      chunk = chunk.toString();
+      encoding = 'utf8';
+      const ct = this.get('Content-Type');
+      if (typeof ct === 'string') {
+        this.set('Content-Type', setCharset(ct, 'utf-8'));
+      } else {
+        this.type('txt');
+      }
+      break;
   }
 
   // determine if ETag should be generated

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -617,4 +617,19 @@ describe('res', function(){
       })
     });
   })
+
+  describe('when chunk is bigint', function(){
+    it('should send the string representation of bigint', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(123n);
+      });
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(200, '123', done);
+    })
+  })
 })


### PR DESCRIPTION
Adds support for BigInt serialization in res.send() by converting BigInts to string representation and setting the content type to text/plain.

Part of the split changes discussed in #7404.
