### PR TITLE
deps: qs@~6.16.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ unreleased
 
   * Allow conditional revalidation for QUERY requests
     - `req.fresh` now includes QUERY in the freshness check, so QUERY responses can return 304 when a validator matches
+  * deps: qs@~6.16.0
 
 4.22.2 / 2026-05-11
 ==========

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "parseurl": "~1.3.3",
     "path-to-regexp": "~0.1.13",
     "proxy-addr": "~2.0.7",
-    "qs": "~6.15.1",
+    "qs": "~6.16.0",
     "range-parser": "~1.2.1",
     "safe-buffer": "5.2.1",
     "send": "~0.19.0",


### PR DESCRIPTION
`4.x` declares `qs` as `~6.15.1`, which caps at `6.15.3`. Both CVE-2026-82417 ([GHSA-4mjr-xmp4-gh2g](https://github.com/ljharb/qs/security/advisories/GHSA-4mjr-xmp4-gh2g), affects `>= 2.2.5, <= 6.15.3`) and CVE-2026-82562 ([GHSA-x5fp-wj9c-mxmx](https://github.com/ljharb/qs/security/advisories/GHSA-x5fp-wj9c-mxmx), affects `>= 6.14.2, <= 6.15.3`) are patched in `qs@6.16.0`, so a fresh `npm install express@4.22.2` still lands on a vulnerable `qs`.

Neither advisory is triggerable through Express itself. Express only calls `qs.parse`, and the first one needs `qs.stringify`. The second needs `comma: true` together with `throwOnLimitExceeded: true`, which Express never sets. The bump still moves the shipped `qs` to a version scanners do not flag.

Both advisories are recent enough that they haven't reached the feed `npm audit` reads, so it still reports 0 vulnerabilities here. The GHSA pages carry the affected ranges.

`body-parser@1.20.8` now declares `qs: ~6.16.0` and satisfies Express's own `~1.20.5` pin, so a fresh install already gets a clean `qs` tree without any change here.

Refs #7439