### PR TITLE
docs: fix capitalization of GitHub Discussions in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ for more information.
 
   * [Website and Documentation](https://expressjs.com/) - [[website repo](https://github.com/expressjs/expressjs.com)]
   * [GitHub Organization](https://github.com/expressjs) for Official Middleware & Modules
-  * [Github Discussions](https://github.com/expressjs/discussions) for discussion on the development and usage of Express
+  * [GitHub Discussions](https://github.com/expressjs/discussions) for discussion on the development and usage of Express
 
 **PROTIP** Be sure to read the [migration guide to v5](https://expressjs.com/en/guide/migrating-5)
 


### PR DESCRIPTION
## Summary
- Fixes a small branding inconsistency in the Readme: "Github Discussions" is corrected to "GitHub Discussions" to match the correct capitalization used one line above ("GitHub Organization") and elsewhere in the file.

## Test plan
- Docs-only change, no code affected. Verified by visually diffing the rendered Readme section.