### PR TITLE
Fix: Throw TypeError instead of sending invalid Location header on missing redirect URL

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,7 +3,7 @@
 ## 🐞 Bug fixes
 
 - Fixed HTTP header conflict between Content-Length and Transfer-Encoding in res.send - by [@YuryShkoda](https://github.com/YuryShkoda) in [#4893](https://github.com/expressjs/express/pull/4893)
-
+- Fixed `res.redirect()` to properly throw a `TypeError` when the url is missing or not a string, rather than just warning and sending an invalid `Location: undefined` header.
 
     Fixed the behavior of `res.send()` to prevent conflicts between `Content-Length` and `Transfer-Encoding` HTTP headers in responses. The `Content-Length` header in `res.send()` is now only added when a `Transfer-Encoding` header is not present, complying with the HTTP specification that states both headers should not coexist in the same response
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -823,12 +823,12 @@ res.redirect = function redirect(url) {
     address = arguments[1]
   }
 
-  if (!address) {
-    deprecate('Provide a url argument');
+  if (address == null) {
+    throw new TypeError('url argument is required');
   }
 
   if (typeof address !== 'string') {
-    deprecate('Url must be a string');
+    throw new TypeError('url must be a string');
   }
 
   if (typeof status !== 'number') {

--- a/test/res.redirect.js
+++ b/test/res.redirect.js
@@ -45,6 +45,40 @@ describe('res', function(){
       .expect(302, done)
     })
   })
+  
+  describe('.redirect(undefined)', function(){
+    it('should throw a TypeError if URL is missing', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        try {
+          res.redirect();
+        } catch (err) {
+          res.status(500).send(err.message);
+        }
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, 'url argument is required', done);
+    })
+
+    it('should throw a TypeError if URL is not a string', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        try {
+          res.redirect(123);
+        } catch (err) {
+          res.status(500).send(err.message);
+        }
+      });
+
+      request(app)
+      .get('/')
+      .expect(500, 'url must be a string', done);
+    })
+  })
 
   describe('.redirect(status, url)', function(){
     it('should set the response status', function(done){


### PR DESCRIPTION
Resolves #6941. When es.redirect() is called with undefined or a non-string argument, it now correctly throws a TypeError rather than falling through to send a malformed HTTP response with a Location: undefined header.