### PR TITLE
fix: send raw ArrayBuffer as binary instead of JSON

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -152,6 +152,11 @@ res.send = function send(body) {
         if (!this.get('Content-Type')) {
           this.type('bin');
         }
+      } else if (chunk instanceof ArrayBuffer) {
+        if (!this.get('Content-Type')) {
+          this.type('bin');
+        }
+        chunk = Buffer.from(chunk);
       } else {
         return this.json(chunk);
       }


### PR DESCRIPTION
## Summary

Fixes #7362

res.send(ArrayBuffer) was sending {} with Content-Type: application/json because ArrayBuffer.isView() returns false for raw ArrayBuffer, causing it to fall through to this.json().

## Problem

`ArrayBuffer.isView()` only returns true for TypedArray views (like `Uint8Array`), but raw `ArrayBuffer` is not a view, so it falls through to `this.json(chunk)` producing `{}`.

## Solution

Add `instanceof ArrayBuffer` check to handle raw ArrayBuffer like TypedArray views:
- Set Content-Type to 'bin' (binary)
- Convert ArrayBuffer to Buffer before sending

## Verification

```js
res.send(new ArrayBuffer(10))
// Before: {} with Content-Type: application/json
// After: 10 zero bytes with Content-Type: application/octet-stream
```