### PR TITLE
Make it clear what arguments `req.accepts*` functions accept

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -147,9 +147,9 @@ req.acceptsEncodings = function(){
  * Returns the best matching charset or an array of acceptable charsets.
  *
  * The `charset` argument(s) can be:
- * - A single charset string (e.g., "utf-8")
- * - Multiple charset strings as arguments (e.g., `"utf-8", "iso-8859-1"`)
- * - A comma-delimited list of charsets (e.g., `"utf-8, iso-8859-1"`)
+ * - A single charset string (e.g., 'utf-8')
+ * - Multiple charset strings as arguments (e.g., `'utf-8', 'iso-8859-1'`)
+ * - An array of charsets (e.g., `['utf-8', 'iso-8859-1']`)
  *
  * Examples:
  *
@@ -160,7 +160,7 @@ req.acceptsEncodings = function(){
  *     req.acceptsCharsets('utf-8', 'iso-8859-1');
  *     // => "utf-8"
  *
- *     req.acceptsCharsets('utf-8, utf-16');
+ *     req.acceptsCharsets(['utf-8', 'utf-16']);
  *     // => "utf-8"
  *
  * @param {...String} charsets - The charset(s) to check against the `Accept-Charset` header.

--- a/test/req.acceptsCharsets.js
+++ b/test/req.acceptsCharsets.js
@@ -59,5 +59,18 @@ describe('req', function(){
         .expect('iso-8859-1', done);
       })
     })
+
+    it('should accept an array of charsets', function (done) {
+      var app = express();
+
+      app.use(function(req, res, next){
+        res.end(req.acceptsCharsets(['utf-8', 'iso-8859-1']));
+      });
+
+      request(app)
+      .get('/')
+      .set('Accept-Charset', 'iso-8859-1, utf-8')
+      .expect('iso-8859-1', done);
+    })
   })
 })

--- a/test/req.acceptsEncodings.js
+++ b/test/req.acceptsEncodings.js
@@ -35,5 +35,31 @@ describe('req', function(){
         .set('Accept-Encoding', ' gzip, deflate')
         .expect(200, { bogus: false }, done)
     })
+
+    it('should accept an array of encodings', function (done) {
+      var app = express();
+
+      app.get('/', function (req, res) {
+        res.send(req.acceptsEncodings(['deflate', 'gzip']))
+      })
+
+      request(app)
+        .get('/')
+        .set('Accept-Encoding', 'gzip;q=0.5, deflate')
+        .expect(200, 'deflate', done)
+    })
+
+    it('should accept an argument list of encodings', function (done) {
+      var app = express();
+
+      app.get('/', function (req, res) {
+        res.send(req.acceptsEncodings('gzip', 'deflate'))
+      })
+
+      request(app)
+        .get('/')
+        .set('Accept-Encoding', 'gzip, deflate')
+        .expect(200, 'gzip', done)
+    })
   })
 })

--- a/test/req.acceptsLanguages.js
+++ b/test/req.acceptsLanguages.js
@@ -36,6 +36,32 @@ describe('req', function(){
         .expect(200, { es: false }, done)
     })
 
+    it('should accept an array of languages', function (done) {
+      var app = express();
+
+      app.get('/', function (req, res) {
+        res.send(req.acceptsLanguages(['en-us', 'en']))
+      })
+
+      request(app)
+        .get('/')
+        .set('Accept-Language', 'en;q=.5, en-us')
+        .expect(200, 'en-us', done)
+    })
+
+    it('should accept an argument list of languages', function (done) {
+      var app = express();
+
+      app.get('/', function (req, res) {
+        res.send(req.acceptsLanguages('jp', 'en'))
+      })
+
+      request(app)
+        .get('/')
+        .set('Accept-Language', 'en;q=.5, en-us')
+        .expect(200, 'en', done)
+    })
+
     describe('when Accept-Language is not present', function(){
       it('should always return language', function (done) {
         var app = express();


### PR DESCRIPTION
## Background

#6088 changed the wording of `req.acceptsCharsets()` docs and introduced a mistake which went unnoticed until #7451, where it was reported as a bug in code. Interestingly, 9 days later #6936 fixed the same mistake in docs for `req.accepts()` and in https://github.com/expressjs/express/pull/6936#discussion_r2699976722 @bjohansebas pointed out that Express had removed support for a comma delimited string before 4.0 release. Historically it looks more or less like this:

1. (2014) Express 4 switches to `jshhtp/accepts`, which does not accept a single comma delimited string, but leaves it in the docs.
2. (2024-10-27) #6088 is opened and mirrors the wrong example from `req.accepts()` to `req.acceptsCharsets()`. The PR appears to be at least AI-assisted, if not completely AI-generated, but this does not explain why nobody noticed this during review. It is possible that the text wasn't based on `req.accepts()`, but the LLM just wrote false information in docs and PR description - it sounds as if the author completely rewrote the method to extend the functionality, while in reality the changes to code were just cosmetic.
3. (2025-12-02) #6936 is opened with a partial fix to the `req.accepts()` docs.
4. (2026-01-06) I [noticed](https://github.com/expressjs/express/pull/6936#issuecomment-3716432614) that #6936 missed some spots in the docs.
5. (2026-01-07) #6088 is merged - the wrong `req.acceptsCharsets()` docs become a part of Express.
6. (2026-01-08) #6936 is updated to eliminate the rest of mistakes in `req.accepts()` docs.
7. (2026-01-16) @bjohansebas [finds](https://github.com/expressjs/express/pull/6936#discussion_r2699976722) the reason why there was a mistake in the first place and merges #6936.

Conclusions? Maybe I should check PRs after they're merged if I've ignored them before...

## Description

This PR fixes this particular docs error and adds tests that cover the types of accepted arguments of `req.accepts*` functions.

### Remaining things

All of these methods (`req.accepts`, `req.acceptsEncodings`, `req.acceptsCharsets`, `req.acceptsLanguages`) do the same thing (except calling different methods of `accepts`), but are written in 3 different ways:

1. no args, temporary variable (`var`), `.apply(accept, arguments)`
   https://github.com/expressjs/express/blob/023767fe9872e029271df1418f73401bff20ff40/lib/request.js#L127-L130
   https://github.com/expressjs/express/blob/023767fe9872e029271df1418f73401bff20ff40/lib/request.js#L140-L143
9. rest parameters, temporary variable (`const`)
   https://github.com/expressjs/express/blob/023767fe9872e029271df1418f73401bff20ff40/lib/request.js#L171-L174
10. rest parameters, everything chained
   https://github.com/expressjs/express/blob/023767fe9872e029271df1418f73401bff20ff40/lib/request.js#L185-L187

All of these functions are also documented completely differently, with or without examples and with JSDoc types not always reflecting the allowed argument types properly.

I'll try to make these functions and their docs more consistent with each other, so it'll be a draft PR for now.

TODO:

- [ ] Make methods use same code style
- [ ] Make the descriptions consistent and more detailed (especially `*Encodings` and `*Languages`)
- [ ] Make sure that the types in JSDoc reflect reality

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
