### PR TITLE
perf: cache parsed request queries

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -236,8 +236,17 @@ defineGetter(req, 'query', function query(){
   }
 
   var querystring = parse(this).query;
+  var parsed = queryparse(querystring);
 
-  return queryparse(querystring);
+  // Cache the parsed query for the lifetime of this request.
+  Object.defineProperty(this, 'query', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: parsed
+  });
+
+  return parsed;
 });
 
 /**

--- a/test/req.query.js
+++ b/test/req.query.js
@@ -22,6 +22,24 @@ describe('req', function(){
       .expect(200, '{"user[name]":"tj"}', done);
     });
 
+    it('should parse the query string only once per request', function (done) {
+      var parses = 0;
+      var app = createApp(function (str) {
+        parses++;
+        return {'value': str};
+      });
+
+      app.use(function (req, res) {
+        assert.strictEqual(req.query, req.query);
+        assert.strictEqual(parses, 1);
+        res.sendStatus(204);
+      });
+
+      request(app)
+      .get('/?value=test')
+      .expect(204, done);
+    });
+
     describe('when "query parser" is extended', function () {
       it('should parse complex keys', function (done) {
         var app = createApp('extended');


### PR DESCRIPTION
## Summary

Memoize `req.query` after the first parse for the lifetime of a request. Applications that read the query object in multiple middleware layers no longer rerun the configured parser (including the more expensive extended `qs` parser). Disabled query parsing retains its existing behavior.

## Performance audit: 10 opportunities

1. **Memoize `req.query` parsing** (implemented here): eliminate repeated parser work per request; high request-path impact and a small isolated change.
2. Memoize `req.accepts*()` negotiation results when the same request and candidate list are queried repeatedly.
3. Cache parsed `Accept` header state on the request instead of constructing a new `accepts` instance for each negotiation call.
4. Cache trusted proxy lookup results for `req.protocol`, `req.host`, `req.ip`, and `req.ips` within a request.
5. Avoid repeated `app.get()` setting lookups in hot response paths by resolving stable settings once per request.
6. Reuse a normalized view-root array in `View` instead of concatenating `this.root` on every lookup.
7. Reduce synchronous filesystem probes for missing views by caching negative view lookups during a render cycle.
8. Avoid repeated MIME normalization in `res.format()` when the same content types are negotiated more than once.
9. Optimize object-form response header setting to call `setHeader` directly after normalization rather than recursively dispatching through `res.set`.
10. Add route/middleware dispatch benchmarks to identify whether path matching or middleware traversal dominates high-route-count applications before optimizing the router boundary.

## Validation

- Added a regression test proving a custom query parser runs once and returns the same request-local object on repeated access.
- `git diff --check` passes.
- Node/npm are not installed in this environment, so the Mocha and ESLint commands could not be run here.