### PR TITLE
test: add test cases for null, string, and NaN status codes in res.sendStatus

### DIFF
--- a/test/res.sendStatus.js
+++ b/test/res.sendStatus.js
@@ -40,5 +40,41 @@ describe('res', function () {
         .get('/')
         .expect(500, /TypeError: Invalid status code/, done)
     })
+
+    it('should raise error for null status code', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.sendStatus(null).end()
+      })
+
+      request(app)
+        .get('/')
+        .expect(500, /TypeError: Invalid status code/, done)
+    })
+
+    it('should raise error for string status code', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.sendStatus('200').end()
+      })
+
+      request(app)
+        .get('/')
+        .expect(500, /TypeError: Invalid status code/, done)
+    })
+
+    it('should raise error for NaN status code', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.sendStatus(NaN).end()
+      })
+
+      request(app)
+        .get('/')
+        .expect(500, /TypeError: Invalid status code/, done)
+    })
   })
 })


### PR DESCRIPTION
### Summary
- In `test/res.sendStatus.js`, add test cases verifying that passing invalid status codes (`null`, strings, and `NaN`) to `res.sendStatus()` correctly raises a `TypeError`.