### PR TITLE
fix(res.sendFile): treat the app etag setting as a default, not an override

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -398,8 +398,12 @@ res.sendFile = function sendFile(path, options, callback) {
   // create file stream
   var pathname = encodeURI(path);
 
-  // wire application etag option to send
-  opts.etag = this.app.enabled('etag');
+  // wire application etag option to send, as a default only: every other
+  // option is passed along to send untouched, and overriding this one made
+  // send's documented `etag` option unreachable through res.sendFile
+  if (opts.etag === undefined) {
+    opts.etag = this.app.enabled('etag');
+  }
   var file = send(req, pathname, opts);
 
   // transfer

--- a/test/res.sendFile.js
+++ b/test/res.sendFile.js
@@ -92,6 +92,28 @@ describe('res', function(){
       }
     });
 
+    it('should let an explicit etag option turn the ETag off', function (done) {
+      var app = createApp(path.resolve(fixtures, 'name.txt'), { etag: false });
+
+      request(app)
+      .get('/')
+      .expect(handleHeaders)
+      .expect(200, done);
+
+      function handleHeaders (res) {
+        assert(res.headers.etag === undefined);
+      }
+    });
+
+    it('should let an explicit etag option turn the ETag on', function (done) {
+      var app = createApp(path.resolve(fixtures, 'name.txt'), { etag: true }).disable('etag');
+
+      request(app)
+      .get('/')
+      .expect('ETag', /^(?:W\/)?"[^"]+"$/)
+      .expect(200, done);
+    });
+
     it('should 404 for directory', function (done) {
       var app = createApp(path.resolve(fixtures, 'blog'));
 


### PR DESCRIPTION
## Problem

#6073 wired the application `etag` setting into `res.sendFile` to close #2294. The assignment is unconditional:

```js
// wire application etag option to send
opts.etag = this.app.enabled('etag');
var file = send(req, pathname, opts);
```

`opts` is the caller's own options object (`var opts = options || {}`), so this both overwrites an `etag` the caller passed and writes the setting onto their object.

`send` documents `etag` as an option (`opts.etag !== undefined ? Boolean(opts.etag) : true`), and `res.sendFile`'s own JSDoc says *"Other options are passed along to `send`"* — which every other option does. This one could not get through.

Measured over HTTP against `master` (5.2.1):

```
app etag ENABLED (default)
  res.sendFile(file, { etag: false })   ETag present   (expected absent)   <-- WRONG
  res.sendFile(file, {})                ETag present   (expected present)

app etag DISABLED
  res.sendFile(file, { etag: true })    ETag absent    (expected present)  <-- WRONG
  res.sendFile(file, {})                ETag absent    (expected absent)
```

`res.download` routes through `res.sendFile`, so it behaves the same way.

## Fix

Assign only when the caller left it undefined:

```js
if (opts.etag === undefined) {
  opts.etag = this.app.enabled('etag');
}
```

This keeps #2294's behaviour intact — with no `etag` option, `app.disable('etag')` still turns it off, which is what that issue asked for ("`app.disable('etag')` sets `sendFile()`s `options.etag` to `false` **for you**"). It restores the per-call option that #6073's title advertises, and it stops clobbering the caller's object when they did supply one.

## Test plan

- Added two cases to `test/res.sendFile.js` beside the existing `should disable the ETag function if requested`: an explicit `{ etag: false }` against the default-on app, and an explicit `{ etag: true }` against `app.disable('etag')`.
- Ran: `mocha test/` → **1154 passing**, no failures. The two pre-existing ETag tests pass no `etag` option, so they are unaffected.
- Checked: reverting only `lib/response.js` fails both new tests.
- Ran: `npm run lint` → clean.

## Note

With no `etag` option supplied, the setting is still written onto the caller's object, as before. Narrowing that further means copying `opts`, which felt like a separate change from the behaviour fix — happy to include it if you would rather.