### PR TITLE
fix: handle raw ArrayBuffer in res.send

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,11 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
+      } else if (chunk instanceof ArrayBuffer || (chunk && chunk.constructor && chunk.constructor.name === 'ArrayBuffer')) {
+        chunk = Buffer.from(chunk);
+        if (!this.get('Content-Type')) {
+          this.type('bin');
+        }
       } else {
         return this.json(chunk);
       }

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -231,6 +231,37 @@ describe('res', function(){
     })
   })
 
+  describe('.send(ArrayBuffer)', function(){
+    it('should send as octet-stream', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(new ArrayBuffer(8))
+      });
+
+      request(app)
+        .get('/')
+        .expect(200)
+        .expect('Content-Type', 'application/octet-stream')
+        .expect('Content-Length', '8')
+        .expect(utils.shouldHaveBody(Buffer.alloc(8, 0)))
+        .end(done)
+    })
+
+    it('should not override Content-Type', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Content-Type', 'text/plain').send(new ArrayBuffer(8))
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(200, done);
+    })
+  })
+
   describe('.send(Object)', function(){
     it('should send as application/json', function(done){
       var app = express();


### PR DESCRIPTION
Fixes #7362

### Summary
Converts raw `ArrayBuffer` instances to `Buffer.from(chunk)` in `res.send()`, preventing them from falling through to `res.json()` and serializing as `{}`.

### Verification
- Added unit tests for ArrayBuffer handling in `test/res.send.js`.
- All unit tests passing via `npm test`.