### PR TITLE
fix: update body-parser to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "accepts": "^2.0.0",
-    "body-parser": "^2.2.1",
+    "body-parser": "^2.3.0",
     "content-disposition": "^2.0.1",
     "content-type": "^2.0.0",
     "cookie": "^0.7.1",


### PR DESCRIPTION
Fixes #7391

Updates body-parser from ^2.2.1 to ^2.3.0 to address CVE-2026-12590.

Versions before 2.3.0 can fail open when an invalid `limit` option is provided, potentially allowing oversized request bodies.

Tests:
- npm test — 1260 passing
- npm run lint — passing