### PR TITLE
fix(res): support raw ArrayBuffer in res.send()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,11 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
+      } else if (chunk instanceof ArrayBuffer) {
+        chunk = Buffer.from(chunk);
+        if (!this.get('Content-Type')) {
+          this.type('bin');
+        }
       } else {
         return this.json(chunk);
       }

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -231,6 +231,36 @@ describe('res', function(){
     })
   })
 
+  describe('.send(ArrayBuffer)', function(){
+    it('should send as octet-stream', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(new ArrayBuffer(10))
+      });
+
+      request(app)
+        .get('/')
+        .expect(200)
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(utils.shouldHaveBody(Buffer.alloc(10)))
+        .end(done)
+    })
+
+    it('should not override Content-Type', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.set('Content-Type', 'text/plain').send(new ArrayBuffer(10))
+      });
+
+      request(app)
+        .get('/')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(200, done);
+    })
+  })
+
   describe('.send(Object)', function(){
     it('should send as application/json', function(done){
       var app = express();


### PR DESCRIPTION
Fixes #7362

### Description
Previously, passing a raw \ArrayBuffer\ to \es.send()\ fell through the switch statement in \lib/response.js\ to \	his.json(chunk)\, resulting in \{}\ being sent as JSON response rather than binary data.

### Solution
- Added a check for \chunk instanceof ArrayBuffer\ in \es.send()\.
- Converted raw \ArrayBuffer\ to a \Buffer\ via \Buffer.from(chunk)\.
- Set \Content-Type: application/octet-stream\ (using \	his.type('bin')\) if \Content-Type\ is not already configured, consistent with \Buffer\ and \ArrayBufferView\ handling.
- Added unit tests in \	est/res.send.js\ asserting that \es.send(new ArrayBuffer(10))\ responds with 10 bytes and \Content-Type: application/octet-stream\, while respecting custom content types.