### PR TITLE
fix(res.send): send a raw ArrayBuffer as binary instead of an empty JSON object

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -119,7 +119,7 @@ res.links = function(links) {
  *     res.send({ some: 'json' });
  *     res.send('<p>some html</p>');
  *
- * @param {string|number|boolean|object|Buffer} body
+ * @param {string|number|boolean|object|Buffer|ArrayBuffer} body
  * @public
  */
 
@@ -148,7 +148,11 @@ res.send = function send(body) {
     case 'object':
       if (chunk === null) {
         chunk = '';
-      } else if (ArrayBuffer.isView(chunk)) {
+      } else if (ArrayBuffer.isView(chunk) || isArrayBuffer(chunk)) {
+        // `ArrayBuffer.isView()` is false for a raw ArrayBuffer, so its bytes
+        // are copied into a Buffer; otherwise it would fall through to
+        // `res.json()` below and be serialized as an empty object.
+        chunk = ArrayBuffer.isView(chunk) ? chunk : Buffer.from(chunk);
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
@@ -1009,6 +1013,23 @@ function sendfile(res, file, options, callback) {
 
   // pipe
   file.pipe(res);
+}
+
+/**
+ * Determine if `obj` is a raw ArrayBuffer or SharedArrayBuffer.
+ *
+ * `ArrayBuffer.isView()` only detects views over a buffer (TypedArray and
+ * DataView), and `instanceof` is not reliable across realms, so the internal
+ * class of the object is checked instead.
+ *
+ * @param {*} obj
+ * @return {boolean}
+ * @private
+ */
+
+function isArrayBuffer (obj) {
+  var tag = Object.prototype.toString.call(obj);
+  return tag === '[object ArrayBuffer]' || tag === '[object SharedArrayBuffer]';
 }
 
 /**

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -231,6 +231,32 @@ describe('res', function(){
     })
   })
 
+  describe('.send(ArrayBuffer)', function(){
+    it('should send as application/octet-stream', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.send(new TextEncoder().encode('hey').buffer);
+      });
+      request(app)
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', 'application/octet-stream')
+      .expect(utils.shouldHaveBody(Buffer.from('hey')))
+      .end(done)
+    })
+
+    it('should not override an existing Content-Type', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.set('Content-Type', 'text/plain').send(new TextEncoder().encode('hey').buffer);
+      });
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(200, 'hey', done);
+    })
+  })
+
   describe('.send(Object)', function(){
     it('should send as application/json', function(done){
       var app = express();


### PR DESCRIPTION
Closes #7362 

**Problem**

`res.send()` treats `Buffer` and ArrayBuffer views (TypedArray, DataView) as binary, but `ArrayBuffer.isView()` returns false for a raw `ArrayBuffer`. A raw `ArrayBuffer` therefore falls through to `res.json()` and is sent as an empty object with `Content-Type: application/json` instead of its bytes.

**Fix**

The object branch of `res.send()` now also accepts a raw `ArrayBuffer` (and `SharedArrayBuffer`). The bytes are copied into a `Buffer` with `Buffer.from()`, and when no `Content-Type` has been set the response type defaults to `bin` (`application/octet-stream`), mirroring what already happens for views. Views keep their current behaviour and are not copied.

Detection uses a small private `isArrayBuffer()` helper based on the internal class rather than `instanceof`, so buffers created in another realm are handled too. The JSDoc for `res.send()` was updated to list `ArrayBuffer` as an accepted body type.

**Tests**

`test/res.send.js` gains a `.send(ArrayBuffer)` suite: one test asserts the response is `application/octet-stream` and contains the exact bytes, and one asserts that an explicitly set `Content-Type` is preserved.

**Notes**

I could not run the test suite locally, so CI is the source of truth for this change. There are already open pull requests for this issue (#7363 and #7410); happy to close this one if a maintainer prefers either of those.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
