### PR TITLE
fix(res.send): preserve ETag generation with Transfer-Encoding

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -162,10 +162,8 @@ res.send = function send(body) {
   var etagFn = app.get('etag fn')
   var generateETag = !this.get('ETag') && typeof etagFn === 'function'
 
-  // Because Content-Length and Transfer-Encoding can't be present in the response headers together,
-  // Content-Length should be added only if there is no Transfer-Encoding header
   var len;
-  if (chunk !== undefined && !this.get('Transfer-Encoding')) {
+  if (chunk !== undefined) {
     if (Buffer.isBuffer(chunk)) {
       // get length of Buffer
       len = chunk.length
@@ -179,7 +177,11 @@ res.send = function send(body) {
       len = chunk.length
     }
 
-    this.set('Content-Length', len);
+    // Because Content-Length and Transfer-Encoding can't be present in the response headers together,
+    // Content-Length should be added only if there is no Transfer-Encoding header
+    if (!this.get('Transfer-Encoding')) {
+      this.set('Content-Length', len);
+    }
   }
 
   // populate ETag

--- a/test/res.send.js
+++ b/test/res.send.js
@@ -616,5 +616,20 @@ describe('res', function(){
           .expect(200, '', done);
       })
     });
+
+    it('should still generate an ETag', function(done){
+      var app = express();
+
+      app.use(function(_, res){
+        res.set('Transfer-Encoding', 'chunked').send('hello');
+      });
+
+      request(app)
+        .get('/')
+        .expect(utils.shouldNotHaveHeader('Content-Length'))
+        .expect(utils.shouldHaveHeader('Transfer-Encoding'))
+        .expect('ETag', 'W/"5-qvTGHdzF6KLavt4PO0gs2a6pQ00"')
+        .expect(200, 'hello', done);
+    })
   })
 })


### PR DESCRIPTION


Preserve automatic ETag generation when `res.send()` is used with a pre-existing `Transfer-Encoding` header.


Commit `18e5985b` correctly prevented `Content-Length` from being added when `Transfer-Encoding` is present, but it also moved the body-length calculation inside the same condition.

Because automatic ETag generation depends on the calculated body length, responses using `Transfer-Encoding` stopped receiving an ETag.


