### PR TITLE
fix: accept a comma-delimited list in req.acceptsCharsets

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -170,7 +170,9 @@ req.acceptsEncodings = function(){
 
 req.acceptsCharsets = function(...charsets) {
   const accept = accepts(this);
-  return accept.charsets(...charsets);
+  return accept.charsets(...charsets.flatMap((charset) =>
+    Array.isArray(charset) ? charset : String(charset).split(',').map((s) => s.trim())
+  ));
 };
 
 /**

--- a/test/req.acceptsCharsets.js
+++ b/test/req.acceptsCharsets.js
@@ -58,6 +58,32 @@ describe('req', function(){
         .set('Accept-Charset', 'iso-8859-1, utf-8')
         .expect('iso-8859-1', done);
       })
+
+      it('should accept a comma-delimited list of charsets', function (done) {
+        var app = express();
+
+        app.use(function(req, res, next){
+          res.end(req.acceptsCharsets('iso-8859-1, utf-8'));
+        });
+
+        request(app)
+        .get('/')
+        .set('Accept-Charset', 'iso-8859-1, utf-8')
+        .expect('iso-8859-1', done);
+      })
+
+      it('should not modify a single charset when given a comma-delimited list', function (done) {
+        var app = express();
+
+        app.use(function(req, res, next){
+          res.end(req.acceptsCharsets('utf-8, iso-8859-1'));
+        });
+
+        request(app)
+        .get('/')
+        .set('Accept-Charset', 'utf-8, iso-8859-1')
+        .expect('utf-8', done);
+      })
     })
   })
 })


### PR DESCRIPTION
### Bug
`req.acceptsCharsets()` silently ignores the documented comma-delimited form. The jsdoc (added by merged PR #6088) documents:

```js
req.acceptsCharsets('utf-8, utf-16');
// => utf-8
```

...but the implementation passes the arguments straight through to `accepts().charsets(...)`, which never splits commas. So a client following the documented API gets a hard `false`:

```js
// with request header `Accept-Charset: iso-8859-1, utf-8`
req.acceptsCharsets('iso-8859-1, utf-8');   // => false   (bug; iso-8859-1 IS acceptable)
req.acceptsCharsets('iso-8859-1', 'utf-8'); // => iso-8859-1  (multi-arg works)
```

### Fix
Expand comma-delimited args before passing them along, so `req.acceptsCharsets('iso-8859-1, utf-8')` behaves like the documented multi-arg form:

```js
req.acceptsCharsets = function(...charsets) {
  const accept = accepts(this);
  return accept.charsets(...charsets.flatMap((charset) =>
    Array.isArray(charset) ? charset : String(charset).split(',').map((s) => s.trim())
  ));
};
```

### Verification
- New regression tests fail on the old code and pass on this change.
- Existing behavior unchanged: no-arg (returns the acceptable list), single-arg, multi-arg, and array inputs are byte-identical.
- `npm test` (mocha, full suite): 1262 passing, 0 failing.
- `eslint` clean on the changed files.