### PR TITLE
fix: restore req/res prototypes when a mounted app hands control back

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -156,6 +156,18 @@ app.handle = function handle(req, res, callback) {
     onerror: logerror.bind(this)
   });
 
+  // restore the prototypes for the caller
+  if (callback) {
+    var reqProto = Object.getPrototypeOf(req);
+    var resProto = Object.getPrototypeOf(res);
+
+    done = function (err) {
+      Object.setPrototypeOf(req, reqProto);
+      Object.setPrototypeOf(res, resProto);
+      callback(err);
+    };
+  }
+
   // set powered by header
   if (this.enabled('x-powered-by')) {
     res.setHeader('X-Powered-By', 'Express');

--- a/test/app.use.js
+++ b/test/app.use.js
@@ -60,6 +60,79 @@ describe('app', function(){
         .expect(200, 'forum', cb)
     })
 
+    it('should restore prototypes when mounted on a router', function (done) {
+      var blog = express()
+        , app = express()
+        , router = express.Router()
+
+      blog.get('/', function (req, res, next) {
+        next()
+      })
+
+      router.use('/blog', blog)
+      app.use(router)
+
+      app.use(function (req, res) {
+        var restored = Object.getPrototypeOf(req) === app.request
+          && Object.getPrototypeOf(res) === app.response
+          && req.app === app
+        res.end(restored ? 'yes' : 'no')
+      })
+
+      request(app)
+        .get('/blog')
+        .expect(200, 'yes', done)
+    })
+
+    it('should restore prototypes when mounted on a router and sub-app errors', function (done) {
+      var blog = express()
+        , app = express()
+        , router = express.Router()
+
+      blog.get('/', function (req, res, next) {
+        next(new Error('boom'))
+      })
+
+      router.use('/blog', blog)
+      app.use(router)
+
+      app.use(function (err, req, res, next) {
+        var restored = Object.getPrototypeOf(req) === app.request
+          && Object.getPrototypeOf(res) === app.response
+          && req.app === app
+        res.status(500).end(restored ? 'yes' : 'no')
+      })
+
+      request(app)
+        .get('/blog')
+        .expect(500, 'yes', done)
+    })
+
+    it('should restore parent request and response extensions when mounted on a router', function (done) {
+      var blog = express()
+        , app = express()
+        , router = express.Router()
+
+      app.request.customHelper = function () {
+        return 'custom'
+      }
+
+      blog.get('/', function (req, res, next) {
+        next()
+      })
+
+      router.use('/blog', blog)
+      app.use(router)
+
+      app.use(function (req, res) {
+        res.end(req.customHelper())
+      })
+
+      request(app)
+        .get('/blog')
+        .expect(200, 'custom', done)
+    })
+
     it('should set the child\'s .parent', function(){
       var blog = express()
         , app = express();


### PR DESCRIPTION
## Problem
When an `express()` sub-app is mounted via `router.use()` instead of `app.use()`, `app.handle` alters the prototypes of `req` and `res` to point to `subApp.request` and `subApp.response`, but never restores them.

Because `router.use()` does not wrap the sub-app in the `mounted_app` cleanup closure found in `app.use()`, the prototype swap is permanent for the remainder of the request. Any middleware or handler executed downstream (after `subApp` calls `next()` or `next(err)`) reads `req.app`, `req.ip`, `req.secure`, and `req.hostname` under the sub-app's configuration rather than the parent app's settings, and any prototype extensions on the parent app are lost.

## Solution
Inside `app.handle()` in `lib/application.js`, capture the incoming `req` and `res` prototypes before mutating them whenever a `callback` is provided (indicating a mounted sub-app or delegated caller). Wrap `done` to restore the captured prototypes via `Object.setPrototypeOf()` prior to invoking `callback(err)`.

This ensures that regardless of whether the app was mounted through `app.use()`, `router.use()`, directly invoked as middleware, or passed an error via `next(err)`, the prototype swap is always safely restored when control returns to the caller.

## Changes Made
- **`lib/application.js`**:
  - In `app.handle`, wrap `done` when `callback` is present to restore `req` and `res` prototypes to their pre-invocation state upon completion.
- **`test/app.use.js`**:
  - Added test case for prototype restoration when sub-app is mounted on a router and calls `next()`.
  - Added test case for prototype restoration when sub-app passes an error to `next(err)` on a router.
  - Added test case for preserving parent custom request and response extensions across router-mounted sub-apps.

## Test Plan
- Run `npm test` to ensure all 1,259 test cases pass cleanly.
- Run `npm run lint` to verify style compliance.

Fixes #7427