### PR TITLE
fix: restore req/res prototypes when a mounted app hands control back

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -165,10 +165,10 @@ app.handle = function handle(req, res, callback) {
   req.res = res;
   res.req = req;
 
-  // restore the prototypes when handing control back to the caller
+  // restore the prototypes for the caller
   if (callback) {
-    var reqProto = Object.getPrototypeOf(req)
-    var resProto = Object.getPrototypeOf(res)
+    var reqProto = Object.getPrototypeOf(req);
+    var resProto = Object.getPrototypeOf(res);
 
     done = function (err) {
       Object.setPrototypeOf(req, reqProto)

--- a/lib/application.js
+++ b/lib/application.js
@@ -165,6 +165,18 @@ app.handle = function handle(req, res, callback) {
   req.res = res;
   res.req = req;
 
+  // restore the prototypes when handing control back to the caller
+  if (callback) {
+    var reqProto = Object.getPrototypeOf(req)
+    var resProto = Object.getPrototypeOf(res)
+
+    done = function (err) {
+      Object.setPrototypeOf(req, reqProto)
+      Object.setPrototypeOf(res, resProto)
+      callback(err);
+    };
+  }
+
   // alter the prototypes
   Object.setPrototypeOf(req, this.request)
   Object.setPrototypeOf(res, this.response)

--- a/lib/application.js
+++ b/lib/application.js
@@ -165,16 +165,18 @@ app.handle = function handle(req, res, callback) {
   req.res = res;
   res.req = req;
 
-  // restore the prototypes for the caller
+  // restore the prototypes for an express caller
   if (callback) {
     var reqProto = Object.getPrototypeOf(req);
     var resProto = Object.getPrototypeOf(res);
 
-    done = function (err) {
-      Object.setPrototypeOf(req, reqProto)
-      Object.setPrototypeOf(res, resProto)
-      callback(err);
-    };
+    if (reqProto.app) {
+      done = function (err) {
+        Object.setPrototypeOf(req, reqProto)
+        Object.setPrototypeOf(res, resProto)
+        callback(err);
+      };
+    }
   }
 
   // alter the prototypes

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -106,6 +106,36 @@ describe('app', function(){
         .expect(500, 'yes', done);
     })
 
+    it('should not restore the prototypes when a bare router mounts an app', function(done){
+      var child = express()
+        , router = express.Router();
+
+      child.use(function(req, res, next){
+        next();
+      });
+
+      router.use(child);
+
+      router.use(function(req, res){
+        var keptChildProto = Object.getPrototypeOf(req) === child.request
+          && Object.getPrototypeOf(res) === child.response;
+        res.end(keptChildProto ? 'yes' : 'no');
+      });
+
+      var server = function(req, res){
+        router.handle(req, res, function(err){
+          if (err) {
+            res.statusCode = 500;
+            res.end(err.message);
+          }
+        });
+      };
+
+      request(server)
+        .get('/')
+        .expect(200, 'yes', done);
+    })
+
     it('should set the child\'s .parent', function(){
       var blog = express()
         , app = express();

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -83,6 +83,29 @@ describe('app', function(){
         .expect(200, 'yes', done);
     })
 
+    it('should restore the prototypes when a router-mounted app calls next(err)', function(done){
+      var blog = express()
+        , app = express()
+        , router = express.Router();
+
+      blog.get('/', function(req, res, next){
+        next(new Error('boom'));
+      });
+
+      router.use('/blog', blog);
+      app.use(router);
+
+      app.use(function(err, req, res, next){
+        var restored = Object.getPrototypeOf(req) === app.request
+          && Object.getPrototypeOf(res) === app.response;
+        res.status(500).end(restored ? 'yes' : 'no');
+      });
+
+      request(app)
+        .get('/blog')
+        .expect(500, 'yes', done);
+    })
+
     it('should set the child\'s .parent', function(){
       var blog = express()
         , app = express();

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -73,12 +73,14 @@ describe('app', function(){
       app.use(router);
 
       app.use(function(req, res){
-        res.end(req.app === app ? 'restored' : 'leaked');
+        var restored = Object.getPrototypeOf(req) === app.request
+          && Object.getPrototypeOf(res) === app.response;
+        res.end(restored ? 'yes' : 'no');
       });
 
       request(app)
         .get('/blog')
-        .expect(200, 'restored', done);
+        .expect(200, 'yes', done);
     })
 
     it('should set the child\'s .parent', function(){

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -60,6 +60,27 @@ describe('app', function(){
         .expect(200, 'forum', cb)
     })
 
+    it('should restore the prototypes when mounted on a router', function(done){
+      var blog = express()
+        , app = express()
+        , router = express.Router();
+
+      blog.get('/', function(req, res, next){
+        next();
+      });
+
+      router.use('/blog', blog);
+      app.use(router);
+
+      app.use(function(req, res){
+        res.end(req.app === app ? 'restored' : 'leaked');
+      });
+
+      request(app)
+        .get('/blog')
+        .expect(200, 'restored', done);
+    })
+
     it('should set the child\'s .parent', function(){
       var blog = express()
         , app = express();


### PR DESCRIPTION
`app.handle` swaps the `req`/`res` prototypes for its own, but only `app.use()` puts them back, inside the `mounted_app` closure it wraps around a sub-app. Mount an app with `router.use()` instead and the swap is never undone, so every middleware that runs after the sub-app calls `next()` reads `req.app`, `req.ip`, `req.secure` and `req.hostname` through the sub-app's settings rather than the parent's.

`app.handle` now saves the prototypes it replaces and restores them before invoking the callback it was handed, so the cleanup happens on whichever path the app was mounted through. The issue suggested patching `restore()` inside `router`, but the swap originates here, and doing it here also covers any other caller that passes a callback without needing a `router` release.

This covers the prototype half of #7427 only. A router-mounted app still gets no `mount` event and so does not inherit `trust proxy`, which would need `router` to know about express apps.

Fixes #7427