### PR TITLE
fix(view): treat a view name ending in "." as extensionless

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -53,7 +53,12 @@ function View(name, options) {
   var opts = options || {};
 
   this.defaultEngine = opts.defaultEngine;
-  this.ext = extname(name);
+  var ext = extname(name);
+  // `path.extname()` returns '.' for a name ending in a dot (e.g. "index."),
+  // which is truthy but is not a usable extension. Treat it as no extension so
+  // the default engine is used, instead of leaving `this.ext` as '.' and then
+  // calling `require('')` when the engine is loaded below.
+  this.ext = ext === '.' ? '' : ext;
   this.name = name;
   this.root = opts.root;
 

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -119,6 +119,21 @@ describe('app', function(){
         })
       })
     })
+    describe('when the view name ends with a "."', function(){
+      it('should invoke the callback with a lookup error', function(done){
+        var app = createApp();
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl')
+        assert.doesNotThrow(function () {
+          app.render('user.', function (err, str) {
+            assert.ok(err)
+            assert.ok(/Failed to lookup view "user\."/.test(err.message))
+            assert.strictEqual(str, undefined)
+            done()
+          })
+        })
+      })
+    })
 
     describe('when "view engine" is given', function(){
       it('should render the template', function(done){

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -119,6 +119,7 @@ describe('app', function(){
         })
       })
     })
+
     describe('when the view name ends with a "."', function(){
       it('should invoke the callback with a lookup error', function(done){
         var app = createApp();

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -64,6 +64,27 @@ describe('res', function(){
       .expect(500, /No default engine was specified/, done);
     })
 
+    it('should error with "view engine" set and a view name ending with a "."', function (done) {
+      var app = createApp();
+      app.set('views', path.join(__dirname, 'fixtures'))
+      app.set('view engine', 'tmpl')
+      app.use(function (req, res) {
+        res.render('user.')
+      })
+      request(app)
+      .get('/')
+      .expect(500, /Failed to lookup view "user\."/, done)
+    })
+    it('should error without "view engine" set and a view name ending with a "."', function (done) {
+      var app = createApp();
+      app.use(function (req, res) {
+        res.render(path.join(__dirname, 'fixtures', 'user.'))
+      })
+      request(app)
+      .get('/')
+      .expect(500, /No default engine was specified/, done)
+    })
+
     it('should expose app.locals', function(done){
       var app = createApp();
 

--- a/test/res.render.js
+++ b/test/res.render.js
@@ -75,6 +75,7 @@ describe('res', function(){
       .get('/')
       .expect(500, /Failed to lookup view "user\."/, done)
     })
+
     it('should error without "view engine" set and a view name ending with a "."', function (done) {
       var app = createApp();
       app.use(function (req, res) {


### PR DESCRIPTION
Closes #7350 

**Problem**

`path.extname('index.')` returns `'.'`, which is truthy but is not a usable extension. `View` assigned `this.ext = extname(name)` directly, so for a view name ending in a dot the `if (!this.ext)` default-engine fallback was skipped, `this.ext.slice(1)` evaluated to an empty string, and the engine loader called `require('')`. That throws `TypeError [ERR_INVALID_ARG_VALUE]` synchronously out of `app.render()` / `res.render()` instead of surfacing the usual lookup error through the callback.

**Fix**

Treat a lone `'.'` returned by `path.extname()` as "no extension", so a name with a trailing dot follows the same code path as any other extensionless name. With `view engine` set, the default engine is appended and lookup fails normally, producing `Failed to lookup view "user."`. Without `view engine` set, the existing `No default engine was specified and no extension was provided.` error is raised. An inline comment above the change documents the edge case.

**Tests**

`test/app.render.js` asserts that `app.render('user.', cb)` no longer throws and that the callback receives a lookup error. `test/res.render.js` asserts that `res.render('user.')` responds 500 with `Failed to lookup view "user."` when `view engine` is set, and 500 with `No default engine was specified` when it is not.

**Notes**

Behaviour is unchanged for any name that does not end in a dot, because `path.extname()` only returns `'.'` in that case.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
