### PR TITLE
fix: throw clean lookup error for view names ending with a dot

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -57,6 +57,13 @@ function View(name, options) {
   this.name = name;
   this.root = opts.root;
 
+  // a name ending in "." yields a bare "." from extname(), which is not a
+  // usable extension; treat it as no extension so the default engine is
+  // applied and a clean lookup error is reported instead of require("")
+  if (this.ext === '.') {
+    this.ext = '';
+  }
+
   if (!this.ext && !this.defaultEngine) {
     throw new Error('No default engine was specified and no extension was provided.');
   }

--- a/test/app.render.js
+++ b/test/app.render.js
@@ -120,6 +120,22 @@ describe('app', function(){
       })
     })
 
+    describe('when the view name ends with a "."', function(){
+      it('should invoke the callback with a lookup error instead of crashing', function(done){
+        var app = createApp();
+
+        app.set('views', path.join(__dirname, 'fixtures'))
+        app.set('view engine', 'tmpl');
+
+        app.render('user.', function (err) {
+          assert.ok(err)
+          assert.notStrictEqual(err.code, 'ERR_INVALID_ARG_VALUE')
+          assert.equal(err.message, 'Failed to lookup view "user." in views directory "' + path.join(__dirname, 'fixtures') + '"')
+          done()
+        })
+      })
+    })
+
     describe('when "view engine" is given', function(){
       it('should render the template', function(done){
         var app = createApp();


### PR DESCRIPTION
## Problem

Closes #7350

A view name ending in `.` makes `path.extname('index.')` return `'.'`, which is truthy, so the "no extension → use default engine" fallback in `lib/view.js` is skipped. `this.ext` stays `'.'`, `this.ext.slice(1)` becomes `''`, and `require('')` is called, throwing an opaque `ERR_INVALID_ARG_VALUE` TypeError instead of resolving the view or reporting a clean lookup error.

Via `res.render('index.')` inside a route, the same error surfaces as an opaque 500 in the error handler instead of the usual `Failed to lookup view "index."` error.

## Solution

Treat a bare `.` as no extension so the default engine is applied and view resolution reports a clean lookup error through the callback:

```js
// a name ending in "." yields a bare "." from extname(), which is not a
// usable extension; treat it as no extension so the default engine is
// applied and a clean lookup error is reported instead of require("")
if (this.ext === '.') {
  this.ext = '';
}
```

## Tests

Added `when the view name ends with a "."` to `test/app.render.js` verifying the callback receives the standard `Failed to lookup view "user."` error rather than `ERR_INVALID_ARG_VALUE`. Full suite passes (`npm test` → 1264 passing), lint clean.

## Note

Re-implements the stalled #7351 (author inactive since July) on current `master`, with the same behavior and test coverage.
