### PR TITLE
fix: send raw ArrayBuffer and SharedArrayBuffer as binary

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,11 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
+      } else if (isArrayBuffer(chunk)) {
+        chunk = Buffer.from(chunk);
+        if (!this.get('Content-Type')) {
+          this.type('bin');
+        }
       } else {
         return this.json(chunk);
       }
@@ -1009,6 +1014,21 @@ function sendfile(res, file, options, callback) {
 
   // pipe
   file.pipe(res);
+}
+
+/**
+ * Determine if value is an ArrayBuffer or SharedArrayBuffer.
+ *
+ * Unlike `ArrayBuffer.isView()`, which only covers typed array views,
+ * this also matches the bare buffers themselves.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ * @private
+ */
+
+function isArrayBuffer (value) {
+  return value instanceof ArrayBuffer || value instanceof SharedArrayBuffer
 }
 
 /**

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -217,6 +217,61 @@ describe('res', function(){
         .expect(200, "hey", done);
     })
 
+    it('should accept ArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        const encodedHey = new TextEncoder().encode("hey");
+        res.set("Content-Type", "text/plain").send(encodedHey.buffer);
+      })
+
+      request(app)
+        .get("/")
+        .expect("Content-Type", "text/plain; charset=utf-8")
+        .expect(200, "hey", done);
+    })
+
+    it('should set Content-Type to application/octet-stream for ArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.send(new ArrayBuffer(4));
+      })
+
+      request(app)
+        .get("/")
+        .expect("Content-Type", "application/octet-stream")
+        .expect(200)
+        .expect(utils.shouldHaveBody(Buffer.alloc(4)))
+        .end(done);
+    })
+
+    it('should accept SharedArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        const sab = new SharedArrayBuffer(3);
+        new Uint8Array(sab).set(new TextEncoder().encode('hey'));
+        res.set('Content-Type', 'text/plain').send(sab);
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(200, 'hey', done);
+    })
+
+    it('should set Content-Type to application/octet-stream for SharedArrayBuffer', function(done){
+      var app = express();
+      app.use(function(req, res){
+        res.send(new SharedArrayBuffer(4));
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200)
+        .expect(utils.shouldHaveBody(Buffer.alloc(4)))
+        .end(done);
+    })
+
     it('should not override ETag', function (done) {
       var app = express()
 


### PR DESCRIPTION
## Problem

Closes #7362

`res.send()` handles `Buffer` and TypedArray views via `ArrayBuffer.isView()`, but a bare `ArrayBuffer` — the standard binary type returned by `fetch`, Web Crypto, WebSocket, FileReader and similar APIs — falls through to the JSON branch:

```js
res.send(new ArrayBuffer(10))
// Sends: {} (Content-Type: application/json)
// Expected: 10 zero bytes (Content-Type: application/octet-stream)
```

`ArrayBuffer.isView(new ArrayBuffer(...))` returns `false`, so the `#6285` fix that added `Uint8Array`/`DataView` support missed bare buffers.

## Solution

Add an `isArrayBuffer()` check in `lib/response.js` that converts to `Buffer` and applies the binary content type, consistent with the existing `ArrayBuffer.isView` branch. `SharedArrayBuffer` is covered too:

```js
} else if (isArrayBuffer(chunk)) {
  chunk = Buffer.from(chunk);
  if (!this.get('Content-Type')) {
    this.type('bin');
  }
}
```

## Tests

Four tests in `test/res.send.js`:
- `ArrayBuffer` with explicit Content-Type sends bytes unchanged
- `ArrayBuffer` without Content-Type gets `application/octet-stream`
- Same two cases for `SharedArrayBuffer`

Full suite passes (`npm test` → 1264 passing), lint clean.

## Note

Re-implements the stalled #7363 (author inactive since July) on current `master`, with the same behavior and test coverage.
