### PR TITLE
fix(res.send): preserve bytes when sending DataView

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -149,6 +149,9 @@ res.send = function send(body) {
       if (chunk === null) {
         chunk = '';
       } else if (ArrayBuffer.isView(chunk)) {
+        if (!Buffer.isBuffer(chunk)) {
+          chunk = Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+        }
         if (!this.get('Content-Type')) {
           this.type('bin');
         }

--- a/lib/response.js
+++ b/lib/response.js
@@ -149,7 +149,7 @@ res.send = function send(body) {
       if (chunk === null) {
         chunk = '';
       } else if (ArrayBuffer.isView(chunk)) {
-        if (!Buffer.isBuffer(chunk)) {
+        if (typeof DataView === 'function' && chunk instanceof DataView) {
           chunk = Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
         }
         if (!this.get('Content-Type')) {

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -249,6 +249,21 @@ describe('res', function(){
         .end(done)
     })
 
+    it('should keep existing non-byte typed array payload', function (done) {
+      var app = express()
+
+      app.use(function (req, res) {
+        res.send(new Uint16Array([0x0102, 0x0304]))
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect('Content-Length', '2')
+        .expect(utils.shouldHaveBody(Buffer.from([0x02, 0x04])))
+        .end(done)
+    })
+
     it('should not override ETag', function (done) {
       var app = express()
 

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -217,6 +217,38 @@ describe('res', function(){
         .expect(200, "hey", done);
     })
 
+    it('should accept DataView', function (done) {
+      var app = express()
+      var ab = new ArrayBuffer(4)
+      new Uint8Array(ab).set([1, 2, 3, 4])
+
+      app.use(function (req, res) {
+        res.send(new DataView(ab))
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(utils.shouldHaveBody(Buffer.from([1, 2, 3, 4])))
+        .end(done)
+    })
+
+    it('should honor DataView byteOffset and byteLength', function (done) {
+      var app = express()
+      var ab = new ArrayBuffer(6)
+      new Uint8Array(ab).set([9, 1, 2, 3, 4, 8])
+
+      app.use(function (req, res) {
+        res.send(new DataView(ab, 1, 4))
+      })
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(utils.shouldHaveBody(Buffer.from([1, 2, 3, 4])))
+        .end(done)
+    })
+
     it('should not override ETag', function (done) {
       var app = express()
 


### PR DESCRIPTION
`res.send(new DataView(buffer))` returned HTTP 200 with `Content-Length: 0` and an empty body. `res.send(new Uint8Array(buffer))` on the same bytes sent the payload.

`ArrayBuffer.isView` is true for DataView, so the value is treated as binary. The length path then uses `chunk.length` / `Buffer.from(chunk, encoding)`. DataView has no `.length` (only `.byteLength`), and `Buffer.from(dataView)` is an empty Buffer.

This copies non-Buffer views with `Buffer.from(view.buffer, view.byteOffset, view.byteLength)`. Existing `Buffer` and `Uint8Array` behavior is unchanged.

This does not change bare `ArrayBuffer` (still sent as `{}` JSON). That is covered by #7362.

Tests: `test/res.send.js` for a full DataView and a sliced DataView.
