### PR TITLE
fix(view): treat names ending in '.' as extensionless

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -61,6 +61,15 @@ function View(name, options) {
     throw new Error('No default engine was specified and no extension was provided.');
   }
 
+  // A name ending in "." (e.g. "index.") yields ext === "." from
+  // path.extname, which is truthy but carries no engine name. Treat it as
+  // having no extension so the default engine fallback applies and lookup
+  // fails with the usual helpful error instead of require("") throwing an
+  // opaque TypeError (see #7350).
+  if (this.ext === '.') {
+    this.ext = '';
+  }
+
   var fileName = name;
 
   if (!this.ext) {

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -90,6 +90,18 @@ describe('app', function(){
           done();
         });
       })
+
+      it('should not throw synchronously for a name ending in "."', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl')
+        app.render('index.', function (err) {
+          assert.ok(err)
+          assert.equal(err.message.indexOf('Failed to lookup view "index."'), 0)
+          done();
+        });
+      })
     })
 
     describe('when an error occurs', function(){


### PR DESCRIPTION
## Fixes #7350

`res.render('index.')` / `app.render('index.')` threw a synchronous, opaque `TypeError [ERR_INVALID_ARG_VALUE]` from `require('')`, instead of the usual helpful `Failed to lookup view` error.

### Root cause

`path.extname('index.')` returns `'.'`, which is truthy — so the "no extension → use default engine" fallback in `lib/view.js` was skipped. `this.ext` stayed `'.'` and `this.ext.slice(1)` became `''`, so `require('')` was called and threw synchronously, bypassing the render callback entirely.

### Change

Normalize `ext === '.'` to `''` at the top of the `View` constructor. The default-engine fallback then applies, and lookup fails cleanly through the normal callback path:

```js
app.render('index.', (err) => { ... })
// Before: synchronous TypeError (callback never invoked)
// After:  err = Failed to lookup view "index." in views directory "..."
```

This also covers `app.set('view engine', ...)` setups, exactly as reported.

### Tests

Added a regression test in `test/app.render.js`. Full suite passes: **1153 passing** (+1 new), eslint clean.